### PR TITLE
v1.3: BitArray support for C implementations (256-bit parameters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 ## [1.3] - 2026-03-29
 
 ### Changed
+- **`Herradura_tests.c`**: replaced fixed 64-bit integers with the same `BitArray`
+  type used in `Herradura cryptographic suite.c`. Default key size is now **256 bits**
+  (`KEYBITS = 256`, `I_VALUE = 64`, `R_VALUE = 192`), matching the Go and Python
+  test files. Added `ba_popcount`, `ba_get_bit`, and `ba_flip_bit` helpers.
+  Benchmarks now run for a fixed wall-clock target (`BENCH_SEC = 1.0`) and report
+  M ops/sec or K ops/sec, matching the Go test style.
+
+  All five security tests pass at 256-bit:
+  1. Non-commutativity — 0 / 10000 commutative pairs
+  2. Linear diffusion  — mean exactly 3 bits per flip (min=3, max=3)
+  3. Orbit period      — all periods are 256 or 128
+  4. Bit-frequency     — each bit set 47–53% of the time
+  5. Key sensitivity   — mean Hamming distance exactly 1 bit per A-flip
+
 - **`Herradura cryptographic suite.c`**: replaced fixed 64-bit integers with a
   `BitArray` type — a fixed-width bit string backed by a big-endian byte array —
   matching the Python and Go implementations. Default key size is now **256 bits**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3] - 2026-03-29
+
+### Changed
+- **`Herradura cryptographic suite.c`**: replaced fixed 64-bit integers with a
+  `BitArray` type — a fixed-width bit string backed by a big-endian byte array —
+  matching the Python and Go implementations. Default key size is now **256 bits**
+  (`KEYBITS = 256`, `I_VALUE = 64`, `R_VALUE = 192`), controlled by a single
+  `#define KEYBITS` at the top of the file. All four protocols (HKEX, HSKE, HPKS,
+  HPKE) and the EVE bypass tests operate on `BitArray` operands.
+
+  `BitArray` API:
+  - `ba_rand`          — fill from `/dev/urandom`
+  - `ba_xor` / `ba_xor_into` — bitwise XOR (out-of-place / in-place)
+  - `ba_rol1` / `ba_ror1`    — rotate left/right by 1 bit (big-endian)
+  - `ba_equal`         — constant-time-style `memcmp` equality
+  - `ba_print_hex`     — zero-padded hex output
+  - `ba_fscx`          — Full Surroundings Cyclic XOR
+  - `ba_fscx_revolve`  — iterate FSCX n times
+  - `ba_fscx_revolve_n` — nonce-augmented FSCX_REVOLVE (v1.1)
+
+  Build: `gcc -O2 -o "Herradura cryptographic suite" "Herradura cryptographic suite.c"`
+
+---
+
 ## [1.2] - 2026-03-29
 
 ### Added

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.1
+/*  Herradura Cryptographic Suite v1.2
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,23 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.2: BitArray (multi-byte parameter support) ---
+
+    The C implementation now uses a BitArray type: a fixed-width bit string
+    backed by a big-endian byte array, matching the Python and Go versions.
+    Default key size is 256 bits (i_value = 64, r_value = 192).
+
+    BitArray supports:
+      - XOR (ba_xor / ba_xor_into)
+      - Rotate-left / rotate-right by 1 bit (big-endian)
+      - Equality comparison (ba_equal)
+      - Hex printing (ba_print_hex)
+      - Secure random fill from /dev/urandom (ba_rand)
+
+    The key size is controlled by KEYBITS (must be a positive multiple of 8).
+    Change the #define to use a different bit width; all parameters and step
+    counts scale automatically.
 
     --- v1.1: FSCX_REVOLVE_N ---
 
@@ -49,240 +66,328 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define INTSZ    64
-#define I_VALUE  16   /* INTSZ / 4 */
-#define R_VALUE  48   /* 3 * INTSZ / 4 */
+/* Key size in bits -- must be a positive multiple of 8.
+   Change this to use a different parameter width; I_VALUE and R_VALUE scale
+   automatically. Equivalent to 256-bit parameters in the Go and Python versions. */
+#define KEYBITS  256
+#define KEYBYTES (KEYBITS / 8)
+#define I_VALUE  (KEYBITS / 4)       /* 64  for 256-bit */
+#define R_VALUE  (3 * KEYBITS / 4)   /* 192 for 256-bit */
 
-typedef uint64_t u64;
+/* Fixed-width bit array backed by a big-endian byte array.
+   b[0] holds the most-significant byte; size is always KEYBYTES. */
+typedef struct {
+    uint8_t b[KEYBYTES];
+} BitArray;
 
-/* Read exactly 8 bytes from /dev/urandom */
-static u64 rand64(FILE *urnd)
+/* Fill dst with KEYBYTES random bytes from /dev/urandom. */
+static void ba_rand(BitArray *dst, FILE *urnd)
 {
-	uint8_t buf[8];
-	if (fread(buf, 1, 8, urnd) != 8) {
-		fputs("ERROR: could not read from /dev/urandom\n", stderr);
-		exit(1);
-	}
-	return ((u64)buf[0] << 56) | ((u64)buf[1] << 48) |
-	       ((u64)buf[2] << 40) | ((u64)buf[3] << 32) |
-	       ((u64)buf[4] << 24) | ((u64)buf[5] << 16) |
-	       ((u64)buf[6] <<  8) | ((u64)buf[7]);
+    if (fread(dst->b, 1, KEYBYTES, urnd) != (size_t)KEYBYTES) {
+        fputs("ERROR: could not read from /dev/urandom\n", stderr);
+        exit(1);
+    }
 }
 
-/* Rotate left */
-static u64 rol64(u64 x, int n)
+/* dst = a XOR b */
+static void ba_xor(BitArray *dst, const BitArray *a, const BitArray *b)
 {
-	n &= 63;
-	if (n == 0) return x;
-	return (x << n) | (x >> (64 - n));
+    int i;
+    for (i = 0; i < KEYBYTES; i++)
+        dst->b[i] = a->b[i] ^ b->b[i];
 }
 
-/* Rotate right */
-static u64 ror64(u64 x, int n)
+/* dst ^= src  (in-place XOR) */
+static void ba_xor_into(BitArray *dst, const BitArray *src)
 {
-	n &= 63;
-	if (n == 0) return x;
-	return (x >> n) | (x << (64 - n));
+    int i;
+    for (i = 0; i < KEYBYTES; i++)
+        dst->b[i] ^= src->b[i];
 }
 
-/* Full Surroundings Cyclic XOR (rotation-based, 64-bit) */
-static u64 fscx(u64 a, u64 b)
+/* dst = src rotated left by 1 bit (big-endian: b[0] is MSB). */
+static void ba_rol1(BitArray *dst, const BitArray *src)
 {
-	u64 result;
-	result  = a ^ b;
-	result ^= rol64(a, 1) ^ rol64(b, 1);
-	result ^= ror64(a, 1) ^ ror64(b, 1);
-	return result;
+    int i;
+    uint8_t msbit = (src->b[0] >> 7) & 1;
+    for (i = 0; i < KEYBYTES - 1; i++)
+        dst->b[i] = (uint8_t)((src->b[i] << 1) | (src->b[i + 1] >> 7));
+    dst->b[KEYBYTES - 1] = (uint8_t)((src->b[KEYBYTES - 1] << 1) | msbit);
 }
 
-/* FSCX_REVOLVE: iterate fscx n times */
-static u64 fscx_revolve(u64 a, u64 b, int steps)
+/* dst = src rotated right by 1 bit (big-endian: b[0] is MSB). */
+static void ba_ror1(BitArray *dst, const BitArray *src)
 {
-	int i;
-	for (i = 0; i < steps; i++)
-		a = fscx(a, b);
-	return a;
+    int i;
+    uint8_t lsbit = src->b[KEYBYTES - 1] & 1;
+    for (i = KEYBYTES - 1; i > 0; i--)
+        dst->b[i] = (uint8_t)((src->b[i] >> 1) | (src->b[i - 1] << 7));
+    dst->b[0] = (uint8_t)((src->b[0] >> 1) | (lsbit << 7));
 }
 
-/* FSCX_REVOLVE_N (v1.1): nonce-augmented iteration */
-static u64 fscx_revolve_n(u64 a, u64 b, u64 nonce, int steps)
+/* Returns 1 if a == b, 0 otherwise. */
+static int ba_equal(const BitArray *a, const BitArray *b)
 {
-	int i;
-	for (i = 0; i < steps; i++)
-		a = fscx(a, b) ^ nonce;
-	return a;
+    return memcmp(a->b, b->b, KEYBYTES) == 0;
+}
+
+/* Print label + hex representation of a + newline. */
+static void ba_print_hex(const char *label, const BitArray *a)
+{
+    int i;
+    printf("%s", label);
+    for (i = 0; i < KEYBYTES; i++)
+        printf("%02x", a->b[i]);
+    putchar('\n');
+}
+
+/* Full Surroundings Cyclic XOR:
+   result = a XOR b XOR ROL(a) XOR ROL(b) XOR ROR(a) XOR ROR(b) */
+static void ba_fscx(BitArray *result, const BitArray *a, const BitArray *b)
+{
+    BitArray rol_a, rol_b, ror_a, ror_b;
+    int i;
+    ba_rol1(&rol_a, a);
+    ba_rol1(&rol_b, b);
+    ba_ror1(&ror_a, a);
+    ba_ror1(&ror_b, b);
+    for (i = 0; i < KEYBYTES; i++)
+        result->b[i] = a->b[i] ^ b->b[i]
+                     ^ rol_a.b[i] ^ rol_b.b[i]
+                     ^ ror_a.b[i] ^ ror_b.b[i];
+}
+
+/* FSCX_REVOLVE: iterate fscx(a, b) n times keeping b constant. */
+static void ba_fscx_revolve(BitArray *result, const BitArray *a,
+                             const BitArray *b, int steps)
+{
+    BitArray tmp;
+    int i;
+    *result = *a;
+    for (i = 0; i < steps; i++) {
+        ba_fscx(&tmp, result, b);
+        *result = tmp;
+    }
+}
+
+/* FSCX_REVOLVE_N (v1.1): nonce-augmented iteration.
+   Each step: result = FSCX(result, b) XOR nonce */
+static void ba_fscx_revolve_n(BitArray *result, const BitArray *a,
+                               const BitArray *b, const BitArray *nonce,
+                               int steps)
+{
+    BitArray tmp;
+    int i;
+    *result = *a;
+    for (i = 0; i < steps; i++) {
+        ba_fscx(&tmp, result, b);
+        ba_xor(result, &tmp, nonce);
+    }
 }
 
 int main(void)
 {
-	FILE *urnd;
-	u64 A, B, A2, B2, C, C2, hkex_nonce;
-	u64 nonce, preshared, plaintext;
-	u64 skeyA, skeyB;
-	u64 E, D, S, V, S2, V2, D2, E2;
+    FILE *urnd;
+    BitArray A, B, A2, B2, C, C2, hkex_nonce;
+    BitArray nonce, preshared, plaintext;
+    BitArray skeyA, skeyB;
+    BitArray E, D, S, V, S2, V2, D2, E2;
+    BitArray tmp;
 
-	urnd = fopen("/dev/urandom", "rb");
-	if (!urnd) {
-		fputs("ERROR: cannot open /dev/urandom\n", stderr);
-		return 1;
-	}
+    urnd = fopen("/dev/urandom", "rb");
+    if (!urnd) {
+        fputs("ERROR: cannot open /dev/urandom\n", stderr);
+        return 1;
+    }
 
-	A         = rand64(urnd);
-	B         = rand64(urnd);
-	A2        = rand64(urnd);
-	B2        = rand64(urnd);
-	nonce     = rand64(urnd);
-	preshared = rand64(urnd);
-	plaintext = rand64(urnd);
+    ba_rand(&A,         urnd);
+    ba_rand(&B,         urnd);
+    ba_rand(&A2,        urnd);
+    ba_rand(&B2,        urnd);
+    ba_rand(&nonce,     urnd);
+    ba_rand(&preshared, urnd);
+    ba_rand(&plaintext, urnd);
 
-	C  = fscx_revolve(A,  B,  I_VALUE);
-	C2 = fscx_revolve(A2, B2, I_VALUE);
-	hkex_nonce = C ^ C2;
+    ba_fscx_revolve(&C,  &A,  &B,  I_VALUE);
+    ba_fscx_revolve(&C2, &A2, &B2, I_VALUE);
+    ba_xor(&hkex_nonce, &C, &C2);
 
-	printf("A         : %016llx\n", (unsigned long long)A);
-	printf("B         : %016llx\n", (unsigned long long)B);
-	printf("A2        : %016llx\n", (unsigned long long)A2);
-	printf("B2        : %016llx\n", (unsigned long long)B2);
-	printf("preshared : %016llx\n", (unsigned long long)preshared);
-	printf("plaintext : %016llx\n", (unsigned long long)plaintext);
-	printf("nonce     : %016llx\n", (unsigned long long)nonce);
-	printf("C         : %016llx\n", (unsigned long long)C);
-	printf("C2        : %016llx\n", (unsigned long long)C2);
-	printf("hkex_nonce: %016llx\n", (unsigned long long)hkex_nonce);
+    ba_print_hex("A         : ", &A);
+    ba_print_hex("B         : ", &B);
+    ba_print_hex("A2        : ", &A2);
+    ba_print_hex("B2        : ", &B2);
+    ba_print_hex("preshared : ", &preshared);
+    ba_print_hex("plaintext : ", &plaintext);
+    ba_print_hex("nonce     : ", &nonce);
+    ba_print_hex("C         : ", &C);
+    ba_print_hex("C2        : ", &C2);
+    ba_print_hex("hkex_nonce: ", &hkex_nonce);
 
-	/* --- HKEX (key exchange) --- */
-	printf("\n--- HKEX (key exchange)\n");
-	skeyA = fscx_revolve_n(C2, B,  hkex_nonce, R_VALUE) ^ A;
-	printf("skeyA (Alice): %016llx\n", (unsigned long long)skeyA);
-	skeyB = fscx_revolve_n(C,  B2, hkex_nonce, R_VALUE) ^ A2;
-	printf("skeyB (Bob)  : %016llx\n", (unsigned long long)skeyB);
-	if (skeyA == skeyB)
-		puts("+ session keys skeyA and skeyB are equal!");
-	else
-		puts("- session keys skeyA and skeyB are different!");
+    /* --- HKEX (key exchange) --- */
+    printf("\n--- HKEX (key exchange)\n");
+    ba_fscx_revolve_n(&tmp, &C2, &B,  &hkex_nonce, R_VALUE);
+    ba_xor(&skeyA, &tmp, &A);
+    ba_print_hex("skeyA (Alice): ", &skeyA);
+    ba_fscx_revolve_n(&tmp, &C,  &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&skeyB, &tmp, &A2);
+    ba_print_hex("skeyB (Bob)  : ", &skeyB);
+    if (ba_equal(&skeyA, &skeyB))
+        puts("+ session keys skeyA and skeyB are equal!");
+    else
+        puts("- session keys skeyA and skeyB are different!");
 
-	/* --- HSKE (symmetric key encryption) --- */
-	printf("\n--- HSKE (symmetric key encryption)\n");
-	E = fscx_revolve_n(plaintext, preshared, preshared, I_VALUE);
-	printf("E (Alice) : %016llx\n", (unsigned long long)E);
-	D = fscx_revolve_n(E, preshared, preshared, R_VALUE);
-	printf("D (Bob)   : %016llx\n", (unsigned long long)D);
-	if (D == plaintext)
-		puts("+ plaintext is correctly decrypted from E with preshared key");
-	else
-		puts("- plaintext is different from decrypted E with preshared key!");
+    /* --- HSKE (symmetric key encryption) --- */
+    printf("\n--- HSKE (symmetric key encryption)\n");
+    ba_fscx_revolve_n(&E, &plaintext, &preshared, &preshared, I_VALUE);
+    ba_print_hex("E (Alice) : ", &E);
+    ba_fscx_revolve_n(&D, &E, &preshared, &preshared, R_VALUE);
+    ba_print_hex("D (Bob)   : ", &D);
+    if (ba_equal(&D, &plaintext))
+        puts("+ plaintext is correctly decrypted from E with preshared key");
+    else
+        puts("- plaintext is different from decrypted E with preshared key!");
 
-	/* --- HPKS (public key signature) --- */
-	printf("\n--- HPKS (public key signature)\n");
-	S = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ plaintext;
-	printf("S (Alice) : %016llx\n", (unsigned long long)S);
-	V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S;
-	printf("V (Bob)   : %016llx\n", (unsigned long long)V);
-	if (V == plaintext)
-		puts("+ signature S from plaintext is correct!");
-	else
-		puts("- signature S from plaintext is incorrect!");
+    /* --- HPKS (public key signature) --- */
+    printf("\n--- HPKS (public key signature)\n");
+    ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
+    ba_xor(&S, &tmp, &A);
+    ba_xor_into(&S, &plaintext);
+    ba_print_hex("S (Alice) : ", &S);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V, &tmp, &A2);
+    ba_xor_into(&V, &S);
+    ba_print_hex("V (Bob)   : ", &V);
+    if (ba_equal(&V, &plaintext))
+        puts("+ signature S from plaintext is correct!");
+    else
+        puts("- signature S from plaintext is incorrect!");
 
-	/* --- HPKS + HSKE with preshared key made public --- */
-	printf("\n--- HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n");
-	E = fscx_revolve_n(plaintext, preshared, preshared, I_VALUE);
-	printf("E (Alice) : %016llx\n", (unsigned long long)E);
-	S = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ E; /* A+B2+C is the trapdoor */
-	printf("S (Alice) : %016llx\n", (unsigned long long)S);
-	V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S; /* => E */
-	printf("V (Bob)   : %016llx\n", (unsigned long long)V);
-	D = fscx_revolve_n(V, preshared, preshared, R_VALUE); /* => plaintext */
-	printf("D (Bob)   : %016llx\n", (unsigned long long)D);
-	if (D == plaintext)
-		puts("+ signature S(E) from plaintext is correct!");
-	else
-		puts("- signature S(E) from plaintext is incorrect!");
+    /* --- HPKS + HSKE with preshared key made public --- */
+    printf("\n--- HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n");
+    ba_fscx_revolve_n(&E, &plaintext, &preshared, &preshared, I_VALUE);
+    ba_print_hex("E (Alice) : ", &E);
+    ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
+    ba_xor(&S, &tmp, &A);
+    ba_xor_into(&S, &E);   /* A+B2+C is the trapdoor */
+    ba_print_hex("S (Alice) : ", &S);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V, &tmp, &A2);
+    ba_xor_into(&V, &S);   /* => E */
+    ba_print_hex("V (Bob)   : ", &V);
+    ba_fscx_revolve_n(&D, &V, &preshared, &preshared, R_VALUE);   /* => plaintext */
+    ba_print_hex("D (Bob)   : ", &D);
+    if (ba_equal(&D, &plaintext))
+        puts("+ signature S(E) from plaintext is correct!");
+    else
+        puts("- signature S(E) from plaintext is incorrect!");
 
-	/* --- HPKE (public key encryption) --- */
-	printf("\n--- HPKE (public key encryption)\n");
-	E = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ plaintext;
-	printf("E (Bob)   : %016llx\n", (unsigned long long)E);
-	D = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ E; /* => plaintext */
-	printf("D (Alice) : %016llx\n", (unsigned long long)D);
-	if (D == plaintext)
-		puts("+ plaintext is correctly decrypted from E with private key!");
-	else
-		puts("- plaintext is different from decrypted E with private key!");
+    /* --- HPKE (public key encryption) --- */
+    printf("\n--- HPKE (public key encryption)\n");
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&E, &tmp, &A2);
+    ba_xor_into(&E, &plaintext);
+    ba_print_hex("E (Bob)   : ", &E);
+    ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
+    ba_xor(&D, &tmp, &A);
+    ba_xor_into(&D, &E);   /* => plaintext */
+    ba_print_hex("D (Alice) : ", &D);
+    if (ba_equal(&D, &plaintext))
+        puts("+ plaintext is correctly decrypted from E with private key!");
+    else
+        puts("- plaintext is different from decrypted E with private key!");
 
-	/* *** EVE bypass TESTS *** */
-	printf("\n\n*** EVE bypass TESTS\n");
+    /* *** EVE bypass TESTS *** */
+    printf("\n\n*** EVE bypass TESTS\n");
 
-	/* EVE HPKS */
-	printf("\n*** HPKS (public key signature)\n");
-	S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ nonce;
-	printf("S (Eve)   : %016llx\n", (unsigned long long)S);
-	V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2; /* X */
-	printf("V (Bob)   : %016llx\n", (unsigned long long)V);
-	if (V == nonce)
-		puts("+ nonce fake signature 1 verification with Alice public key is correct!");
-	else
-		puts("- nonce fake signature 1 verification with Alice public key is incorrect!");
-	S2 = V ^ nonce;
-	printf("S2 (Eve)  : %016llx\n", (unsigned long long)S2);
-	V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2; /* KK */
-	printf("V2 (Bob)  : %016llx\n", (unsigned long long)V2);
-	if (V2 == nonce)
-		puts("+ nonce fake signature 2 verification with Alice public key is correct!");
-	else
-		puts("- nonce fake signature 2 verification with Alice public key is incorrect!");
+    /* EVE HPKS */
+    printf("\n*** HPKS (public key signature)\n");
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&S, &tmp, &nonce);
+    ba_print_hex("S (Eve)   : ", &S);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V, &tmp, &A2);   /* X */
+    ba_print_hex("V (Bob)   : ", &V);
+    if (ba_equal(&V, &nonce))
+        puts("+ nonce fake signature 1 verification with Alice public key is correct!");
+    else
+        puts("- nonce fake signature 1 verification with Alice public key is incorrect!");
+    ba_xor(&S2, &V, &nonce);
+    ba_print_hex("S2 (Eve)  : ", &S2);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V2, &tmp, &A2);
+    ba_xor_into(&V2, &S2);   /* KK */
+    ba_print_hex("V2 (Bob)  : ", &V2);
+    if (ba_equal(&V2, &nonce))
+        puts("+ nonce fake signature 2 verification with Alice public key is correct!");
+    else
+        puts("- nonce fake signature 2 verification with Alice public key is incorrect!");
 
-	/* EVE HPKS + HSKE with preshared made public */
-	printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n");
-	E = fscx_revolve_n(nonce, preshared, preshared, I_VALUE);
-	printf("E (Eve)   : %016llx\n", (unsigned long long)E);
-	S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ E;
-	printf("S (Eve)   : %016llx\n", (unsigned long long)S);
-	V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2; /* X */
-	printf("V (Eve)   : %016llx\n", (unsigned long long)V);
-	S2 = V ^ S;
-	printf("S2 (Eve)  : %016llx\n", (unsigned long long)S2);
-	V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2; /* KK */
-	printf("V2 (Bob)  : %016llx\n", (unsigned long long)V2);
-	D = fscx_revolve_n(V2, preshared, preshared, R_VALUE);
-	printf("D (Bob)   : %016llx\n", (unsigned long long)D); /* X */
-	if (D == nonce)
-		puts("+ fake signature(encrypted nonce) verification with Alice public key is correct!");
-	else
-		puts("- fake signature(encrypted nonce) verification with Alice public key is incorrect!");
+    /* EVE HPKS + HSKE with preshared made public */
+    printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n");
+    ba_fscx_revolve_n(&E, &nonce, &preshared, &preshared, I_VALUE);
+    ba_print_hex("E (Eve)   : ", &E);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&S, &tmp, &A2);
+    ba_xor_into(&S, &E);
+    ba_print_hex("S (Eve)   : ", &S);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V, &tmp, &A2);   /* X */
+    ba_print_hex("V (Eve)   : ", &V);
+    ba_xor(&S2, &V, &S);
+    ba_print_hex("S2 (Eve)  : ", &S2);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V2, &tmp, &A2);
+    ba_xor_into(&V2, &S2);   /* KK */
+    ba_print_hex("V2 (Bob)  : ", &V2);
+    ba_fscx_revolve_n(&D, &V2, &preshared, &preshared, R_VALUE);
+    ba_print_hex("D (Bob)   : ", &D);   /* X */
+    if (ba_equal(&D, &nonce))
+        puts("+ fake signature(encrypted nonce) verification with Alice public key is correct!");
+    else
+        puts("- fake signature(encrypted nonce) verification with Alice public key is incorrect!");
 
-	/* EVE HPKS + HSKE with preshared made public - v2 */
-	printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2\n");
-	S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ nonce;
-	printf("S (Eve)   : %016llx\n", (unsigned long long)S);
-	E = fscx_revolve_n(S, preshared, preshared, I_VALUE);
-	printf("E (Eve)   : %016llx\n", (unsigned long long)E);
-	V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2; /* X */
-	printf("V (Eve)   : %016llx\n", (unsigned long long)V);
-	S2 = V ^ E;
-	printf("S2 (Eve)  : %016llx\n", (unsigned long long)S2);
-	V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2; /* KK */
-	printf("V2 (Bob)  : %016llx\n", (unsigned long long)V2);
-	D = fscx_revolve_n(V2, preshared, preshared, R_VALUE);
-	printf("D (Bob)   : %016llx\n", (unsigned long long)D); /* X */
-	if (D == nonce)
-		puts("+ fake signature(encrypted nonce) v2 verification with Alice public key is correct!");
-	else
-		puts("- fake signature(encrypted nonce) v2 verification with Alice public key is incorrect!");
+    /* EVE HPKS + HSKE with preshared made public - v2 */
+    printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2\n");
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&S, &tmp, &A2);
+    ba_xor_into(&S, &nonce);
+    ba_print_hex("S (Eve)   : ", &S);
+    ba_fscx_revolve_n(&E, &S, &preshared, &preshared, I_VALUE);
+    ba_print_hex("E (Eve)   : ", &E);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V, &tmp, &A2);   /* X */
+    ba_print_hex("V (Eve)   : ", &V);
+    ba_xor(&S2, &V, &E);
+    ba_print_hex("S2 (Eve)  : ", &S2);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&V2, &tmp, &A2);
+    ba_xor_into(&V2, &S2);   /* KK */
+    ba_print_hex("V2 (Bob)  : ", &V2);
+    ba_fscx_revolve_n(&D, &V2, &preshared, &preshared, R_VALUE);
+    ba_print_hex("D (Bob)   : ", &D);   /* X */
+    if (ba_equal(&D, &nonce))
+        puts("+ fake signature(encrypted nonce) v2 verification with Alice public key is correct!");
+    else
+        puts("- fake signature(encrypted nonce) v2 verification with Alice public key is incorrect!");
 
-	/* EVE HPKE */
-	printf("\n*** HPKE (public key encryption)\n");
-	E = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ plaintext;
-	printf("E (Bob)   : %016llx\n", (unsigned long long)E);
-	D = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2; /* X */
-	printf("D (Eve)   : %016llx\n", (unsigned long long)D);
-	E2 = D ^ E;
-	D2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ E2; /* KK */
-	printf("D2 (Eve)  : %016llx\n", (unsigned long long)D2);
-	if ((D == nonce) || (D2 == nonce))
-		puts("+ Eve could decrypt plaintext without Alice's private key!");
-	else
-		puts("- Eve could not decrypt plaintext without Alice's private key!");
+    /* EVE HPKE */
+    printf("\n*** HPKE (public key encryption)\n");
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&E, &tmp, &A2);
+    ba_xor_into(&E, &plaintext);
+    ba_print_hex("E (Bob)   : ", &E);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&D, &tmp, &A2);   /* X */
+    ba_print_hex("D (Eve)   : ", &D);
+    ba_xor(&E2, &D, &E);
+    ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
+    ba_xor(&D2, &tmp, &E2);   /* KK */
+    ba_print_hex("D2 (Eve)  : ", &D2);
+    if (ba_equal(&D, &nonce) || ba_equal(&D2, &nonce))
+        puts("+ Eve could decrypt plaintext without Alice's private key!");
+    else
+        puts("- Eve could not decrypt plaintext without Alice's private key!");
 
-	fclose(urnd);
-	return 0;
+    fclose(urnd);
+    return 0;
 }

--- a/Herradura_tests.c
+++ b/Herradura_tests.c
@@ -1,6 +1,6 @@
 /* Build: gcc -O2 -o Herradura_tests Herradura_tests.c */
 
-/*  Herradura KEx -- Security & Performance Tests (C, 64-bit)
+/*  Herradura KEx -- Security & Performance Tests (C, 256-bit BitArray)
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,88 +16,164 @@
 #include <string.h>
 #include <time.h>
 
-#define INTSZ   64
-#define I_VALUE 16   /* INTSZ / 4 */
-#define R_VALUE 48   /* 3 * INTSZ / 4 */
+/* Key size in bits — must be a positive multiple of 8.
+   Matches the default in "Herradura cryptographic suite.c", and in
+   the Go and Python implementations. */
+#define KEYBITS  256
+#define KEYBYTES (KEYBITS / 8)
+#define I_VALUE  (KEYBITS / 4)       /* 64  for 256-bit */
+#define R_VALUE  (3 * KEYBITS / 4)   /* 192 for 256-bit */
 
-typedef uint64_t u64;
+/* Target wall time per benchmark (seconds). */
+#define BENCH_SEC 1.0
 
-static FILE *urnd;
+/* Fixed-width bit array backed by a big-endian byte array.
+   b[0] holds the most-significant byte.
+   Bit numbering: bit 0 is the LSB (byte[KEYBYTES-1] bit 0);
+   bit KEYBITS-1 is the MSB (byte[0] bit 7). */
+typedef struct {
+    uint8_t b[KEYBYTES];
+} BitArray;
+
+static FILE *urnd_fp;
 
 /* ------------------------------------------------------------------ */
-/* Helpers                                                             */
+/* BitArray primitives                                                 */
 /* ------------------------------------------------------------------ */
 
-static double elapsed_ms(struct timespec *t0, struct timespec *t1)
+static void ba_rand(BitArray *dst)
 {
-	return (double)(t1->tv_sec  - t0->tv_sec)  * 1000.0
-	     + (double)(t1->tv_nsec - t0->tv_nsec) / 1.0e6;
+    if (fread(dst->b, 1, KEYBYTES, urnd_fp) != (size_t)KEYBYTES) {
+        fputs("ERROR: read from /dev/urandom failed\n", stderr);
+        exit(1);
+    }
 }
 
-static u64 rand64(void)
+static void ba_xor(BitArray *dst, const BitArray *a, const BitArray *b)
 {
-	uint8_t buf[8];
-	if (fread(buf, 1, 8, urnd) != 8) {
-		fputs("ERROR: read from /dev/urandom failed\n", stderr);
-		exit(1);
-	}
-	return ((u64)buf[0] << 56) | ((u64)buf[1] << 48) |
-	       ((u64)buf[2] << 40) | ((u64)buf[3] << 32) |
-	       ((u64)buf[4] << 24) | ((u64)buf[5] << 16) |
-	       ((u64)buf[6] <<  8) | ((u64)buf[7]);
+    int i;
+    for (i = 0; i < KEYBYTES; i++)
+        dst->b[i] = a->b[i] ^ b->b[i];
 }
 
-static int popcount64(u64 x)
+/* dst = src rotated left by 1 bit (big-endian, b[0] is MSB). */
+static void ba_rol1(BitArray *dst, const BitArray *src)
 {
-	int cnt = 0;
-	while (x) {
-		cnt += (int)(x & 1u);
-		x >>= 1;
-	}
-	return cnt;
+    int i;
+    uint8_t msbit = (src->b[0] >> 7) & 1;
+    for (i = 0; i < KEYBYTES - 1; i++)
+        dst->b[i] = (uint8_t)((src->b[i] << 1) | (src->b[i + 1] >> 7));
+    dst->b[KEYBYTES - 1] = (uint8_t)((src->b[KEYBYTES - 1] << 1) | msbit);
+}
+
+/* dst = src rotated right by 1 bit (big-endian, b[0] is MSB). */
+static void ba_ror1(BitArray *dst, const BitArray *src)
+{
+    int i;
+    uint8_t lsbit = src->b[KEYBYTES - 1] & 1;
+    for (i = KEYBYTES - 1; i > 0; i--)
+        dst->b[i] = (uint8_t)((src->b[i] >> 1) | (src->b[i - 1] << 7));
+    dst->b[0] = (uint8_t)((src->b[0] >> 1) | (lsbit << 7));
+}
+
+static int ba_equal(const BitArray *a, const BitArray *b)
+{
+    return memcmp(a->b, b->b, KEYBYTES) == 0;
+}
+
+/* Count set bits across all bytes. */
+static int ba_popcount(const BitArray *a)
+{
+    int cnt = 0, i;
+    for (i = 0; i < KEYBYTES; i++) {
+        uint8_t v = a->b[i];
+        while (v) {
+            cnt += (v & 1);
+            v >>= 1;
+        }
+    }
+    return cnt;
+}
+
+/* Return the value of bit pos (0 = LSB of byte[KEYBYTES-1]). */
+static int ba_get_bit(const BitArray *a, int pos)
+{
+    int byte_idx = KEYBYTES - 1 - pos / 8;
+    int bit_pos  = pos % 8;
+    return (a->b[byte_idx] >> bit_pos) & 1;
+}
+
+/* dst = src with bit pos (0 = LSB) toggled. */
+static void ba_flip_bit(BitArray *dst, const BitArray *src, int pos)
+{
+    int byte_idx = KEYBYTES - 1 - pos / 8;
+    int bit_pos  = pos % 8;
+    *dst = *src;
+    dst->b[byte_idx] ^= (uint8_t)(1u << bit_pos);
 }
 
 /* ------------------------------------------------------------------ */
 /* FSCX primitives                                                     */
 /* ------------------------------------------------------------------ */
 
-static u64 rol64(u64 x, int n)
+static void ba_fscx(BitArray *result, const BitArray *a, const BitArray *b)
 {
-	n &= 63;
-	if (n == 0) return x;
-	return (x << n) | (x >> (64 - n));
+    BitArray rol_a, rol_b, ror_a, ror_b;
+    int i;
+    ba_rol1(&rol_a, a);
+    ba_rol1(&rol_b, b);
+    ba_ror1(&ror_a, a);
+    ba_ror1(&ror_b, b);
+    for (i = 0; i < KEYBYTES; i++)
+        result->b[i] = a->b[i] ^ b->b[i]
+                     ^ rol_a.b[i] ^ rol_b.b[i]
+                     ^ ror_a.b[i] ^ ror_b.b[i];
 }
 
-static u64 ror64(u64 x, int n)
+static void ba_fscx_revolve(BitArray *result, const BitArray *a,
+                             const BitArray *b, int steps)
 {
-	n &= 63;
-	if (n == 0) return x;
-	return (x >> n) | (x << (64 - n));
+    BitArray tmp;
+    int i;
+    *result = *a;
+    for (i = 0; i < steps; i++) {
+        ba_fscx(&tmp, result, b);
+        *result = tmp;
+    }
 }
 
-static u64 fscx(u64 a, u64 b)
+static void ba_fscx_revolve_n(BitArray *result, const BitArray *a,
+                               const BitArray *b, const BitArray *nonce,
+                               int steps)
 {
-	u64 result;
-	result  = a ^ b;
-	result ^= rol64(a, 1) ^ rol64(b, 1);
-	result ^= ror64(a, 1) ^ ror64(b, 1);
-	return result;
+    BitArray tmp;
+    int i;
+    *result = *a;
+    for (i = 0; i < steps; i++) {
+        ba_fscx(&tmp, result, b);
+        ba_xor(result, &tmp, nonce);
+    }
 }
 
-static u64 fscx_revolve(u64 a, u64 b, int steps)
+/* ------------------------------------------------------------------ */
+/* Timing helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+static double elapsed_sec(struct timespec *t0, struct timespec *t1)
 {
-	int i;
-	for (i = 0; i < steps; i++)
-		a = fscx(a, b);
-	return a;
+    return (double)(t1->tv_sec  - t0->tv_sec)
+         + (double)(t1->tv_nsec - t0->tv_nsec) / 1.0e9;
 }
 
-static u64 fscx_revolve_n(u64 a, u64 b, u64 nonce, int steps)
+static void print_rate(long long ops, double secs)
 {
-	int i;
-	for (i = 0; i < steps; i++)
-		a = fscx(a, b) ^ nonce;
-	return a;
+    double rate = (double)ops / secs;
+    if (rate >= 1.0e6)
+        printf("%.2f M ops/sec  (%lld ops in %.2fs)\n",
+               rate / 1.0e6, ops, secs);
+    else
+        printf("%.2f K ops/sec  (%lld ops in %.2fs)\n",
+               rate / 1.0e3, ops, secs);
 }
 
 /* ------------------------------------------------------------------ */
@@ -106,144 +182,154 @@ static u64 fscx_revolve_n(u64 a, u64 b, u64 nonce, int steps)
 
 static void test_noncommutativity(void)
 {
-	int i, comm = 0;
-	/* FSCX(A,B) == FSCX(B,A) always (symmetric formula).
-	   Asymmetry arises from FSCX_REVOLVE, where B is held constant across
-	   iterations: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n) in general. */
-	printf("[1] FSCX_REVOLVE non-commutativity: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n)\n");
-	for (i = 0; i < 10000; i++) {
-		u64 a = rand64();
-		u64 b = rand64();
-		if (fscx_revolve(a, b, I_VALUE) == fscx_revolve(b, a, I_VALUE))
-			comm++;
-	}
-	printf("    %d / 10000 pairs were commutative (expected ~0)\n", comm);
-	if (comm == 0)
-		puts("    PASS\n");
-	else
-		puts("    FAIL\n");
+    int i, comm = 0;
+    BitArray a, b, ab, ba_rev;
+    /* FSCX(A,B) == FSCX(B,A) always (symmetric formula).
+       Asymmetry arises from FSCX_REVOLVE, where B is held constant across
+       iterations: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n) in general. */
+    printf("[1] FSCX_REVOLVE non-commutativity: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n)\n");
+    for (i = 0; i < 10000; i++) {
+        ba_rand(&a);
+        ba_rand(&b);
+        ba_fscx_revolve(&ab,     &a, &b, I_VALUE);
+        ba_fscx_revolve(&ba_rev, &b, &a, I_VALUE);
+        if (ba_equal(&ab, &ba_rev))
+            comm++;
+    }
+    printf("    bits=%d  %d / 10000 commutative  [%s]\n",
+           KEYBITS, comm, comm == 0 ? "PASS" : "FAIL");
+    putchar('\n');
 }
 
 static void test_avalanche(void)
 {
-	int trial, bit;
-	double total = 0.0;
-	int gmin = 65, gmax = -1;
-	/* FSCX is a linear map over GF(2): output bit i depends only on input
-	   bits i-1, i, i+1 (cyclic).  Flipping one input bit always changes
-	   exactly 3 output bits — the bit and its two cyclic neighbors.
-	   Security comes from FSCX_REVOLVE iteration, not single-step diffusion.
-	   Frobenius over GF(2): (1+t+t^-1)^(2^k) = 1+t^(2^k)+t^(-2^k), so
-	   power-of-2 step counts also give 3-bit diffusion. */
-	printf("[2] FSCX single-step linear diffusion (expected: exactly 3 bits per flip)\n");
-	for (trial = 0; trial < 1000; trial++) {
-		u64 a = rand64();
-		u64 b = rand64();
-		u64 base = fscx(a, b);
-		for (bit = 0; bit < 64; bit++) {
-			u64 ap = a ^ (1ULL << bit);
-			int hd = popcount64(fscx(ap, b) ^ base);
-			total += hd;
-			if (hd < gmin) gmin = hd;
-			if (hd > gmax) gmax = hd;
-		}
-	}
-	double mean = total / (1000.0 * 64.0);
-	printf("    Mean Hamming distance: %.2f bits (expected 3 / %d)\n", mean, INTSZ);
-	printf("    Min: %d  Max: %d\n", gmin, gmax);
-	if (mean >= 2.9 && mean <= 3.1)
-		puts("    PASS\n");
-	else
-		puts("    FAIL\n");
+    int trial, bit;
+    double total = 0.0;
+    int gmin = KEYBITS + 1, gmax = -1;
+    BitArray a, b, base_out, ap, flip_out, diff;
+    /* FSCX is a linear map over GF(2): output bit i depends only on input
+       bits i-1, i, i+1 (cyclic). Flipping one input bit always changes
+       exactly 3 output bits — the bit and its two cyclic neighbors.
+       Security comes from FSCX_REVOLVE iteration, not single-step diffusion.
+       Frobenius over GF(2): (1+t+t^-1)^(2^k) = 1+t^(2^k)+t^(-2^k), so
+       power-of-2 step counts also give exactly 3-bit diffusion. */
+    printf("[2] FSCX single-step linear diffusion (expected: exactly 3 bits per flip)\n");
+    for (trial = 0; trial < 1000; trial++) {
+        ba_rand(&a);
+        ba_rand(&b);
+        ba_fscx(&base_out, &a, &b);
+        for (bit = 0; bit < KEYBITS; bit++) {
+            int hd;
+            ba_flip_bit(&ap, &a, bit);
+            ba_fscx(&flip_out, &ap, &b);
+            ba_xor(&diff, &flip_out, &base_out);
+            hd = ba_popcount(&diff);
+            total += hd;
+            if (hd < gmin) gmin = hd;
+            if (hd > gmax) gmax = hd;
+        }
+    }
+    {
+        double mean = total / (1000.0 * (double)KEYBITS);
+        printf("    bits=%d  mean=%.2f (expected 3/%d)  min=%d  max=%d  [%s]\n",
+               KEYBITS, mean, KEYBITS, gmin, gmax,
+               (mean >= 2.9 && mean <= 3.1) ? "PASS" : "FAIL");
+    }
+    putchar('\n');
 }
 
 static void test_orbit_period(void)
 {
-	int trial, cnt64 = 0, cnt32 = 0, other = 0;
-	printf("[3] Orbit period: FSCX_REVOLVE(A,B,n) cycles back to A\n");
-	for (trial = 0; trial < 100; trial++) {
-		u64 a = rand64();
-		u64 b = rand64();
-		u64 cur = fscx(a, b);
-		int period = 1;
-		int cap = 2 * INTSZ;
-		while (cur != a && period < cap) {
-			cur = fscx(cur, b);
-			period++;
-		}
-		if (period == 64)      cnt64++;
-		else if (period == 32) cnt32++;
-		else                   other++;
-	}
-	printf("    period=64: %d  period=32: %d  other: %d  (out of 100)\n",
-	       cnt64, cnt32, other);
-	if (other == 0)
-		puts("    PASS\n");
-	else
-		puts("    FAIL\n");
+    int trial, cntP = 0, cntHP = 0, other = 0;
+    int cap = 2 * KEYBITS;
+    BitArray a, b, cur, tmp;
+    printf("[3] Orbit period: FSCX_REVOLVE(A,B,n) cycles back to A\n");
+    for (trial = 0; trial < 100; trial++) {
+        int period = 1;
+        ba_rand(&a);
+        ba_rand(&b);
+        ba_fscx(&cur, &a, &b);
+        while (!ba_equal(&cur, &a) && period < cap) {
+            ba_fscx(&tmp, &cur, &b);
+            cur = tmp;
+            period++;
+        }
+        if      (period == KEYBITS)     cntP++;
+        else if (period == KEYBITS / 2) cntHP++;
+        else                            other++;
+    }
+    printf("    bits=%d  period=%d: %3d  period=%d: %3d  other: %d  [%s]\n",
+           KEYBITS, KEYBITS, cntP, KEYBITS / 2, cntHP, other,
+           other == 0 ? "PASS" : "FAIL");
+    putchar('\n');
 }
 
 static void test_bit_frequency(void)
 {
-	int bit;
-	long long counts[64];
-	int trial;
-	double minpct = 100.0, maxpct = 0.0, meanpct;
-	int N = 100000;
-	printf("[4] Bit-frequency bias: %d FSCX outputs\n", N);
-	memset(counts, 0, sizeof(counts));
-	for (trial = 0; trial < N; trial++) {
-		u64 a = rand64();
-		u64 b = rand64();
-		u64 out = fscx(a, b);
-		for (bit = 0; bit < 64; bit++)
-			if ((out >> bit) & 1ULL)
-				counts[bit]++;
-	}
-	meanpct = 0.0;
-	for (bit = 0; bit < 64; bit++) {
-		double pct = (double)counts[bit] / (double)N * 100.0;
-		meanpct += pct;
-		if (pct < minpct) minpct = pct;
-		if (pct > maxpct) maxpct = pct;
-	}
-	meanpct /= 64.0;
-	printf("    Bit frequency: min=%.2f%%  max=%.2f%%  mean=%.2f%%\n",
-	       minpct, maxpct, meanpct);
-	if (minpct > 47.0 && maxpct < 53.0)
-		puts("    PASS\n");
-	else
-		puts("    FAIL\n");
+    int bit, trial;
+    long long counts[KEYBITS];
+    double minpct, maxpct, meanpct;
+    int N = 100000;
+    BitArray a, b, out;
+    printf("[4] Bit-frequency bias: %d FSCX outputs\n", N);
+    memset(counts, 0, sizeof(counts));
+    for (trial = 0; trial < N; trial++) {
+        ba_rand(&a);
+        ba_rand(&b);
+        ba_fscx(&out, &a, &b);
+        for (bit = 0; bit < KEYBITS; bit++)
+            if (ba_get_bit(&out, bit))
+                counts[bit]++;
+    }
+    minpct = 101.0;
+    maxpct = -1.0;
+    meanpct = 0.0;
+    for (bit = 0; bit < KEYBITS; bit++) {
+        double pct = (double)counts[bit] / (double)N * 100.0;
+        meanpct += pct;
+        if (pct < minpct) minpct = pct;
+        if (pct > maxpct) maxpct = pct;
+    }
+    meanpct /= (double)KEYBITS;
+    printf("    bits=%d  min=%.2f%%  max=%.2f%%  mean=%.2f%%  [%s]\n",
+           KEYBITS, minpct, maxpct, meanpct,
+           (minpct > 47.0 && maxpct < 53.0) ? "PASS" : "FAIL");
+    putchar('\n');
 }
 
 static void test_key_sensitivity(void)
 {
-	int i;
-	double total = 0.0;
-	/* sk = FSCX_REVOLVE_N(C2, B, hn, r) ^ A
-	   Flipping bit k of A changes sk by exactly 1 bit via the direct XOR.
-	   The nonce change (hn = C^C2, C = FSCX_REVOLVE(A,B,i)) propagates
-	   L^i(e_k) into the nonce; algebraically this cancels in S_r * L^i(e_k)
-	   leaving only the 1-bit XOR contribution.
-	   This is a structural property of the HKEX XOR construction. */
-	printf("[5] HKEX session key XOR construction (expected: exactly 1-bit direct sensitivity)\n");
-	for (i = 0; i < 10000; i++) {
-		u64 a  = rand64(), b  = rand64();
-		u64 a2 = rand64(), b2 = rand64();
-		u64 c  = fscx_revolve(a,  b,  I_VALUE);
-		u64 c2 = fscx_revolve(a2, b2, I_VALUE);
-		u64 hn = c ^ c2;
-		u64 key1 = fscx_revolve_n(c2, b, hn, R_VALUE) ^ a;
-		u64 af   = a ^ 1ULL;
-		u64 key2 = fscx_revolve_n(c2, b, hn, R_VALUE) ^ af;
-		total += popcount64(key1 ^ key2);
-	}
-	double mean = total / 10000.0;
-	printf("    Mean Hamming distance: %.2f bits (expected 1 / %d)\n", mean, INTSZ);
-	if (mean >= 0.9 && mean <= 1.1)
-		puts("    PASS\n");
-	else
-		puts("    FAIL\n");
+    int i;
+    double total = 0.0;
+    BitArray a, b, a2, b2, c, c2, hn, key1, key2, af, diff;
+    /* sk = FSCX_REVOLVE_N(C2, B, hn, r) ^ A
+       Flipping bit k of A changes sk by exactly 1 bit via the direct XOR term.
+       The nonce change (hn = C^C2, C = FSCX_REVOLVE(A,B,i)) propagates
+       L^i(e_k) into the nonce; algebraically S_r * L^i(e_k) cancels to zero,
+       leaving only the 1-bit XOR contribution. This is a structural property
+       of the HKEX XOR construction. */
+    printf("[5] HKEX session key XOR construction (expected: exactly 1-bit direct sensitivity)\n");
+    for (i = 0; i < 10000; i++) {
+        ba_rand(&a);  ba_rand(&b);
+        ba_rand(&a2); ba_rand(&b2);
+        ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+        ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+        ba_xor(&hn, &c, &c2);
+        ba_fscx_revolve_n(&key1, &c2, &b, &hn, R_VALUE);
+        ba_xor(&key1, &key1, &a);
+        ba_flip_bit(&af, &a, 0);
+        ba_fscx_revolve_n(&key2, &c2, &b, &hn, R_VALUE);
+        ba_xor(&key2, &key2, &af);
+        ba_xor(&diff, &key1, &key2);
+        total += ba_popcount(&diff);
+    }
+    {
+        double mean = total / 10000.0;
+        printf("    bits=%d  mean Hamming=%.2f (expected 1/%d)  [%s]\n",
+               KEYBITS, mean, KEYBITS,
+               (mean >= 0.9 && mean <= 1.1) ? "PASS" : "FAIL");
+    }
+    putchar('\n');
 }
 
 /* ------------------------------------------------------------------ */
@@ -252,104 +338,117 @@ static void test_key_sensitivity(void)
 
 static void bench_fscx_throughput(void)
 {
-	long long N = 10000000LL;
-	long long i;
-	u64 a = rand64(), b = rand64();
-	u64 sink = 0;
-	struct timespec t0, t1;
-	double ms, mops;
+    BitArray a, b, tmp;
+    struct timespec t0, t1;
+    long long ops = 0;
+    double secs;
+    int i;
 
-	printf("[6] FSCX throughput (%lld iterations)\n", N);
-	clock_gettime(CLOCK_MONOTONIC, &t0);
-	for (i = 0; i < N; i++) {
-		a = fscx(a, b);
-		sink ^= a;
-	}
-	clock_gettime(CLOCK_MONOTONIC, &t1);
-	ms   = elapsed_ms(&t0, &t1);
-	mops = (double)N / ms / 1000.0;
-	printf("    %.2f M ops/sec  (sink=%llx)\n\n", mops, (unsigned long long)sink);
+    printf("[6] FSCX throughput  (bits=%d)\n    ", KEYBITS);
+    ba_rand(&a); ba_rand(&b);
+    /* warm up */
+    for (i = 0; i < 10; i++) ba_fscx(&tmp, &a, &b);
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        for (i = 0; i < 100; i++) { ba_fscx(&tmp, &a, &b); a = tmp; }
+        ops += 100;
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    print_rate(ops, secs);
+    putchar('\n');
 }
 
 static void bench_fscx_revolve_throughput(void)
 {
-	long long N = 500000LL;
-	long long i;
-	int steps_arr[3];
-	int s;
-	u64 sink = 0;
-	struct timespec t0, t1;
-	double ms, kops;
+    int steps_arr[2] = { I_VALUE, R_VALUE };
+    const char *labels[2] = { "i", "r" };
+    int s, i;
+    struct timespec t0, t1;
 
-	steps_arr[0] = I_VALUE;
-	steps_arr[1] = INTSZ / 2;
-	steps_arr[2] = R_VALUE;
-
-	printf("[7] FSCX_REVOLVE throughput (%lld iterations per step count)\n", N);
-	for (s = 0; s < 3; s++) {
-		u64 a = rand64(), b = rand64();
-		clock_gettime(CLOCK_MONOTONIC, &t0);
-		for (i = 0; i < N; i++) {
-			a = fscx_revolve(a, b, steps_arr[s]);
-			sink ^= a;
-		}
-		clock_gettime(CLOCK_MONOTONIC, &t1);
-		ms   = elapsed_ms(&t0, &t1);
-		kops = (double)N / ms;
-		printf("    steps=%2d : %.2f K ops/sec\n", steps_arr[s], kops);
-	}
-	printf("    (sink=%llx)\n\n", (unsigned long long)sink);
+    printf("[7] FSCX_REVOLVE throughput  (bits=%d)\n", KEYBITS);
+    for (s = 0; s < 2; s++) {
+        BitArray a, b, tmp;
+        long long ops = 0;
+        double secs;
+        ba_rand(&a); ba_rand(&b);
+        for (i = 0; i < 5; i++) ba_fscx_revolve(&tmp, &a, &b, steps_arr[s]);
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        do {
+            for (i = 0; i < 20; i++) {
+                ba_fscx_revolve(&tmp, &a, &b, steps_arr[s]);
+                a = tmp;
+            }
+            ops += 20;
+            clock_gettime(CLOCK_MONOTONIC, &t1);
+        } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+        printf("    steps=%3d (%s)  : ", steps_arr[s], labels[s]);
+        print_rate(ops, secs);
+    }
+    putchar('\n');
 }
 
 static void bench_hkex_handshake(void)
 {
-	long long N = 100000LL;
-	long long i;
-	u64 sink = 0;
-	struct timespec t0, t1;
-	double ms, kops;
+    struct timespec t0, t1;
+    long long ops = 0;
+    double secs;
+    int i;
+    BitArray a, b, a2, b2, c, c2, hn, keyA, keyB, tmp;
 
-	printf("[8] HKEX full handshake (%lld handshakes)\n", N);
-	clock_gettime(CLOCK_MONOTONIC, &t0);
-	for (i = 0; i < N; i++) {
-		u64 a  = rand64(), b  = rand64();
-		u64 a2 = rand64(), b2 = rand64();
-		u64 c  = fscx_revolve(a,  b,  I_VALUE);
-		u64 c2 = fscx_revolve(a2, b2, I_VALUE);
-		u64 hn = c ^ c2;
-		u64 keyA = fscx_revolve_n(c2, b,  hn, R_VALUE) ^ a;
-		u64 keyB = fscx_revolve_n(c,  b2, hn, R_VALUE) ^ a2;
-		sink ^= keyA ^ keyB;
-	}
-	clock_gettime(CLOCK_MONOTONIC, &t1);
-	ms   = elapsed_ms(&t0, &t1);
-	kops = (double)N / ms;
-	printf("    %.2f K handshakes/sec  (sink=%llx)\n\n",
-	       kops, (unsigned long long)sink);
+    printf("[8] HKEX full handshake  (bits=%d)\n    ", KEYBITS);
+    /* warm up */
+    for (i = 0; i < 3; i++) {
+        ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2);
+        ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+        ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+        ba_xor(&hn, &c, &c2);
+        ba_fscx_revolve_n(&tmp, &c2, &b,  &hn, R_VALUE); ba_xor(&keyA, &tmp, &a);
+        ba_fscx_revolve_n(&tmp, &c,  &b2, &hn, R_VALUE); ba_xor(&keyB, &tmp, &a2);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        for (i = 0; i < 10; i++) {
+            ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2);
+            ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+            ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+            ba_xor(&hn, &c, &c2);
+            ba_fscx_revolve_n(&tmp, &c2, &b,  &hn, R_VALUE); ba_xor(&keyA, &tmp, &a);
+            ba_fscx_revolve_n(&tmp, &c,  &b2, &hn, R_VALUE); ba_xor(&keyB, &tmp, &a2);
+        }
+        ops += 10;
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    print_rate(ops, secs);
+    putchar('\n');
 }
 
 static void bench_hske_roundtrip(void)
 {
-	long long N = 200000LL;
-	long long i;
-	u64 sink = 0;
-	struct timespec t0, t1;
-	double ms, kops;
+    struct timespec t0, t1;
+    long long ops = 0;
+    double secs;
+    int i;
+    BitArray pt, key, enc, dec;
 
-	printf("[9] HSKE round-trip: encrypt+decrypt (%lld cycles)\n", N);
-	clock_gettime(CLOCK_MONOTONIC, &t0);
-	for (i = 0; i < N; i++) {
-		u64 pt  = rand64();
-		u64 key = rand64();
-		u64 enc = fscx_revolve_n(pt,  key, key, I_VALUE);
-		u64 dec = fscx_revolve_n(enc, key, key, R_VALUE);
-		sink ^= dec ^ pt;
-	}
-	clock_gettime(CLOCK_MONOTONIC, &t1);
-	ms   = elapsed_ms(&t0, &t1);
-	kops = (double)N / ms;
-	printf("    %.2f K round-trips/sec  (correctness sink=%llx)\n\n",
-	       kops, (unsigned long long)sink);
+    printf("[9] HSKE round-trip: encrypt+decrypt  (bits=%d)\n    ", KEYBITS);
+    /* warm up */
+    for (i = 0; i < 5; i++) {
+        ba_rand(&pt); ba_rand(&key);
+        ba_fscx_revolve_n(&enc, &pt,  &key, &key, I_VALUE);
+        ba_fscx_revolve_n(&dec, &enc, &key, &key, R_VALUE);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        for (i = 0; i < 20; i++) {
+            ba_rand(&pt); ba_rand(&key);
+            ba_fscx_revolve_n(&enc, &pt,  &key, &key, I_VALUE);
+            ba_fscx_revolve_n(&dec, &enc, &key, &key, R_VALUE);
+        }
+        ops += 20;
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    print_rate(ops, secs);
+    putchar('\n');
 }
 
 /* ------------------------------------------------------------------ */
@@ -358,27 +457,28 @@ static void bench_hske_roundtrip(void)
 
 int main(void)
 {
-	urnd = fopen("/dev/urandom", "rb");
-	if (!urnd) {
-		fputs("ERROR: cannot open /dev/urandom\n", stderr);
-		return 1;
-	}
+    urnd_fp = fopen("/dev/urandom", "rb");
+    if (!urnd_fp) {
+        fputs("ERROR: cannot open /dev/urandom\n", stderr);
+        return 1;
+    }
 
-	puts("=== Herradura KEx \xe2\x80\x94 Security & Performance Tests (C, 64-bit) ===\n");
+    printf("=== Herradura KEx \xe2\x80\x94 Security & Performance Tests (C, %d-bit) ===\n\n",
+           KEYBITS);
 
-	puts("--- Security Assumption Tests ---\n");
-	test_noncommutativity();
-	test_avalanche();
-	test_orbit_period();
-	test_bit_frequency();
-	test_key_sensitivity();
+    puts("--- Security Assumption Tests ---\n");
+    test_noncommutativity();
+    test_avalanche();
+    test_orbit_period();
+    test_bit_frequency();
+    test_key_sensitivity();
 
-	puts("--- Performance Benchmarks ---\n");
-	bench_fscx_throughput();
-	bench_fscx_revolve_throughput();
-	bench_hkex_handshake();
-	bench_hske_roundtrip();
+    puts("--- Performance Benchmarks ---\n");
+    bench_fscx_throughput();
+    bench_fscx_revolve_throughput();
+    bench_hkex_handshake();
+    bench_hske_roundtrip();
 
-	fclose(urnd);
-	return 0;
+    fclose(urnd_fp);
+    return 0;
 }

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ gcc -DINTSZ=64 -DVERBOSE -O2 -o HKEX_verbose Herradura_KEx.c
 gcc -DINTSZ=256 -O2 -o HKEX_bignum Herradura_KEx_bignum.c -lgmp
 ./HKEX_bignum
 
-# Full cryptographic suite (HKEX + HSKE + HPKS + HPKE)
+# Full cryptographic suite (HKEX + HSKE + HPKS + HPKE) — 256-bit BitArray parameters
 gcc -O2 -o "Herradura cryptographic suite" "Herradura cryptographic suite.c"
 ./"Herradura cryptographic suite"
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ gcc -DINTSZ=256 -O2 -o HKEX_bignum Herradura_KEx_bignum.c -lgmp
 gcc -O2 -o "Herradura cryptographic suite" "Herradura cryptographic suite.c"
 ./"Herradura cryptographic suite"
 
-# Security & performance tests
+# Security & performance tests (256-bit BitArray)
 gcc -O2 -o Herradura_tests Herradura_tests.c
 ./Herradura_tests
 ```


### PR DESCRIPTION
## Summary

- Replace fixed 64-bit integers in `Herradura cryptographic suite.c` and `Herradura_tests.c` with a `BitArray` type — a fixed-width bit string backed by a big-endian byte array — matching the Python and Go implementations
- Default key size is now **256 bits** (`KEYBITS = 256`, `I_VALUE = 64`, `R_VALUE = 192`) in both C files, controlled by a single `#define KEYBITS` at the top
- Benchmarks in `Herradura_tests.c` switched from fixed iteration counts to a 1-second wall-clock target, reporting M ops/sec or K ops/sec (matching Go test style)

### `BitArray` API (shared between both C files)
- `ba_rand` — fill from `/dev/urandom`
- `ba_xor` / `ba_xor_into` — bitwise XOR (out-of-place / in-place)
- `ba_rol1` / `ba_ror1` — rotate left/right by 1 bit (big-endian)
- `ba_equal` — `memcmp`-based equality
- `ba_print_hex` — zero-padded hex output
- `ba_popcount`, `ba_get_bit`, `ba_flip_bit` — bit inspection helpers (tests only)
- `ba_fscx`, `ba_fscx_revolve`, `ba_fscx_revolve_n` — FSCX primitives

## Test plan

- [x] `Herradura cryptographic suite.c` compiles clean (`gcc -O2 -Wall -Wextra`) and all 4 protocols + EVE bypass tests produce correct output
- [x] `Herradura_tests.c` compiles clean and all 5 security tests pass at 256-bit:
  1. Non-commutativity — 0 / 10000 commutative pairs
  2. Linear diffusion — mean exactly 3.00 bits/flip (min=3, max=3)
  3. Orbit period — all periods are 256 or 128
  4. Bit-frequency — each bit set 49–51% of the time
  5. Key sensitivity — mean Hamming distance exactly 1.00 bit per A-flip
- [x] CHANGELOG updated with v1.3 entry; README build comments updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)