### PR TITLE
v1.3 / v1.3.1: BitArray support for C files + FSCX_REVOLVE_N test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3.1] - 2026-03-29
+
+### Changed
+- **`Herradura_tests.c`**, **`Herradura_tests.go`**, **`Herradura_tests.py`**:
+
+  - **Test [1] (non-commutativity)**: switched from `fscx_revolve` to
+    `fscx_revolve_n` with a random nonce per trial, confirming
+    `FSCX_REVOLVE_N(A,B,N,n) ≠ FSCX_REVOLVE_N(B,A,N,n)` in general.
+    The nonce term `T_n(N)` cancels from both sides so commutativity depends
+    only on A and B; the test remains 0/10000.
+
+  - **New test [6] — FSCX_REVOLVE_N nonce-avalanche**: flip 1 bit of the nonce
+    N while keeping A and B constant and measure the output Hamming distance.
+    The change equals `T_n(e_k)` where `T_n = I + L + … + L^(n-1)`, which
+    is independent of A and B (deterministic, so min = max = mean).
+    For `n = size/4` (i_val): `HD = size/4` exactly — 16/32/64 bits for
+    64/128/256-bit parameters respectively — far above the 3-bit single-step
+    FSCX diffusion.  Pass criterion: `HD ≥ size/4`.
+
+  - **Benchmark [7]** (was [6]): FSCX throughput — unchanged.
+  - **Benchmark [8]** (was [7]): renamed from *FSCX_REVOLVE throughput* to
+    **FSCX_REVOLVE_N throughput**; benchmark now calls `fscx_revolve_n` with
+    a random nonce.
+  - **Benchmarks [9–10]** (were [8–9]): HKEX handshake and HSKE round-trip —
+    unchanged, renumbered.
+
+---
+
 ## [1.3] - 2026-03-29
 
 ### Changed

--- a/Herradura_tests.c
+++ b/Herradura_tests.c
@@ -183,16 +183,19 @@ static void print_rate(long long ops, double secs)
 static void test_noncommutativity(void)
 {
     int i, comm = 0;
-    BitArray a, b, ab, ba_rev;
+    BitArray a, b, n, ab, ba_rev;
     /* FSCX(A,B) == FSCX(B,A) always (symmetric formula).
-       Asymmetry arises from FSCX_REVOLVE, where B is held constant across
-       iterations: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n) in general. */
-    printf("[1] FSCX_REVOLVE non-commutativity: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n)\n");
+       Asymmetry arises in FSCX_REVOLVE_N, where B is held constant across
+       iterations: FSCX_REVOLVE_N(A,B,N,n) != FSCX_REVOLVE_N(B,A,N,n) in general.
+       The nonce term T_n(N) cancels from both sides of the difference, so
+       commutativity is determined solely by the A and B inputs. */
+    printf("[1] FSCX_REVOLVE_N non-commutativity: FSCX_REVOLVE_N(A,B,N,n) != FSCX_REVOLVE_N(B,A,N,n)\n");
     for (i = 0; i < 10000; i++) {
         ba_rand(&a);
         ba_rand(&b);
-        ba_fscx_revolve(&ab,     &a, &b, I_VALUE);
-        ba_fscx_revolve(&ba_rev, &b, &a, I_VALUE);
+        ba_rand(&n);
+        ba_fscx_revolve_n(&ab,     &a, &b, &n, I_VALUE);
+        ba_fscx_revolve_n(&ba_rev, &b, &a, &n, I_VALUE);
         if (ba_equal(&ab, &ba_rev))
             comm++;
     }
@@ -332,6 +335,46 @@ static void test_key_sensitivity(void)
     putchar('\n');
 }
 
+static void test_avalanche_revolve_n(void)
+{
+    int i, hd;
+    double total = 0.0;
+    int gmin = KEYBITS + 1, gmax = -1;
+    BitArray a, b, nonce, nonce_flip, base, flipped, diff;
+    /* FSCX_REVOLVE_N nonce-injection avalanche.
+       Flipping 1 bit of the nonce N while keeping A and B constant propagates
+       through all remaining revolve steps.  The change in the output equals
+       T_n(e_k) where T_n = I + L + ... + L^(n-1) and e_k is the unit vector
+       at bit position k.  Unlike the 3-bit diffusion of single-step FSCX or
+       the purely linear FSCX_REVOLVE, T_n accumulates contributions from every
+       step, producing a much larger Hamming distance.
+       Expected: HD >> 3 (significantly more than single-step FSCX diffusion). */
+    printf("[6] FSCX_REVOLVE_N nonce-avalanche: flip 1 nonce bit, measure output diffusion\n");
+    for (i = 0; i < 1000; i++) {
+        ba_rand(&a);
+        ba_rand(&b);
+        ba_rand(&nonce);
+        ba_fscx_revolve_n(&base,    &a, &b, &nonce,      I_VALUE);
+        ba_flip_bit(&nonce_flip, &nonce, 0);
+        ba_fscx_revolve_n(&flipped, &a, &b, &nonce_flip, I_VALUE);
+        ba_xor(&diff, &base, &flipped);
+        hd = ba_popcount(&diff);
+        total += hd;
+        if (hd < gmin) gmin = hd;
+        if (hd > gmax) gmax = hd;
+    }
+    {
+        double mean = total / 1000.0;
+        /* HD = popcount(T_n(e_0)) is deterministic (independent of A and B),
+           so min == max == mean.  For n = KEYBITS/4, HD = KEYBITS/4 exactly.
+           Pass if HD >= KEYBITS/4 (far above the 3-bit single-step diffusion). */
+        printf("    bits=%d  mean HD=%.1f (expected >=%d)  min=%d  max=%d  [%s]\n",
+               KEYBITS, mean, KEYBITS / 4, gmin, gmax,
+               mean >= (double)(KEYBITS / 4) ? "PASS" : "FAIL");
+    }
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
 /* Performance benchmarks                                              */
 /* ------------------------------------------------------------------ */
@@ -344,7 +387,7 @@ static void bench_fscx_throughput(void)
     double secs;
     int i;
 
-    printf("[6] FSCX throughput  (bits=%d)\n    ", KEYBITS);
+    printf("[7] FSCX throughput  (bits=%d)\n    ", KEYBITS);
     ba_rand(&a); ba_rand(&b);
     /* warm up */
     for (i = 0; i < 10; i++) ba_fscx(&tmp, &a, &b);
@@ -358,24 +401,24 @@ static void bench_fscx_throughput(void)
     putchar('\n');
 }
 
-static void bench_fscx_revolve_throughput(void)
+static void bench_fscx_revolve_n_throughput(void)
 {
     int steps_arr[2] = { I_VALUE, R_VALUE };
     const char *labels[2] = { "i", "r" };
     int s, i;
     struct timespec t0, t1;
 
-    printf("[7] FSCX_REVOLVE throughput  (bits=%d)\n", KEYBITS);
+    printf("[8] FSCX_REVOLVE_N throughput  (bits=%d)\n", KEYBITS);
     for (s = 0; s < 2; s++) {
-        BitArray a, b, tmp;
+        BitArray a, b, nonce, tmp;
         long long ops = 0;
         double secs;
-        ba_rand(&a); ba_rand(&b);
-        for (i = 0; i < 5; i++) ba_fscx_revolve(&tmp, &a, &b, steps_arr[s]);
+        ba_rand(&a); ba_rand(&b); ba_rand(&nonce);
+        for (i = 0; i < 5; i++) ba_fscx_revolve_n(&tmp, &a, &b, &nonce, steps_arr[s]);
         clock_gettime(CLOCK_MONOTONIC, &t0);
         do {
             for (i = 0; i < 20; i++) {
-                ba_fscx_revolve(&tmp, &a, &b, steps_arr[s]);
+                ba_fscx_revolve_n(&tmp, &a, &b, &nonce, steps_arr[s]);
                 a = tmp;
             }
             ops += 20;
@@ -395,7 +438,7 @@ static void bench_hkex_handshake(void)
     int i;
     BitArray a, b, a2, b2, c, c2, hn, keyA, keyB, tmp;
 
-    printf("[8] HKEX full handshake  (bits=%d)\n    ", KEYBITS);
+    printf("[9] HKEX full handshake  (bits=%d)\n    ", KEYBITS);
     /* warm up */
     for (i = 0; i < 3; i++) {
         ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2);
@@ -430,7 +473,7 @@ static void bench_hske_roundtrip(void)
     int i;
     BitArray pt, key, enc, dec;
 
-    printf("[9] HSKE round-trip: encrypt+decrypt  (bits=%d)\n    ", KEYBITS);
+    printf("[10] HSKE round-trip: encrypt+decrypt  (bits=%d)\n    ", KEYBITS);
     /* warm up */
     for (i = 0; i < 5; i++) {
         ba_rand(&pt); ba_rand(&key);
@@ -473,9 +516,11 @@ int main(void)
     test_bit_frequency();
     test_key_sensitivity();
 
+    test_avalanche_revolve_n();
+
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();
-    bench_fscx_revolve_throughput();
+    bench_fscx_revolve_n_throughput();
     bench_hkex_handshake();
     bench_hske_roundtrip();
 

--- a/Herradura_tests.go
+++ b/Herradura_tests.go
@@ -194,16 +194,19 @@ func fmtRate(ops int, elapsed time.Duration) string {
 
 func testNonCommutativity() {
 	// Fscx(A,B) == Fscx(B,A) always (symmetric formula: A^B^ROL(A)^ROL(B)^ROR(A)^ROR(B)).
-	// Asymmetry arises from FscxRevolve, where B is held constant across
-	// iterations: FscxRevolve(A,B,n) != FscxRevolve(B,A,n) in general.
-	fmt.Println("[1] FscxRevolve non-commutativity: FscxRevolve(A,B,n) != FscxRevolve(B,A,n)")
+	// Asymmetry arises in FscxRevolveN, where B is held constant across
+	// iterations: FscxRevolveN(A,B,N,n) != FscxRevolveN(B,A,N,n) in general.
+	// The nonce term T_n(N) cancels from both sides of the difference, so
+	// commutativity is determined solely by the A and B inputs.
+	fmt.Println("[1] FscxRevolveN non-commutativity: FscxRevolveN(A,B,N,n) != FscxRevolveN(B,A,N,n)")
 	for _, size := range sizes {
 		iv := iVal(size)
 		comm := 0
 		for i := 0; i < 10000; i++ {
 			a := randBA(size)
 			b := randBA(size)
-			if FscxRevolve(a, b, iv).Equal(FscxRevolve(b, a, iv)) {
+			n := randBA(size)
+			if FscxRevolveN(a, b, n, iv).Equal(FscxRevolveN(b, a, n, iv)) {
 				comm++
 			}
 		}
@@ -362,12 +365,54 @@ func testKeySensitivity() {
 	fmt.Println()
 }
 
+func testAvalancheRevolveN() {
+	// FSCX_REVOLVE_N nonce-injection avalanche.
+	// Flipping 1 bit of the nonce N while keeping A and B constant propagates
+	// through all remaining revolve steps.  The change in the output equals
+	// T_n(e_k) where T_n = I + L + ... + L^(n-1) and e_k is the unit vector
+	// at bit position k.  Unlike the 3-bit diffusion of single-step FSCX or
+	// the purely linear FscxRevolve, T_n accumulates contributions from every
+	// step.  HD = popcount(T_n(e_0)) is deterministic (independent of A and B),
+	// so min == max == mean.  For n = size/4 (i_val), HD = size/4 exactly.
+	fmt.Println("[6] FscxRevolveN nonce-avalanche: flip 1 nonce bit, measure output diffusion")
+	for _, size := range sizes {
+		iv := iVal(size)
+		total := 0.0
+		gmin := size + 1
+		gmax := -1
+		for i := 0; i < 1000; i++ {
+			a := randBA(size)
+			b := randBA(size)
+			n := randBA(size)
+			base := FscxRevolveN(a, b, n, iv)
+			nf := n.FlipBit(0)
+			hd := FscxRevolveN(a, b, nf, iv).Xor(base).Popcount()
+			total += float64(hd)
+			if hd < gmin {
+				gmin = hd
+			}
+			if hd > gmax {
+				gmax = hd
+			}
+		}
+		mean := total / 1000.0
+		expected := size / 4
+		status := "PASS"
+		if mean < float64(expected) {
+			status = "FAIL"
+		}
+		fmt.Printf("    bits=%3d  mean HD=%.1f (expected >=%d)  min=%d  max=%d  [%s]\n",
+			size, mean, expected, gmin, gmax, status)
+	}
+	fmt.Println()
+}
+
 // ---------------------------------------------------------------------------
 // Performance benchmarks
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[6] FSCX throughput")
+	fmt.Println("[7] FSCX throughput")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -380,8 +425,8 @@ func benchFscx() {
 	fmt.Println()
 }
 
-func benchFscxRevolve() {
-	fmt.Println("[7] FSCX_REVOLVE throughput")
+func benchFscxRevolveN() {
+	fmt.Println("[8] FSCX_REVOLVE_N throughput")
 	for _, size := range sizes {
 		for _, stepsLabel := range []struct {
 			steps int
@@ -392,10 +437,11 @@ func benchFscxRevolve() {
 		} {
 			a := randBA(size)
 			b := randBA(size)
+			n := randBA(size)
 			steps := stepsLabel.steps
 			lbl := stepsLabel.label
 			ops, elapsed := bench("", func() {
-				FscxRevolve(a, b, steps)
+				FscxRevolveN(a, b, n, steps)
 			})
 			fmt.Printf("    bits=%3d  steps=%-12s        : %s  (%d ops in %.2fs)\n",
 				size, lbl, fmtRate(ops, elapsed), ops, elapsed.Seconds())
@@ -405,7 +451,7 @@ func benchFscxRevolve() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[8] HKEX full handshake")
+	fmt.Println("[9] HKEX full handshake")
 	for _, size := range sizes {
 		iv := iVal(size)
 		rv := rVal(size)
@@ -427,7 +473,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[9] HSKE round-trip: encrypt+decrypt")
+	fmt.Println("[10] HSKE round-trip: encrypt+decrypt")
 	for _, size := range sizes {
 		iv := iVal(size)
 		rv := rVal(size)
@@ -459,9 +505,11 @@ func main() {
 	testBitFrequency()
 	testKeySensitivity()
 
+	testAvalancheRevolveN()
+
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()
-	benchFscxRevolve()
+	benchFscxRevolveN()
 	benchHkexHandshake()
 	benchHskeRoundTrip()
 }

--- a/Herradura_tests.py
+++ b/Herradura_tests.py
@@ -157,16 +157,19 @@ TARGET_SEC = 1.0
 
 def test_noncommutativity():
     # FSCX(A,B) == FSCX(B,A) always (symmetric formula: A^B^ROL(A)^ROL(B)^ROR(A)^ROR(B)).
-    # Asymmetry arises from FSCX_REVOLVE, where B is held constant across
-    # iterations: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n) in general.
-    print("[1] FSCX_REVOLVE non-commutativity: FSCX_REVOLVE(A,B,n) != FSCX_REVOLVE(B,A,n)")
+    # Asymmetry arises in FSCX_REVOLVE_N, where B is held constant across
+    # iterations: FSCX_REVOLVE_N(A,B,N,n) != FSCX_REVOLVE_N(B,A,N,n) in general.
+    # The nonce term T_n(N) cancels from both sides of the difference, so
+    # commutativity is determined solely by the A and B inputs.
+    print("[1] FSCX_REVOLVE_N non-commutativity: FSCX_REVOLVE_N(A,B,N,n) != FSCX_REVOLVE_N(B,A,N,n)")
     for size in SIZES:
         iv = i_val(size)
         comm = 0
         for _ in range(10000):
             a = BitArray.random(size)
             b = BitArray.random(size)
-            if fscx_revolve(a, b, iv) == fscx_revolve(b, a, iv):
+            n = BitArray.random(size)
+            if fscx_revolve_n(a, b, n, iv) == fscx_revolve_n(b, a, n, iv):
                 comm += 1
         status = "PASS" if comm == 0 else "FAIL"
         print(f"    bits={size:3d}  {comm:5d} / 10000 commutative  [{status}]")
@@ -280,6 +283,41 @@ def test_key_sensitivity():
     print()
 
 
+def test_avalanche_revolve_n():
+    # FSCX_REVOLVE_N nonce-injection avalanche.
+    # Flipping 1 bit of the nonce N while keeping A and B constant propagates
+    # through all remaining revolve steps.  The change in the output equals
+    # T_n(e_k) where T_n = I + L + ... + L^(n-1) and e_k is the unit vector
+    # at bit position k.  Unlike the 3-bit diffusion of single-step FSCX or
+    # the purely linear FSCX_REVOLVE, T_n accumulates contributions from every
+    # step.  HD = popcount(T_n(e_0)) is deterministic (independent of A and B),
+    # so min == max == mean.  For n = size/4 (i_val), HD = size/4 exactly.
+    print("[6] FSCX_REVOLVE_N nonce-avalanche: flip 1 nonce bit, measure output diffusion")
+    for size in SIZES:
+        iv = i_val(size)
+        expected = size // 4
+        total = 0.0
+        gmin = size + 1
+        gmax = -1
+        for _ in range(1000):
+            a = BitArray.random(size)
+            b = BitArray.random(size)
+            n = BitArray.random(size)
+            base    = fscx_revolve_n(a, b, n,           iv)
+            nf      = n.flip_bit(0)
+            flipped = fscx_revolve_n(a, b, nf,          iv)
+            hd = (base ^ flipped).popcount()
+            total += hd
+            if hd < gmin:
+                gmin = hd
+            if hd > gmax:
+                gmax = hd
+        mean = total / 1000.0
+        status = "PASS" if mean >= expected else "FAIL"
+        print(f"    bits={size:3d}  mean HD={mean:.1f} (expected >={expected})  min={gmin}  max={gmax}  [{status}]")
+    print()
+
+
 # ---------------------------------------------------------------------------
 # Performance benchmarks
 # ---------------------------------------------------------------------------
@@ -309,7 +347,7 @@ def _bench(label: str, fn):
 
 
 def bench_fscx():
-    print("[6] FSCX throughput")
+    print("[7] FSCX throughput")
     for size in SIZES:
         a = BitArray.random(size)
         b = BitArray.random(size)
@@ -320,20 +358,21 @@ def bench_fscx():
     print()
 
 
-def bench_fscx_revolve():
-    print("[7] FSCX_REVOLVE throughput")
+def bench_fscx_revolve_n():
+    print("[8] FSCX_REVOLVE_N throughput")
     for size in SIZES:
         for steps, label in [(i_val(size), f"i({i_val(size)})"), (r_val(size), f"r({r_val(size)})")]:
             a = BitArray.random(size)
             b = BitArray.random(size)
-            def fn(a=a, b=b, steps=steps):
-                return fscx_revolve(a, b, steps)
+            n = BitArray.random(size)
+            def fn(a=a, b=b, n=n, steps=steps):
+                return fscx_revolve_n(a, b, n, steps)
             _bench(f"bits={size:3d}  steps={label}", fn)
     print()
 
 
 def bench_hkex_handshake():
-    print("[8] HKEX full handshake")
+    print("[9] HKEX full handshake")
     for size in SIZES:
         iv = i_val(size)
         rv = r_val(size)
@@ -352,7 +391,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[9] HSKE round-trip: encrypt+decrypt")
+    print("[10] HSKE round-trip: encrypt+decrypt")
     for size in SIZES:
         iv = i_val(size)
         rv = r_val(size)
@@ -382,8 +421,10 @@ if __name__ == '__main__':
     test_bit_frequency()
     test_key_sensitivity()
 
+    test_avalanche_revolve_n()
+
     print("--- Performance Benchmarks ---\n")
     bench_fscx()
-    bench_fscx_revolve()
+    bench_fscx_revolve_n()
     bench_hkex_handshake()
     bench_hske_roundtrip()


### PR DESCRIPTION
## Summary

### v1.3 — BitArray support for C implementations (256-bit parameters)

- `Herradura cryptographic suite.c`: replaced fixed `uint64_t` arithmetic with a `BitArray` type (big-endian byte array, configurable via `#define KEYBITS`), matching the Python and Go implementations. Default is **256-bit** parameters (`I_VALUE = 64`, `R_VALUE = 192`).
- `Herradura_tests.c`: same `BitArray` upgrade; benchmarks switched to a 1-second wall-clock target reporting M/K ops/sec.
- README build comments updated to note 256-bit parameters.

### v1.3.1 — FSCX_REVOLVE_N test coverage across all test files

- **Test [1] (non-commutativity)** — all three files: switched from `fscx_revolve` to `fscx_revolve_n` with a random nonce per trial.
- **New test [6] — FSCX_REVOLVE_N nonce-avalanche** — all three files: flips 1 bit of nonce N (A and B held constant) and measures output Hamming distance. The change equals `T_n(e_0)` — deterministic, independent of A and B — and equals `size/4` exactly (16 / 32 / 64 bits for 64 / 128 / 256-bit). Pass criterion: `HD ≥ size/4`, demonstrating diffusion far above the 3-bit single-step FSCX baseline.
- **Benchmark [8]** (was [7]): renamed from *FSCX_REVOLVE* to *FSCX_REVOLVE_N throughput*; calls `fscx_revolve_n` with a nonce. Benchmarks [9–10] renumbered.
- CHANGELOG updated with v1.3 and v1.3.1 entries.

## Test plan

- [x] `Herradura cryptographic suite.c` compiles clean (`-Wall -Wextra`) and all 4 protocols + EVE bypass tests produce correct output at 256-bit
- [x] `Herradura_tests.c` compiles clean; all 6 security tests PASS at 256-bit
- [x] `go run Herradura_tests.go`: all 6 security tests PASS at 64/128/256-bit
- [x] `python3 Herradura_tests.py`: all 6 security tests PASS at 64/128/256-bit
- [x] New test [6] shows HD = size/4 (deterministic) for all sizes and all implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)