### PR TITLE
v1.3.2: performance optimizations, readability, cross-language consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3.2] - 2026-03-29
+
+### Changed — performance, readability, and cross-language structural consistency
+
+#### All suite files (`Herradura cryptographic suite.{c,go,py}`)
+- **Version headers** updated to v1.3.2; prior v1.1/v1.2 labels corrected to v1.3.
+
+#### C — `Herradura cryptographic suite.c` and `Herradura_tests.c`
+- **`ba_fscx` — fused single-pass**: ROL and ROR are now computed inline from
+  adjacent bytes in a single loop, eliminating 4 temporary `BitArray` stack
+  allocations and reducing 5 separate memory passes to 1.
+  A `#if KEYBYTES < 2 #error` guard documents the KEYBITS ≥ 16 requirement.
+- **`ba_fscx_revolve` / `ba_fscx_revolve_n` — double-buffering**: two local
+  buffers alternate with `idx ^= 1`, eliminating one full `BitArray` struct
+  copy per iteration step.
+- **`ba_popcount` — hardware `__builtin_popcount`** (tests only): replaces the
+  manual bit-shift loop; compiles to a single `POPCNT` instruction on x86-64/ARM.
+- **`ba_xor_into` removed** (suite only): every call site replaced by
+  `ba_xor(dst, dst, src)`, which is correct since `ba_xor` handles aliasing.
+- **`ba_rol1` / `ba_ror1` removed**: rotation logic is now inlined inside
+  `ba_fscx`; these helpers are no longer part of the API.
+
+#### Go — `Herradura cryptographic suite.go` and `Herradura_tests.go`
+- **`Fscx` rewritten**: replaces the parameter-shadowing style
+  (`ba = ba.RotateLeft(1)`) with a direct formula expression — each of the six
+  terms maps one-to-one to `A⊕B⊕ROL(A)⊕ROL(B)⊕ROR(A)⊕ROR(B)`.
+- **Naming — suite file**: `Fscx_revolve` → `FscxRevolve`, `Fscx_revolve_n` →
+  `FscxRevolveN`, `New_rand_bitarray` → `NewRandBitArray`; removes non-idiomatic
+  underscores in exported Go names, consistent with the tests file.
+- **Naming — tests file**: `New_rand_bitarray` → `newRandBitArray` (unexported).
+- **Local variables in `main`**: `r_value`/`i_value` → `rValue`/`iValue`,
+  `hkex_nonce` → `hkexNonce` (idiomatic Go camelCase).
+- **`Popcount` — `math/bits.OnesCount8`** (tests only): replaces the manual
+  bit-shift loop; compiles to a hardware popcount instruction.
+- **`FlipBit` simplified** (tests only): `if cur == 0 / else` replaced by
+  the one-liner `SetBit(&v, pos, v.Bit(pos)^1)`.
+
+#### Python — `Herradura_KEx.py` (basic key-exchange demo)
+- **`BitArray.rotated(n)`** added: same non-mutating rotation method as the suite
+  and tests files; brings the basic demo into structural parity with those files.
+- **`fscx` rewritten** using `rotated()`; no longer mutates its inputs.
+- **`keybits` parameter removed** from `fscx`, `fscx_revolve`, and `fscx_revolve_n`:
+  the parameter was unused in all three functions (size is carried by the
+  `BitArray` object itself); callers in `main()` updated accordingly.
+
+#### Python — `Herradura cryptographic suite.py` and `Herradura_tests.py`
+- **`BitArray.rotated(n)`** — new non-mutating rotation method (both files):
+  returns a new `BitArray` rotated left by `n` bits (right if `n < 0`).
+  Positive and negative rotations share one method, matching `RotateLeft` in Go.
+- **`fscx` rewritten** (both files): replaces the copy-then-mutate pattern
+  (`a.ror(1); a.rol(2)`) with a direct expression using `rotated()`.
+  No input mutation occurs — the function is now a pure transformation.
+- **`BitArray.random()` classmethod added** (suite only): the suite now uses the
+  same `BitArray.random(size)` interface as the tests file; `new_rand_bitarray()`
+  is removed.
+- **`main()` function and `if __name__ == '__main__':` guard** (suite only):
+  protocol demonstration code is wrapped in `main()`, consistent with Go and C
+  which have explicit entry-point functions.
+- **`fscx` defined before `fscx_revolve`** (suite only): declaration order now
+  matches C and Go (definition before first use).
+- **Module-level constants** (suite only): `KEYBITS = 256`, `I_VALUE`,
+  `R_VALUE` defined at module scope, matching the C `#define` names.
+
+#### Not applicable — `Herradura_KEx.{c,go}`, `Herradura_KEx_bignum.c`, `HAEN.asm`, `HKEX_arm_linux.s`
+The v1.3.2 optimisations do not apply to these files:
+- The C and Go basic KEx files and the GMP bignum file implement FSCX via a
+  bit-by-bit extraction loop (`BITX`/`BIT` helpers) rather than byte-parallel
+  ROL/ROR operations, so the fused single-pass `ba_fscx` is architecturally
+  inapplicable. Their `FSCX_REVOLVE` loops operate on scalar or GMP values
+  with no per-step struct copy to eliminate.
+- The x86 NASM and ARM assembly files are fixed instruction sequences; none of
+  the language-level improvements (compiler hints, Python integer arithmetic,
+  Go struct layout) apply.
+
+---
+
 ## [1.3.1] - 2026-03-29
 
 ### Changed

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.2
+/*  Herradura Cryptographic Suite v1.3.2
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,20 +17,32 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.2: BitArray (multi-byte parameter support) ---
+    --- v1.3.2: performance and readability ---
 
-    The C implementation now uses a BitArray type: a fixed-width bit string
-    backed by a big-endian byte array, matching the Python and Go versions.
-    Default key size is 256 bits (i_value = 64, r_value = 192).
+    - ba_fscx: fused into a single-pass loop.  Eliminates 4 temporary BitArray
+      allocations and reduces 5 separate memory passes to 1.
+    - ba_fscx_revolve / ba_fscx_revolve_n: double-buffered with index swap;
+      eliminates one full BitArray copy per iteration step.
+    - ba_rol1 / ba_ror1: removed from the public API; their logic is now
+      inlined inside ba_fscx.
+    - ba_xor_into: removed; replaced by ba_xor(dst, dst, src) at every call
+      site (aliasing dst == a is safe in ba_xor).
+    - Version header updated; build comment moved to a single line.
+
+    --- v1.3: BitArray (multi-byte parameter support) ---
+
+    The C implementation uses a BitArray type: a fixed-width bit string backed
+    by a big-endian byte array, matching the Python and Go versions.
+    Default key size is 256 bits (I_VALUE = 64, R_VALUE = 192).
 
     BitArray supports:
-      - XOR (ba_xor / ba_xor_into)
-      - Rotate-left / rotate-right by 1 bit (big-endian)
+      - XOR (ba_xor — aliasing-safe)
       - Equality comparison (ba_equal)
       - Hex printing (ba_print_hex)
       - Secure random fill from /dev/urandom (ba_rand)
 
-    The key size is controlled by KEYBITS (must be a positive multiple of 8).
+    The key size is controlled by KEYBITS (must be a positive multiple of 8
+    and >= 16 for the single-pass ba_fscx implementation).
     Change the #define to use a different bit width; all parameters and step
     counts scale automatically.
 
@@ -66,13 +78,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Key size in bits -- must be a positive multiple of 8.
+/* Key size in bits -- must be a positive multiple of 8 and >= 16.
    Change this to use a different parameter width; I_VALUE and R_VALUE scale
    automatically. Equivalent to 256-bit parameters in the Go and Python versions. */
 #define KEYBITS  256
 #define KEYBYTES (KEYBITS / 8)
 #define I_VALUE  (KEYBITS / 4)       /* 64  for 256-bit */
 #define R_VALUE  (3 * KEYBITS / 4)   /* 192 for 256-bit */
+
+#if KEYBYTES < 2
+#  error "KEYBITS must be >= 16 for the single-pass ba_fscx implementation"
+#endif
 
 /* Fixed-width bit array backed by a big-endian byte array.
    b[0] holds the most-significant byte; size is always KEYBYTES. */
@@ -89,40 +105,12 @@ static void ba_rand(BitArray *dst, FILE *urnd)
     }
 }
 
-/* dst = a XOR b */
+/* dst = a XOR b.  Aliasing dst == a or dst == b is safe. */
 static void ba_xor(BitArray *dst, const BitArray *a, const BitArray *b)
 {
     int i;
     for (i = 0; i < KEYBYTES; i++)
         dst->b[i] = a->b[i] ^ b->b[i];
-}
-
-/* dst ^= src  (in-place XOR) */
-static void ba_xor_into(BitArray *dst, const BitArray *src)
-{
-    int i;
-    for (i = 0; i < KEYBYTES; i++)
-        dst->b[i] ^= src->b[i];
-}
-
-/* dst = src rotated left by 1 bit (big-endian: b[0] is MSB). */
-static void ba_rol1(BitArray *dst, const BitArray *src)
-{
-    int i;
-    uint8_t msbit = (src->b[0] >> 7) & 1;
-    for (i = 0; i < KEYBYTES - 1; i++)
-        dst->b[i] = (uint8_t)((src->b[i] << 1) | (src->b[i + 1] >> 7));
-    dst->b[KEYBYTES - 1] = (uint8_t)((src->b[KEYBYTES - 1] << 1) | msbit);
-}
-
-/* dst = src rotated right by 1 bit (big-endian: b[0] is MSB). */
-static void ba_ror1(BitArray *dst, const BitArray *src)
-{
-    int i;
-    uint8_t lsbit = src->b[KEYBYTES - 1] & 1;
-    for (i = KEYBYTES - 1; i > 0; i--)
-        dst->b[i] = (uint8_t)((src->b[i] >> 1) | (src->b[i - 1] << 7));
-    dst->b[0] = (uint8_t)((src->b[0] >> 1) | (lsbit << 7));
 }
 
 /* Returns 1 if a == b, 0 otherwise. */
@@ -142,32 +130,57 @@ static void ba_print_hex(const char *label, const BitArray *a)
 }
 
 /* Full Surroundings Cyclic XOR:
-   result = a XOR b XOR ROL(a) XOR ROL(b) XOR ROR(a) XOR ROR(b) */
+   result = a XOR b XOR ROL(a) XOR ROL(b) XOR ROR(a) XOR ROR(b)
+
+   Fused single-pass implementation: ROL and ROR are computed inline from
+   adjacent bytes, avoiding 4 temporary BitArray allocations and 5 separate
+   memory passes.  Requires KEYBYTES >= 2. */
 static void ba_fscx(BitArray *result, const BitArray *a, const BitArray *b)
 {
-    BitArray rol_a, rol_b, ror_a, ror_b;
+    /* Wrap-around bits extracted before the loop */
+    uint8_t a_msbit = a->b[0] >> 7;
+    uint8_t b_msbit = b->b[0] >> 7;
+    uint8_t a_lsbit = a->b[KEYBYTES - 1] & 1;
+    uint8_t b_lsbit = b->b[KEYBYTES - 1] & 1;
     int i;
-    ba_rol1(&rol_a, a);
-    ba_rol1(&rol_b, b);
-    ba_ror1(&ror_a, a);
-    ba_ror1(&ror_b, b);
-    for (i = 0; i < KEYBYTES; i++)
+
+    /* byte 0: ROR wraps in from the last byte */
+    result->b[0] = a->b[0] ^ b->b[0]
+        ^ (uint8_t)((a->b[0] << 1) | (a->b[1] >> 7))   /* ROL(a)[0] */
+        ^ (uint8_t)((b->b[0] << 1) | (b->b[1] >> 7))   /* ROL(b)[0] */
+        ^ (uint8_t)((a->b[0] >> 1) | (a_lsbit << 7))   /* ROR(a)[0] */
+        ^ (uint8_t)((b->b[0] >> 1) | (b_lsbit << 7));  /* ROR(b)[0] */
+
+    /* middle bytes: no wrap-around */
+    for (i = 1; i < KEYBYTES - 1; i++)
         result->b[i] = a->b[i] ^ b->b[i]
-                     ^ rol_a.b[i] ^ rol_b.b[i]
-                     ^ ror_a.b[i] ^ ror_b.b[i];
+            ^ (uint8_t)((a->b[i] << 1) | (a->b[i + 1] >> 7))
+            ^ (uint8_t)((b->b[i] << 1) | (b->b[i + 1] >> 7))
+            ^ (uint8_t)((a->b[i] >> 1) | (a->b[i - 1] << 7))
+            ^ (uint8_t)((b->b[i] >> 1) | (b->b[i - 1] << 7));
+
+    /* last byte: ROL wraps in from the first byte */
+    result->b[KEYBYTES - 1] = a->b[KEYBYTES-1] ^ b->b[KEYBYTES-1]
+        ^ (uint8_t)((a->b[KEYBYTES-1] << 1) | a_msbit)
+        ^ (uint8_t)((b->b[KEYBYTES-1] << 1) | b_msbit)
+        ^ (uint8_t)((a->b[KEYBYTES-1] >> 1) | (a->b[KEYBYTES-2] << 7))
+        ^ (uint8_t)((b->b[KEYBYTES-1] >> 1) | (b->b[KEYBYTES-2] << 7));
 }
 
-/* FSCX_REVOLVE: iterate fscx(a, b) n times keeping b constant. */
+/* FSCX_REVOLVE: iterate fscx(a, b) n times keeping b constant.
+   Double-buffered: alternates between two local buffers to avoid
+   copying the result back every step. */
 static void ba_fscx_revolve(BitArray *result, const BitArray *a,
                              const BitArray *b, int steps)
 {
-    BitArray tmp;
-    int i;
-    *result = *a;
+    BitArray buf[2];
+    int idx = 0, i;
+    buf[0] = *a;
     for (i = 0; i < steps; i++) {
-        ba_fscx(&tmp, result, b);
-        *result = tmp;
+        ba_fscx(&buf[1 - idx], &buf[idx], b);
+        idx ^= 1;
     }
+    *result = buf[idx];
 }
 
 /* FSCX_REVOLVE_N (v1.1): nonce-augmented iteration.
@@ -176,14 +189,73 @@ static void ba_fscx_revolve_n(BitArray *result, const BitArray *a,
                                const BitArray *b, const BitArray *nonce,
                                int steps)
 {
-    BitArray tmp;
-    int i;
-    *result = *a;
+    BitArray buf[2];
+    int idx = 0, i;
+    buf[0] = *a;
     for (i = 0; i < steps; i++) {
-        ba_fscx(&tmp, result, b);
-        ba_xor(result, &tmp, nonce);
+        ba_fscx(&buf[1 - idx], &buf[idx], b);
+        ba_xor(&buf[1 - idx], &buf[1 - idx], nonce);
+        idx ^= 1;
     }
+    *result = buf[idx];
 }
+
+/*
+let,    Alice, Bob: i + r == bitlength b;  i == 1/4 bitlength; r == 3/4 bitlength; bitlength is a power of 2 >= 8
+        P be a plaintext message of bitlength b,
+        E the encrypted version of plaintext P,
+        D == P the decrypted version of E.
+let,    Alice: A,B be random values of bitlength b,
+        Bob: A2,B2 be random values of bitlength b
+let,    Alice: C = fscx_revolve(A, B, i) ,
+        Bob: C2 = fscx_revolve(A2, B2, i)
+then,   Alice: D = fscx_revolve(C2, B, r) ^ A ,
+        Bob: D2 = fscx_revolve(C, B2, r) ^ A2
+where,  Alice, Bob: D == D2
+then,   fscx_revolve(C2, B, r) ^ A  == fscx_revolve(C, B2, r) ^ A2,
+        fscx_revolve(C2, B, r) ^ A ^ P == fscx_revolve(C, B2, r) ^ A2 ^ P,
+        fscx_revolve(C2, B, R) ^ A ^ A2 ^ P == fscx_revolve(C, B2, r)  ^ P  #Note that this form breaks trapdoor
+also,   fscx_revolve(C2, B, r) ^ A  ^ P == fscx_revolve(C2 ^ P, B, r) ^ A
+
+let,    public key => {C,B2,A2,r},
+        private key => {C2,B,A,r}
+then,   E = fscx_revolve(C, B2, r) ^ A2  ^ P,
+        P == (D = fscx_revolve(C2, B, r) ^ A ^ E)
+
+let,    E = fscx_revolve(C2, B, r) ^ A  ^ P
+then,   fscx_revolve(E, B2, i) ^ A2 ^ P  == 0
+        fscx_revolve(E ^ P, B2, i) == 0
+
+HKEX (key exchange)
+    Alice:  C = fscx_revolve(A,B,i)
+            send C to Bob and get C2
+            shared_key = fscx_revolve(C2, B, r) ^ A,
+    Bob:    C2 = fscx_revolve(A2,B2,i)
+            send C2 to Alice and get C
+            shared_key => fscx_revolve(C, B2, r) ^ A2
+
+HSKE (symmetric key encryption):
+    Alice,Bob:  share key of bitlength b
+    Alice:  E = fscx_revolve(P , key , i)
+            shares E with Bob
+    Bob:    P = fscx_revolve(E , key , r)
+
+HPKS (public key signature)
+    Alice:  C = fscx_revolve(A,B,i)
+            C2 = fscx_revolve(A2,B2,i)
+            {publish (C,B2,A2,r) as public key, also disclose b,r,i; keep the rest of parameters (C2,B,A) as private key},
+            S = fscx_revolve(C2, B, r) ^ A ^ P
+            shares E, S with Bob
+    Bob:    P = fscx_revolve(C,B2, r) ^ A2  ^ S
+
+HPKE (public key encryption)
+    Alice:  C = fscx_revolve(A,B,i),
+            C2 = fscx_revolve(A2,B2,i),
+            {publish (C,B2,A2,r) as public key, keep the rest of parameters as private key},
+    Bob:    E = fscx_revolve(C, B2, r) ^ A2  ^ P
+            shares E with Alice
+    Alice:  P = fscx_revolve(C2, B, r) ^ A ^ E
+*/
 
 int main(void)
 {
@@ -251,11 +323,11 @@ int main(void)
     printf("\n--- HPKS (public key signature)\n");
     ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
     ba_xor(&S, &tmp, &A);
-    ba_xor_into(&S, &plaintext);
+    ba_xor(&S, &S, &plaintext);
     ba_print_hex("S (Alice) : ", &S);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V, &tmp, &A2);
-    ba_xor_into(&V, &S);
+    ba_xor(&V, &V, &S);
     ba_print_hex("V (Bob)   : ", &V);
     if (ba_equal(&V, &plaintext))
         puts("+ signature S from plaintext is correct!");
@@ -268,11 +340,11 @@ int main(void)
     ba_print_hex("E (Alice) : ", &E);
     ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
     ba_xor(&S, &tmp, &A);
-    ba_xor_into(&S, &E);   /* A+B2+C is the trapdoor */
+    ba_xor(&S, &S, &E);   /* A+B2+C is the trapdoor */
     ba_print_hex("S (Alice) : ", &S);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V, &tmp, &A2);
-    ba_xor_into(&V, &S);   /* => E */
+    ba_xor(&V, &V, &S);   /* => E */
     ba_print_hex("V (Bob)   : ", &V);
     ba_fscx_revolve_n(&D, &V, &preshared, &preshared, R_VALUE);   /* => plaintext */
     ba_print_hex("D (Bob)   : ", &D);
@@ -285,11 +357,11 @@ int main(void)
     printf("\n--- HPKE (public key encryption)\n");
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&E, &tmp, &A2);
-    ba_xor_into(&E, &plaintext);
+    ba_xor(&E, &E, &plaintext);
     ba_print_hex("E (Bob)   : ", &E);
     ba_fscx_revolve_n(&tmp, &C2, &B, &hkex_nonce, R_VALUE);
     ba_xor(&D, &tmp, &A);
-    ba_xor_into(&D, &E);   /* => plaintext */
+    ba_xor(&D, &D, &E);   /* => plaintext */
     ba_print_hex("D (Alice) : ", &D);
     if (ba_equal(&D, &plaintext))
         puts("+ plaintext is correctly decrypted from E with private key!");
@@ -315,7 +387,7 @@ int main(void)
     ba_print_hex("S2 (Eve)  : ", &S2);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V2, &tmp, &A2);
-    ba_xor_into(&V2, &S2);   /* KK */
+    ba_xor(&V2, &V2, &S2);   /* KK */
     ba_print_hex("V2 (Bob)  : ", &V2);
     if (ba_equal(&V2, &nonce))
         puts("+ nonce fake signature 2 verification with Alice public key is correct!");
@@ -328,7 +400,7 @@ int main(void)
     ba_print_hex("E (Eve)   : ", &E);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&S, &tmp, &A2);
-    ba_xor_into(&S, &E);
+    ba_xor(&S, &S, &E);
     ba_print_hex("S (Eve)   : ", &S);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V, &tmp, &A2);   /* X */
@@ -337,7 +409,7 @@ int main(void)
     ba_print_hex("S2 (Eve)  : ", &S2);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V2, &tmp, &A2);
-    ba_xor_into(&V2, &S2);   /* KK */
+    ba_xor(&V2, &V2, &S2);   /* KK */
     ba_print_hex("V2 (Bob)  : ", &V2);
     ba_fscx_revolve_n(&D, &V2, &preshared, &preshared, R_VALUE);
     ba_print_hex("D (Bob)   : ", &D);   /* X */
@@ -350,7 +422,7 @@ int main(void)
     printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2\n");
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&S, &tmp, &A2);
-    ba_xor_into(&S, &nonce);
+    ba_xor(&S, &S, &nonce);
     ba_print_hex("S (Eve)   : ", &S);
     ba_fscx_revolve_n(&E, &S, &preshared, &preshared, I_VALUE);
     ba_print_hex("E (Eve)   : ", &E);
@@ -361,7 +433,7 @@ int main(void)
     ba_print_hex("S2 (Eve)  : ", &S2);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&V2, &tmp, &A2);
-    ba_xor_into(&V2, &S2);   /* KK */
+    ba_xor(&V2, &V2, &S2);   /* KK */
     ba_print_hex("V2 (Bob)  : ", &V2);
     ba_fscx_revolve_n(&D, &V2, &preshared, &preshared, R_VALUE);
     ba_print_hex("D (Bob)   : ", &D);   /* X */
@@ -374,7 +446,7 @@ int main(void)
     printf("\n*** HPKE (public key encryption)\n");
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&E, &tmp, &A2);
-    ba_xor_into(&E, &plaintext);
+    ba_xor(&E, &E, &plaintext);
     ba_print_hex("E (Bob)   : ", &E);
     ba_fscx_revolve_n(&tmp, &C, &B2, &hkex_nonce, R_VALUE);
     ba_xor(&D, &tmp, &A2);   /* X */

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.1
+/*  Herradura Cryptographic Suite v1.3.2
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,22 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.3.2: performance and readability ---
+
+    - Fscx: rewritten without parameter shadowing; each term maps directly
+      to the formula A⊕B⊕ROL(A)⊕ROL(B)⊕ROR(A)⊕ROR(B).
+    - FscxRevolve / FscxRevolveN: renamed from Fscx_revolve / Fscx_revolve_n
+      to follow Go's idiomatic PascalCase naming convention (consistent with
+      the tests file).
+    - NewRandBitArray: renamed from New_rand_bitarray for the same reason.
+    - Local variables in main: renamed to camelCase (iValue, rValue, hkexNonce).
+    - Version header updated to v1.3.
+
+    --- v1.3: BitArray (multi-byte parameter support) ---
+
+    The Go implementation now uses 256-bit parameters by default, matching
+    the C and Python versions at the same bit width.
 
     --- v1.1: FSCX_REVOLVE_N ---
 
@@ -72,6 +88,16 @@ func NewFromBytes(data []byte, _ int, size int) *BitArray {
 	return ba
 }
 
+// NewRandBitArray returns a cryptographically random BitArray of bitlength bits.
+func NewRandBitArray(bitlength int) *BitArray {
+	buf := make([]byte, bitlength/8)
+	_, err := rand.Read(buf)
+	if err != nil {
+		log.Fatalf("ERROR while generating random string: %s", err)
+	}
+	return NewFromBytes(buf, 0, bitlength)
+}
+
 // Xor returns a new BitArray that is the bitwise XOR of ba and other.
 func (ba *BitArray) Xor(other *BitArray) *BitArray {
 	result := &BitArray{size: ba.size}
@@ -111,19 +137,23 @@ func (ba *BitArray) Format(f fmt.State, verb rune) {
 	fmt.Fprint(f, s)
 }
 
-func New_rand_bitarray(bitlength int) *BitArray {
-	buf := make([]byte, bitlength/8)
-	_, err := rand.Read(buf)
-	if err != nil {
-		log.Fatalf("ERROR while generating random string: %s", err)
-	}
-	return NewFromBytes(buf, 0, bitlength)
+// Fscx computes the Full Surroundings Cyclic XOR:
+//
+//	result = A ⊕ B ⊕ ROL(A) ⊕ ROL(B) ⊕ ROR(A) ⊕ ROR(B)
+//
+// Each term maps directly to the formula; no parameter shadowing.
+func Fscx(a, b *BitArray) *BitArray {
+	return a.Xor(b).
+		Xor(a.RotateLeft(1)).Xor(b.RotateLeft(1)).
+		Xor(a.RotateLeft(-1)).Xor(b.RotateLeft(-1))
 }
 
-func Fscx_revolve(ba *BitArray, bb *BitArray, steps int, verbose bool) *BitArray {
-	result := ba
+// FscxRevolve iterates Fscx(a, b) for the given number of steps,
+// keeping b constant. If verbose is true, each intermediate result is printed.
+func FscxRevolve(a, b *BitArray, steps int, verbose bool) *BitArray {
+	result := a
 	for i := 1; i <= steps; i++ {
-		result = Fscx(result, bb)
+		result = Fscx(result, b)
 		if verbose {
 			fmt.Printf("Step %d: %x\n", i, result)
 		}
@@ -131,181 +161,161 @@ func Fscx_revolve(ba *BitArray, bb *BitArray, steps int, verbose bool) *BitArray
 	return result
 }
 
-// Fscx_revolve_n: nonce-augmented FSCX_REVOLVE (v1.1).
-// Each step: result = FSCX(result, bb) ⊕ nonce
-// Breaks the pure GF(2)-linearity of FSCX_REVOLVE while preserving the HKEX equality
-// and orbit properties. The HKEX equality holds for any nonce value because N cancels
-// from both sides of the protocol equality condition.
-func Fscx_revolve_n(ba *BitArray, bb *BitArray, nonce *BitArray, steps int, verbose bool) *BitArray {
-	result := ba
+// FscxRevolveN is the nonce-augmented variant (v1.1).
+// Each step: result = Fscx(result, b) ⊕ nonce
+// Breaks the pure GF(2)-linearity of FscxRevolve while preserving the HKEX
+// equality and orbit properties. The HKEX equality holds for any nonce value
+// because N cancels from both sides of the protocol equality condition.
+func FscxRevolveN(a, b, nonce *BitArray, steps int, verbose bool) *BitArray {
+	result := a
 	for i := 1; i <= steps; i++ {
-		result = Fscx(result, bb).Xor(nonce)
+		result = Fscx(result, b).Xor(nonce)
 		if verbose {
 			fmt.Printf("Step %d: %x\n", i, result)
 		}
 	}
-	return result
-}
-
-func Fscx(ba *BitArray, bb *BitArray) *BitArray {
-	result := ba.Xor(bb)
-	ba = ba.RotateLeft(1)
-	bb = bb.RotateLeft(1)
-	result = result.Xor(ba).Xor(bb) // result ^= A ^ B
-	ba = ba.RotateLeft(-2)
-	bb = bb.RotateLeft(-2)
-	result = result.Xor(ba).Xor(bb) // result ^= A ^ B
 	return result
 }
 
 /*
-	let,    Alice, Bob: i + r == bitlength b;  i == 1/4 bitlength; r == 3/4 bitlength; bitlength is a power of 2 >= 8
-			P be a plaintext message of bitlength b,
-			E the encrypted version of plaintext P,
-			D == P the decrypted version of E.
-	let,    Alice: A,B be random values of bitlength b,
-			Bob: A2,B2 be random values of bitlength b
-	let,    Alice: C = fscx_revolve(A, B, i) ,
-			Bob: C2 = fscx_revolve(A2, B2, i)
-	then,   Alice: D = fscx_revolve(C2, B, r) ^ A ,
-			Bob: D2 = fscx_revolve(C, B2, r) ^ A2
-	where,  Alice, Bob: D == D2
-	then,   fscx_revolve(C2, B, r) ^ A  == fscx_revolve(C, B2, r) ^ A2,
-			fscx_revolve(C2, B, r) ^ A ^ P == fscx_revolve(C, B2, r) ^ A2 ^ P,
-			fscx_revolve(C2, B, R) ^ A ^ A2 ^ P == fscx_revolve(C, B2, r)  ^ P #Note that this form breaks trapdoor
-	also,   fscx_revolve(C2, B, r) ^ A  ^ P == fscx_revolve(C2 ^ P, B, r) ^ A
+let,    Alice, Bob: i + r == bitlength b;  i == 1/4 bitlength; r == 3/4 bitlength; bitlength is a power of 2 >= 8
+		P be a plaintext message of bitlength b,
+		E the encrypted version of plaintext P,
+		D == P the decrypted version of E.
+let,    Alice: A,B be random values of bitlength b,
+		Bob: A2,B2 be random values of bitlength b
+let,    Alice: C = fscx_revolve(A, B, i) ,
+		Bob: C2 = fscx_revolve(A2, B2, i)
+then,   Alice: D = fscx_revolve(C2, B, r) ^ A ,
+		Bob: D2 = fscx_revolve(C, B2, r) ^ A2
+where,  Alice, Bob: D == D2
+then,   fscx_revolve(C2, B, r) ^ A  == fscx_revolve(C, B2, r) ^ A2,
+		fscx_revolve(C2, B, r) ^ A ^ P == fscx_revolve(C, B2, r) ^ A2 ^ P,
+		fscx_revolve(C2, B, R) ^ A ^ A2 ^ P == fscx_revolve(C, B2, r)  ^ P #Note that this form breaks trapdoor
+also,   fscx_revolve(C2, B, r) ^ A  ^ P == fscx_revolve(C2 ^ P, B, r) ^ A
 
-	let,    public key => {C,B2,A2,r},
-			private key => {C2,B,A,r}
-	then,   E = fscx_revolve(C, B2, r) ^ A2  ^ P,
-			P == (D = fscx_revolve(C2, B, r) ^ A ^ E)
+let,    public key => {C,B2,A2,r},
+		private key => {C2,B,A,r}
+then,   E = fscx_revolve(C, B2, r) ^ A2  ^ P,
+		P == (D = fscx_revolve(C2, B, r) ^ A ^ E)
 
-	let,    E = fscx_revolve(C2, B, r) ^ A  ^ P
-	then,   fscx_revolve(E, B2, i) ^ A2 ^ P  == 0
-			fscx_revolve(E ^ P, B2, i) == 0
+let,    E = fscx_revolve(C2, B, r) ^ A  ^ P
+then,   fscx_revolve(E, B2, i) ^ A2 ^ P  == 0
+		fscx_revolve(E ^ P, B2, i) == 0
 
-	HKEX (key exchange)
-		Alice:  C = fscx_revolve(A,B,i)
-				send C to Bob and get C2
-				shared_key = fscx_revolve(C2, B, r) ^ A,
-		Bob:    C2 = fscx_revolve(A2,B2,i)
-				send C2 to Alice and get C
-				shared_key => fscx_revolve(C, B2, r) ^ A2
+HKEX (key exchange)
+	Alice:  C = fscx_revolve(A,B,i)
+			send C to Bob and get C2
+			shared_key = fscx_revolve(C2, B, r) ^ A,
+	Bob:    C2 = fscx_revolve(A2,B2,i)
+			send C2 to Alice and get C
+			shared_key => fscx_revolve(C, B2, r) ^ A2
 
-	HSKE (symmetric key encryption):
-		Alice,Bob:  share key of bitlength b
-		Alice:  E = fscx_revolve(P , key , i)
-				shares E with Bob
-		Bob:    P = fscx_revolve(E , key , r)
+HSKE (symmetric key encryption):
+	Alice,Bob:  share key of bitlength b
+	Alice:  E = fscx_revolve(P , key , i)
+			shares E with Bob
+	Bob:    P = fscx_revolve(E , key , r)
 
-	HPKS (public key signature)
-		Alice:  C = fscx_revolve(A,B,i)
-				C2 = fscx_revolve(A2,B2,i)
-				{publish (C,B2,A2,r) as public key, also disclose b,r,i; keep the rest of parameters (C2,B,A) as private key},
-				S = fscx_revolve(C2, B, r) ^ A ^ P
-				shares E, S with Bob
-		Bob:    P = fscx_revolve(C,B2, r) ^ A2  ^ S
+HPKS (public key signature)
+	Alice:  C = fscx_revolve(A,B,i)
+			C2 = fscx_revolve(A2,B2,i)
+			{publish (C,B2,A2,r) as public key, also disclose b,r,i; keep the rest of parameters (C2,B,A) as private key},
+			S = fscx_revolve(C2, B, r) ^ A ^ P
+			shares E, S with Bob
+	Bob:    P = fscx_revolve(C,B2, r) ^ A2  ^ S
 
-	HPKE (public key encryption)
-		Alice:  C = fscx_revolve(A,B,i),
-				C2 = fscx_revolve(A2,B2,i),
-				{publish (C,B2,A2,r) as public key, keep the rest of parameters as private key},
-		Bob:    E = fscx_revolve(C, B2, r) ^ A2  ^ P
-				shares E with Alice
-		Alice:  P = fscx_revolve(C2, B, r) ^ A ^ E
+HPKE (public key encryption)
+	Alice:  C = fscx_revolve(A,B,i),
+			C2 = fscx_revolve(A2,B2,i),
+			{publish (C,B2,A2,r) as public key, keep the rest of parameters as private key},
+	Bob:    E = fscx_revolve(C, B2, r) ^ A2  ^ P
+			shares E with Alice
+	Alice:  P = fscx_revolve(C2, B, r) ^ A ^ E
 */
 
 func main() {
-	/*
-		A := New_rand_bitarray(256)
-		B := New_rand_bitarray(256)
-		C := Fscx(A, B)
-		D := Fscx_revolve(A, B, 256, false)
-		fmt.Printf("A         : %x\n", A)
-		fmt.Printf("B         : %x\n", B)
-		fmt.Printf("C         : %x\n", C)
-		fmt.Printf("D         : %x\n\n", D)
-	*/
+	// Example Usage (256-bit parameters):
+	iValue := 64  // i = KEYBITS/4
+	rValue := 192 // r = 3*KEYBITS/4
 
-	// Example Usage:
-	r_value := 192 // Adjust as needed
-	i_value := 64  // Adjust as needed
+	A := NewRandBitArray(256)
+	B := NewRandBitArray(256)
+	A2 := NewRandBitArray(256)
+	B2 := NewRandBitArray(256)
+	nonce := NewRandBitArray(256)
+	preshared := NewRandBitArray(256)
+	plaintext := NewRandBitArray(256)
 
-	A := New_rand_bitarray(256)
+	C := FscxRevolve(A, B, iValue, false)
+	C2 := FscxRevolve(A2, B2, iValue, false)
+	hkexNonce := C.Xor(C2) // N = C ⊕ C2: session-specific nonce (computable from public key)
+
 	fmt.Printf("A         : %x\n", A)
-	A2 := New_rand_bitarray(256)
-	fmt.Printf("A2        : %x\n", A2)
-	B := New_rand_bitarray(256)
 	fmt.Printf("B         : %x\n", B)
-	B2 := New_rand_bitarray(256)
+	fmt.Printf("A2        : %x\n", A2)
 	fmt.Printf("B2        : %x\n", B2)
-	C := Fscx_revolve(A, B, i_value, false)
-	fmt.Printf("C         : %x\n", C)
-	C2 := Fscx_revolve(A2, B2, i_value, false)
-	fmt.Printf("C2        : %x\n", C2)
-	hkex_nonce := C.Xor(C2) // N = C ⊕ C2: session-specific nonce (computable from public key)
-	fmt.Printf("hkex_nonce: %x\n", hkex_nonce)
-	nonce := New_rand_bitarray(256)
-	fmt.Printf("nonce     : %x\n", nonce)
-	preshared := New_rand_bitarray(256)
 	fmt.Printf("preshared : %x\n", preshared)
-	plaintext := New_rand_bitarray(256)
 	fmt.Printf("plaintext : %x\n", plaintext)
+	fmt.Printf("nonce     : %x\n", nonce)
+	fmt.Printf("C         : %x\n", C)
+	fmt.Printf("C2        : %x\n", C2)
+	fmt.Printf("hkex_nonce: %x\n", hkexNonce)
 
 	fmt.Printf("\n--- HKEX (key exchange)\n")
-	skeyA := Fscx_revolve_n(C2, B, hkex_nonce, r_value, false).Xor(A)
-	fmt.Printf("skeyA     : %x\n", skeyA)
-	skeyB := Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2)
-	fmt.Printf("skeyB     : %x\n", skeyB)
-	if skeyA.Equal(skeyB) { // Assert equality
+	skeyA := FscxRevolveN(C2, B, hkexNonce, rValue, false).Xor(A)
+	fmt.Printf("skeyA (Alice): %x\n", skeyA)
+	skeyB := FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2)
+	fmt.Printf("skeyB (Bob)  : %x\n", skeyB)
+	if skeyA.Equal(skeyB) {
 		fmt.Printf("+ session keys skeyA and skeyB are equal!\n")
 	} else {
 		fmt.Printf("- session keys skeyA and skeyB are different!\n")
 	}
 
 	fmt.Printf("\n--- HSKE (symmetric key encryption)\n")
-	E := Fscx_revolve_n(plaintext, preshared, preshared, i_value, false)
+	E := FscxRevolveN(plaintext, preshared, preshared, iValue, false)
 	fmt.Printf("E (Alice) : %x\n", E)
-	D := Fscx_revolve_n(E, preshared, preshared, r_value, false)
+	D := FscxRevolveN(E, preshared, preshared, rValue, false)
 	fmt.Printf("D (Bob)   : %x\n", D)
-	if D.Equal(plaintext) { // Assert equality
+	if D.Equal(plaintext) {
 		fmt.Printf("+ plaintext is correctly decrypted from E with preshared key\n")
 	} else {
 		fmt.Printf("- plaintext is different from decrypted E with preshared key!\n")
 	}
 
 	fmt.Printf("\n--- HPKS (public key signature)\n")
-	S := Fscx_revolve_n(C2, B, hkex_nonce, r_value, false).Xor(A).Xor(plaintext)
+	S := FscxRevolveN(C2, B, hkexNonce, rValue, false).Xor(A).Xor(plaintext)
 	fmt.Printf("S (Alice) : %x\n", S)
-	V := Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(S) // == plaintext !!!!
+	V := FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(S) // == plaintext
 	fmt.Printf("V (Bob)   : %x\n", V)
-	if V.Equal(plaintext) { // Assert equality
+	if V.Equal(plaintext) {
 		fmt.Printf("+ signature S from plaintext is correct!\n")
 	} else {
 		fmt.Printf("- signature S from plaintext is incorrect!\n")
 	}
 
 	fmt.Printf("\n--- HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n")
-	E = Fscx_revolve_n(plaintext, preshared, preshared, i_value, false)
+	E = FscxRevolveN(plaintext, preshared, preshared, iValue, false)
 	fmt.Printf("E (Alice) : %x\n", E)
-	S = Fscx_revolve_n(C2, B, hkex_nonce, r_value, false).Xor(A).Xor(E) // A+B2+C is the trapdoor for deceiving EVE!!!!
+	S = FscxRevolveN(C2, B, hkexNonce, rValue, false).Xor(A).Xor(E) // A+B2+C is the trapdoor for deceiving EVE
 	fmt.Printf("S (Alice) : %x\n", S)
-	V = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(S) // == encryptedText
+	V = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(S) // == encryptedText
 	fmt.Printf("V (Bob)   : %x\n", V)
-	D = Fscx_revolve_n(V, preshared, preshared, r_value, false) // => plaintext
+	D = FscxRevolveN(V, preshared, preshared, rValue, false) // => plaintext
 	fmt.Printf("D (Bob)   : %x\n", D)
-	if D.Equal(plaintext) { // Assert equality
+	if D.Equal(plaintext) {
 		fmt.Printf("+ signature S(E) from plaintext is correct!\n")
 	} else {
 		fmt.Printf("- signature S(E) from plaintext is incorrect!\n")
 	}
 
 	fmt.Printf("\n--- HPKE (public key encryption)\n")
-	E = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(plaintext)
+	E = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(plaintext)
 	fmt.Printf("E (Bob)   : %x\n", E)
-	D = Fscx_revolve_n(C2, B, hkex_nonce, r_value, false).Xor(A).Xor(E) // == plaintext !!!!
+	D = FscxRevolveN(C2, B, hkexNonce, rValue, false).Xor(A).Xor(E) // == plaintext
 	fmt.Printf("D (Alice) : %x\n", D)
-	if D.Equal(plaintext) { // Assert equality
+	if D.Equal(plaintext) {
 		fmt.Printf("+ plaintext is correctly decrypted from E with private key!\n")
 	} else {
 		fmt.Printf("- plaintext is different from decrypted E with private key!\n")
@@ -313,72 +323,72 @@ func main() {
 
 	fmt.Printf("\n\n*** EVE bypass TESTS\n")
 	fmt.Printf("*** HPKS (public key signature)\n")
-	S = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(nonce) // ^ bruteForceValue  // w/o A+A2+C2 Eve would be forced to do a Brute force attack to find it.
+	S = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(nonce) // w/o A+A2+C2 Eve would be forced to brute force
 	fmt.Printf("S (Eve)   : %x\n", S)
-	V = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2) // X
+	V = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2) // X
 	fmt.Printf("V (Bob)   : %x\n", V)
-	if V.Equal(nonce) { // Assert equality
+	if V.Equal(nonce) {
 		fmt.Printf("+ nonce fake signature 1 verification with Alice public key is correct!\n")
 	} else {
 		fmt.Printf("- nonce fake signature 1 verification with Alice public key is incorrect!\n")
 	}
 	S2 := V.Xor(nonce)
 	fmt.Printf("S2 (Eve)  : %x\n", S2)
-	V2 := Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(S2) // KK
+	V2 := FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(S2) // KK
 	fmt.Printf("V2 (Bob)  : %x\n", V2)
-	if V2.Equal(nonce) { // Assert equality
+	if V2.Equal(nonce) {
 		fmt.Printf("+ nonce fake signature 2 verification with Alice public key is correct!\n")
 	} else {
 		fmt.Printf("- nonce fake signature 2 verification with Alice public key is incorrect!\n")
 	}
 
 	fmt.Printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public\n")
-	E = Fscx_revolve_n(nonce, preshared, preshared, i_value, false)
+	E = FscxRevolveN(nonce, preshared, preshared, iValue, false)
 	fmt.Printf("E (Eve)   : %x\n", E)
-	S = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(E) // ^ bruteForceValue  // w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
+	S = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(E) // w/o A+B2+C Eve would be forced to brute force
 	fmt.Printf("S (Eve)   : %x\n", S)
-	V = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2) // X
+	V = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2) // X
 	fmt.Printf("V (Eve)   : %x\n", V)
 	S2 = V.Xor(S)
 	fmt.Printf("S2 (Eve)  : %x\n", S2)
-	V2 = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(S2) // KK
+	V2 = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(S2) // KK
 	fmt.Printf("V2 (Bob)  : %x\n", V2)
-	D = Fscx_revolve_n(V2, preshared, preshared, r_value, false)
-	fmt.Printf("D (Bob)   : %x\n", D) //X
-	if D.Equal(nonce) {               // Assert equality
+	D = FscxRevolveN(V2, preshared, preshared, rValue, false)
+	fmt.Printf("D (Bob)   : %x\n", D) // X
+	if D.Equal(nonce) {
 		fmt.Printf("+ fake signature(encrypted nonce) verification with Alice public key is correct!\n")
 	} else {
 		fmt.Printf("- fake signature(encrypted nonce) verification with Alice public key is incorrect!\n")
 	}
 
 	fmt.Printf("\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2\n")
-	S = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(nonce) // ^ bruteForceValue  // w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
+	S = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(nonce) // w/o A+B2+C Eve would be forced to brute force
 	fmt.Printf("S (Eve)   : %x\n", S)
-	E = Fscx_revolve_n(S, preshared, preshared, i_value, false)
+	E = FscxRevolveN(S, preshared, preshared, iValue, false)
 	fmt.Printf("E (Eve)   : %x\n", E)
-	V = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2) // X
+	V = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2) // X
 	fmt.Printf("V (Eve)   : %x\n", V)
 	S2 = V.Xor(E)
 	fmt.Printf("S2 (Eve)  : %x\n", S2)
-	V2 = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(S2) // KK
+	V2 = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(S2) // KK
 	fmt.Printf("V2 (Bob)  : %x\n", V2)
-	D = Fscx_revolve_n(V2, preshared, preshared, r_value, false)
-	fmt.Printf("D (Bob)   : %x\n", D) //X
-	if D.Equal(nonce) {               // Assert equality
+	D = FscxRevolveN(V2, preshared, preshared, rValue, false)
+	fmt.Printf("D (Bob)   : %x\n", D) // X
+	if D.Equal(nonce) {
 		fmt.Printf("+ fake signature(encrypted nonce) v2 verification with Alice public key is correct!\n")
 	} else {
 		fmt.Printf("- fake signature(encrypted nonce) v2 verification with Alice public key is incorrect!\n")
 	}
 
 	fmt.Printf("\n*** HPKE (public key encryption)\n")
-	E = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2).Xor(plaintext) // ^ bruteForceValue  // w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
+	E = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2).Xor(plaintext) // w/o A+B2+C Eve would be forced to brute force
 	fmt.Printf("E (Bob)   : %x\n", E)
-	D = Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(A2) //X, but == fsession from private/public key generation if components had been reused from an HKEX!?
+	D = FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(A2) // X
 	fmt.Printf("D (Eve)   : %x\n", D)
 	E2 := D.Xor(E)
-	D2 := Fscx_revolve_n(C, B2, hkex_nonce, r_value, false).Xor(E2) // KK
+	D2 := FscxRevolveN(C, B2, hkexNonce, rValue, false).Xor(E2) // KK
 	fmt.Printf("D2 (Eve)  : %x\n", D2)
-	if D.Equal(nonce) || D2.Equal(nonce) { // Assert equality
+	if D.Equal(nonce) || D2.Equal(nonce) {
 		fmt.Printf("+ Eve could decrypt plaintext without Alice's private key!\n")
 	} else {
 		fmt.Printf("- Eve could not decrypt plaintext without Alice's private key!\n")

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.1
+    Herradura Cryptographic Suite v1.3.2
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,6 +17,25 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.3.2: performance and readability ---
+
+    - BitArray: added rotated(n) non-mutating rotation method (positive = left,
+      negative = right); replaces the copy-then-mutate pattern.
+    - BitArray: added random() classmethod, consistent with the tests file.
+    - fscx: rewritten using rotated(); each term maps directly to the formula
+      A^B^ROL(A)^ROL(B)^ROR(A)^ROR(B). No longer mutates its inputs.
+    - fscx defined before fscx_revolve/fscx_revolve_n for consistent ordering
+      with C and Go (definition before first use).
+    - Protocol code wrapped in main() with if __name__ == "__main__" guard,
+      consistent with the tests file, C, and Go (each has an explicit entry point).
+    - KEYBITS, I_VALUE, R_VALUE defined as module-level constants, matching C.
+    - BitArray.random() used throughout main(), consistent with tests file.
+
+    --- v1.3: BitArray (multi-byte parameter support) ---
+
+    The Python implementation now uses 256-bit parameters by default, matching
+    the C and Go versions at the same bit width.
 
     --- v1.1: FSCX_REVOLVE_N ---
 
@@ -46,9 +65,17 @@
 import os
 
 
+# Key size in bits — must be a positive multiple of 8.
+# Change to use a different parameter width; I_VALUE and R_VALUE scale automatically.
+# Equivalent to 256-bit parameters in the C and Go versions.
+KEYBITS = 256
+I_VALUE = KEYBITS // 4       # 64  for 256-bit
+R_VALUE = 3 * KEYBITS // 4   # 192 for 256-bit
+
+
 class BitArray:
     """Fixed-width bit string backed by a Python int.
-    Supports XOR, in-place rotation, equality, and hex/bytes/uint I/O.
+    Supports XOR, rotation, equality, and hex/bytes/uint I/O.
     Size must be a positive multiple of 8.
     """
 
@@ -82,6 +109,14 @@ class BitArray:
     def copy(self) -> 'BitArray':
         return BitArray(self._size, self._val)
 
+    def rotated(self, n: int) -> 'BitArray':
+        """Return a new BitArray rotated left by n bits (right if n < 0)."""
+        n %= self._size
+        if n == 0:
+            return BitArray(self._size, self._val)
+        return BitArray(self._size,
+                        ((self._val << n) | (self._val >> (self._size - n))) & self._mask)
+
     def rol(self, n: int) -> None:
         """Rotate left in-place by n bits."""
         n %= self._size
@@ -112,12 +147,25 @@ class BitArray:
     def __repr__(self) -> str:
         return f'BitArray({self._size}, 0x{self.hex})'
 
-def new_rand_bitarray(bitlength):
-    result = BitArray(bitlength)
-    result.bytes = os.urandom(bitlength // 8) # bytes([1] * (bitlength // 8))  # Replace with a secure random number generator
-    return result
+    @classmethod
+    def random(cls, size: int) -> 'BitArray':
+        """Return a random BitArray of *size* bits using os.urandom."""
+        ba = cls(size)
+        ba.bytes = os.urandom(size // 8)
+        return ba
 
-def fscx_revolve(A, B, steps, verbose=False):
+
+# ---------------------------------------------------------------------------
+# FSCX functions
+# ---------------------------------------------------------------------------
+
+def fscx(A: BitArray, B: BitArray) -> BitArray:
+    """Full Surroundings Cyclic XOR: A ^ B ^ ROL(A) ^ ROL(B) ^ ROR(A) ^ ROR(B).
+    Uses rotated() — does not mutate its inputs."""
+    return A ^ B ^ A.rotated(1) ^ B.rotated(1) ^ A.rotated(-1) ^ B.rotated(-1)
+
+
+def fscx_revolve(A: BitArray, B: BitArray, steps: int, verbose: bool = False) -> BitArray:
     result = A.copy()
     for step in range(steps):
         result = fscx(result, B)
@@ -125,7 +173,9 @@ def fscx_revolve(A, B, steps, verbose=False):
             print(f"Step {step + 1}: {result.hex}")
     return result
 
-def fscx_revolve_n(A, B, nonce, steps, verbose=False):
+
+def fscx_revolve_n(A: BitArray, B: BitArray, nonce: BitArray,
+                   steps: int, verbose: bool = False) -> BitArray:
     """Nonce-augmented FSCX_REVOLVE (v1.1).
     Each step: result = fscx(result, B) ^ nonce
     Breaks pure GF(2)-linearity while preserving HKEX equality and orbit properties.
@@ -137,17 +187,6 @@ def fscx_revolve_n(A, B, nonce, steps, verbose=False):
             print(f"Step {step + 1}: {result.hex}")
     return result
 
-def fscx(A, B):     # [binary] full surroundings cyclic xor
-    result = A ^ B
-    A.rol(1)
-    B.rol(1)
-    result ^= A ^ B
-    A.ror(2)
-    B.ror(2)
-    result ^= A ^ B
-    A.rol(1)
-    B.rol(1)
-    return result
 
 '''
 let,    Alice, Bob: i + r == bitlength b;  i == 1/4 bitlength; r == 3/4 bitlength; bitlength is a power of 2 >= 8
@@ -205,149 +244,155 @@ HPKE (public key encryption)
             shares E with Alice
     Alice:  P = fscx_revolve(C2, B, r) ^ A ^ E
 '''
-# Examples with b = 256 bits:
-r_value = 192  # Adjust as needed
-i_value = 64   # Adjust as needed
 
-A = new_rand_bitarray(256)
-print(f"A         : {A.hex}")
-B = new_rand_bitarray(256)
-print(f"B         : {B.hex}")
-A2 = new_rand_bitarray(256)
-print(f"A2        : {A2.hex}")
-B2 = new_rand_bitarray(256)
-print(f"B2        : {B2.hex}")
-C = fscx_revolve(A, B, i_value)
-print(f"C         : {C.hex}")
-C2 = fscx_revolve(A2, B2, i_value)
-print(f"C2        : {C2.hex}")
-hkex_nonce = C ^ C2
-print(f"hkex_nonce: {hkex_nonce.hex}")
-nonce = new_rand_bitarray(256)
-print(f"nonce     : {nonce.hex}")
-preshared = new_rand_bitarray(256)
-print(f"preshared : {preshared.hex}")
-plaintext = new_rand_bitarray(256)
-print(f"plaintext : {plaintext.hex}")
 
-print (f"\n--- HKEX (key exchange)")
-skeyA = fscx_revolve_n(C2 , B, hkex_nonce, r_value) ^ A
-print(f"skeyA (Alice): {skeyA.hex}")
-skeyB = fscx_revolve_n(C , B2, hkex_nonce, r_value) ^ A2
-print(f"skeyB (Bob)  : {skeyB.hex}")
-if skeyA == skeyB: # Assert equality
-    print("+ session keys skeyA and skeyB are equal!")
-else:
-    print("- session keys skeyA and skeyB are different!")
+def main():
+    # Examples with b = KEYBITS bits:
+    A  = BitArray.random(KEYBITS)
+    B  = BitArray.random(KEYBITS)
+    A2 = BitArray.random(KEYBITS)
+    B2 = BitArray.random(KEYBITS)
+    nonce     = BitArray.random(KEYBITS)
+    preshared = BitArray.random(KEYBITS)
+    plaintext = BitArray.random(KEYBITS)
 
-print ("\n--- HSKE (symmetric key encryption)")
-E = fscx_revolve_n(plaintext, preshared, preshared, i_value)
-print(f"E (Alice) : {E.hex}")
-D = fscx_revolve_n(E , preshared, preshared, r_value)
-print(f"D (Bob)   : {D.hex}")
-if D == plaintext: # Assert equality
-    print("+ plaintext is correctly decrypted from E with preshared key")
-else:
-    print("- plaintext is different from decrypted E with preshared key!")
+    C  = fscx_revolve(A,  B,  I_VALUE)
+    C2 = fscx_revolve(A2, B2, I_VALUE)
+    hkex_nonce = C ^ C2
 
-print ("\n--- HPKS (public key signature)")
-S = fscx_revolve_n(C2 , B, hkex_nonce, r_value) ^ A  ^ plaintext
-print(f"S (Alice) : {S.hex}")
-V = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ S
-print(f"V (Bob)   : {V.hex}")
-if V == plaintext: # Assert equality
-    print("+ signature S from plaintext is correct!")
-else:
-    print("- signature S from plaintext is incorrect!")
+    print(f"A         : {A.hex}")
+    print(f"B         : {B.hex}")
+    print(f"A2        : {A2.hex}")
+    print(f"B2        : {B2.hex}")
+    print(f"preshared : {preshared.hex}")
+    print(f"plaintext : {plaintext.hex}")
+    print(f"nonce     : {nonce.hex}")
+    print(f"C         : {C.hex}")
+    print(f"C2        : {C2.hex}")
+    print(f"hkex_nonce: {hkex_nonce.hex}")
 
-print ("\n--- HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public")
-E = fscx_revolve_n(plaintext, preshared, preshared, i_value)
-print(f"E (Alice) : {E.hex}")
-S = fscx_revolve_n(C2 , B, hkex_nonce, r_value) ^ A  ^ E # A+B2+C is the trapdoor for deceiving EVE!!!!
-print(f"S (Alice) : {S.hex}")
-V = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ S   # => E
-print(f"V (Bob)   : {V.hex}")
-D = fscx_revolve_n(V, preshared, preshared, r_value)  # => plainText
-print(f"D (Bob)   : {D.hex}")
-if D == plaintext: # Assert equality
-    print("+ signature S(E) from plaintext is correct!")
-else:
-    print("- signature S(E) from plaintext is incorrect!")
+    print(f"\n--- HKEX (key exchange)")
+    skeyA = fscx_revolve_n(C2, B,  hkex_nonce, R_VALUE) ^ A
+    print(f"skeyA (Alice): {skeyA.hex}")
+    skeyB = fscx_revolve_n(C,  B2, hkex_nonce, R_VALUE) ^ A2
+    print(f"skeyB (Bob)  : {skeyB.hex}")
+    if skeyA == skeyB:
+        print("+ session keys skeyA and skeyB are equal!")
+    else:
+        print("- session keys skeyA and skeyB are different!")
 
-print ("\n--- HPKE (public key encryption)")
-E = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ plaintext
-print(f"E (Bob)   : {E.hex}")
-D = fscx_revolve_n(C2 , B, hkex_nonce, r_value)  ^ A ^ E  # => plaintext
-print(f"D (Alice) : {D.hex}")
-if D == plaintext: # Assert equality
-    print("+ plaintext is correctly decrypted from E with private key!")
-else:
-    print("- plaintext is different from decrypted E with private key!")
+    print("\n--- HSKE (symmetric key encryption)")
+    E = fscx_revolve_n(plaintext, preshared, preshared, I_VALUE)
+    print(f"E (Alice) : {E.hex}")
+    D = fscx_revolve_n(E, preshared, preshared, R_VALUE)
+    print(f"D (Bob)   : {D.hex}")
+    if D == plaintext:
+        print("+ plaintext is correctly decrypted from E with preshared key")
+    else:
+        print("- plaintext is different from decrypted E with preshared key!")
 
-print (f"\n\n*** EVE bypass TESTS")
-print (f"\n*** HPKS (public key signature)")
-S = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ nonce  # ^ bruteForceValue  ## w/o A+B+C2 Eve would be forced to do a Brute force attack to find it.
-print(f"S (Eve)   : {S.hex}")
-V = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2  # X
-print(f"V (Bob)   : {V.hex}")
-if V == nonce: # Assert equality
-    print("+ nonce fake signature 1 verification with Alice public key is correct!")
-else:
-    print("- nonce fake signature 1 verification with Alice public key is incorrect!")
-S2 = V ^ nonce
-print(f"S2 (Eve)  : {S2.hex}")
-V2 = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ S2 # KK
-print(f"V2 (Bob)  : {V2.hex}")
-if V2 == nonce: # Assert equality
-    print("+ nonce fake signature 2 verification with Alice public key is correct!")
-else:
-    print("- nonce fake signature 2 verification with Alice public key is incorrect!")
+    print("\n--- HPKS (public key signature)")
+    S = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ plaintext
+    print(f"S (Alice) : {S.hex}")
+    V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S
+    print(f"V (Bob)   : {V.hex}")
+    if V == plaintext:
+        print("+ signature S from plaintext is correct!")
+    else:
+        print("- signature S from plaintext is incorrect!")
 
-print (f"\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public")
-E = fscx_revolve_n(nonce, preshared, preshared, i_value)
-print(f"E (Eve)   : {E.hex}")
-S = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ E  # ^ bruteForceValue  ## w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
-print(f"S (Eve)   : {S.hex}")
-V = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 #X
-print(f"V (Eve)   : {V.hex}")
-S2 = V ^ S
-print(f"S2 (Eve)  : {S2.hex}")
-V2 = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ S2 # KK
-print(f"V2 (Bob)  : {V2.hex}")
-D = fscx_revolve_n(V2, preshared, preshared, r_value)
-print(f"D (Bob)   : {D.hex}") #X
-if D == nonce: # Assert equality
-    print("+ fake signature(encrypted nonce) verification with Alice public key is correct!")
-else:
-    print("- fake signature(encrypted nonce) verification with Alice public key is incorrect!")
+    print("\n--- HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public")
+    E = fscx_revolve_n(plaintext, preshared, preshared, I_VALUE)
+    print(f"E (Alice) : {E.hex}")
+    S = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ E  # A+B2+C is the trapdoor for deceiving EVE
+    print(f"S (Alice) : {S.hex}")
+    V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S  # => E
+    print(f"V (Bob)   : {V.hex}")
+    D = fscx_revolve_n(V, preshared, preshared, R_VALUE)      # => plaintext
+    print(f"D (Bob)   : {D.hex}")
+    if D == plaintext:
+        print("+ signature S(E) from plaintext is correct!")
+    else:
+        print("- signature S(E) from plaintext is incorrect!")
 
-print (f"\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2")
-S = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ nonce  # ^ bruteForceValue  ## w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
-print(f"S (Eve)   : {S.hex}")
-E = fscx_revolve_n(S, preshared, preshared, i_value)
-print(f"E (Eve)   : {E.hex}")
-V = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 #X
-print(f"V (Eve)   : {V.hex}")
-S2 = V ^ E
-print(f"S2 (Eve)  : {S2.hex}")
-V2 = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ S2 # KK
-print(f"V2 (Bob)  : {V2.hex}")
-D = fscx_revolve_n(V2, preshared, preshared, r_value)
-print(f"D (Bob)   : {D.hex}") #X
-if D == nonce: # Assert equality
-    print("+ fake signature(encrypted nonce) v2 verification with Alice public key is correct!")
-else:
-    print("- fake signature(encrypted nonce) v2 verification with Alice public key is incorrect!")
+    print("\n--- HPKE (public key encryption)")
+    E = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ plaintext
+    print(f"E (Bob)   : {E.hex}")
+    D = fscx_revolve_n(C2, B, hkex_nonce, R_VALUE) ^ A ^ E   # => plaintext
+    print(f"D (Alice) : {D.hex}")
+    if D == plaintext:
+        print("+ plaintext is correctly decrypted from E with private key!")
+    else:
+        print("- plaintext is different from decrypted E with private key!")
 
-print (f"\n*** HPKE (public key encryption)")
-E = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 ^ plaintext  # ^ bruteForceValue  ## w/o A+B2+C  Eve would be forced to do a Brute force attack to find it.
-print(f"E (Bob)   : {E.hex}")
-D = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ A2 #X, but == fsession from private/public key generation if components had been reused from an HKEX!?
-print(f"D (Eve)   : {D.hex}")
-E2 = D ^ E
-D2 = fscx_revolve_n(C, B2, hkex_nonce, r_value) ^ E2 # KK
-print(f"D2 (Eve)  : {D2.hex}")
-if (D == nonce) or (D2 == nonce): # Assert equality
-    print("+ Eve could decrypt plaintext without Alice's private key!")
-else:
-    print("- Eve could not decrypt plaintext without Alice's private key!")
+    print(f"\n\n*** EVE bypass TESTS")
+    print(f"\n*** HPKS (public key signature)")
+    S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ nonce  # w/o A+B+C2 Eve would be forced to brute force
+    print(f"S (Eve)   : {S.hex}")
+    V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2  # X
+    print(f"V (Bob)   : {V.hex}")
+    if V == nonce:
+        print("+ nonce fake signature 1 verification with Alice public key is correct!")
+    else:
+        print("- nonce fake signature 1 verification with Alice public key is incorrect!")
+    S2 = V ^ nonce
+    print(f"S2 (Eve)  : {S2.hex}")
+    V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2  # KK
+    print(f"V2 (Bob)  : {V2.hex}")
+    if V2 == nonce:
+        print("+ nonce fake signature 2 verification with Alice public key is correct!")
+    else:
+        print("- nonce fake signature 2 verification with Alice public key is incorrect!")
+
+    print(f"\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public")
+    E = fscx_revolve_n(nonce, preshared, preshared, I_VALUE)
+    print(f"E (Eve)   : {E.hex}")
+    S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ E  # w/o A+B2+C Eve would be forced to brute force
+    print(f"S (Eve)   : {S.hex}")
+    V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2  # X
+    print(f"V (Eve)   : {V.hex}")
+    S2 = V ^ S
+    print(f"S2 (Eve)  : {S2.hex}")
+    V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2  # KK
+    print(f"V2 (Bob)  : {V2.hex}")
+    D = fscx_revolve_n(V2, preshared, preshared, R_VALUE)
+    print(f"D (Bob)   : {D.hex}")  # X
+    if D == nonce:
+        print("+ fake signature(encrypted nonce) verification with Alice public key is correct!")
+    else:
+        print("- fake signature(encrypted nonce) verification with Alice public key is incorrect!")
+
+    print(f"\n*** HPKS (public key signature) + HSKE (symmetric key encryption) with preshared key made public - v2")
+    S = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ nonce  # w/o A+B2+C Eve would be forced to brute force
+    print(f"S (Eve)   : {S.hex}")
+    E = fscx_revolve_n(S, preshared, preshared, I_VALUE)
+    print(f"E (Eve)   : {E.hex}")
+    V = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2  # X
+    print(f"V (Eve)   : {V.hex}")
+    S2 = V ^ E
+    print(f"S2 (Eve)  : {S2.hex}")
+    V2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ S2  # KK
+    print(f"V2 (Bob)  : {V2.hex}")
+    D = fscx_revolve_n(V2, preshared, preshared, R_VALUE)
+    print(f"D (Bob)   : {D.hex}")  # X
+    if D == nonce:
+        print("+ fake signature(encrypted nonce) v2 verification with Alice public key is correct!")
+    else:
+        print("- fake signature(encrypted nonce) v2 verification with Alice public key is incorrect!")
+
+    print(f"\n*** HPKE (public key encryption)")
+    E = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2 ^ plaintext  # w/o A+B2+C Eve would be forced to brute force
+    print(f"E (Bob)   : {E.hex}")
+    D = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ A2  # X
+    print(f"D (Eve)   : {D.hex}")
+    E2 = D ^ E
+    D2 = fscx_revolve_n(C, B2, hkex_nonce, R_VALUE) ^ E2  # KK
+    print(f"D2 (Eve)  : {D2.hex}")
+    if (D == nonce) or (D2 == nonce):
+        print("+ Eve could decrypt plaintext without Alice's private key!")
+    else:
+        print("- Eve could not decrypt plaintext without Alice's private key!")
+
+
+if __name__ == '__main__':
+    main()

--- a/Herradura_KEx.py
+++ b/Herradura_KEx.py
@@ -62,6 +62,14 @@ class BitArray:
     def copy(self) -> 'BitArray':
         return BitArray(self._size, self._val)
 
+    def rotated(self, n: int) -> 'BitArray':
+        """Return a new BitArray rotated left by n bits (right if n < 0)."""
+        n %= self._size
+        if n == 0:
+            return BitArray(self._size, self._val)
+        return BitArray(self._size,
+                        ((self._val << n) | (self._val >> (self._size - n))) & self._mask)
+
     def rol(self, n: int) -> None:
         """Rotate left in-place by n bits."""
         n %= self._size
@@ -116,36 +124,28 @@ def new_rand_bitarray(bitlength: int) -> BitArray:
 	result.uint = randbits(bitlength)
 	return result
 
-#fscx(a,b) = (a ^ b ^ rol(a) ^ rol(b) ^ ror(a) ^ ror(b))
-def fscx(A: BitArray, B: BitArray, keybits: int) -> BitArray:
-	"""Perform one FSCX transformation."""
-	a = A.copy()
-	b = B.copy()
-	result = a ^ b
-	a.ror(1)
-	b.ror(1)
-	result ^= a ^ b
-	a.rol(2)
-	b.rol(2)
-	result ^= a ^ b
-	return result
+# fscx(A,B) = A ^ B ^ ROL(A) ^ ROL(B) ^ ROR(A) ^ ROR(B)
+# Uses rotated() — does not mutate its inputs.
+def fscx(A: BitArray, B: BitArray) -> BitArray:
+    """Full Surroundings Cyclic XOR: A ^ B ^ ROL(A) ^ ROL(B) ^ ROR(A) ^ ROR(B)."""
+    return A ^ B ^ A.rotated(1) ^ B.rotated(1) ^ A.rotated(-1) ^ B.rotated(-1)
 
-#Iterative version of fscx
-def fscx_revolve(A: BitArray, B: BitArray, keybits: int, steps: int, verbose: bool = False) -> BitArray:
+# Iterative version of fscx
+def fscx_revolve(A: BitArray, B: BitArray, steps: int, verbose: bool = False) -> BitArray:
     result = A
     for n in range(steps):
         prev = result
-        result = fscx(result, B, keybits)
+        result = fscx(result, B)
         if verbose:
             print(f"---FSCX_REVOLVE_PRINT UP:{prev} DOWN:{B} Step {n + 1}: {result}")
     return result
 
-def fscx_revolve_n(A: BitArray, B: BitArray, nonce: BitArray, keybits: int, steps: int, verbose: bool = False) -> BitArray:
+def fscx_revolve_n(A: BitArray, B: BitArray, nonce: BitArray, steps: int, verbose: bool = False) -> BitArray:
     """Nonce-augmented FSCX_REVOLVE (v1.1). Each step: result = fscx(result,B) XOR nonce."""
     result = A.copy()
     for n in range(steps):
         prev = result
-        result = fscx(result, B, keybits) ^ nonce
+        result = fscx(result, B) ^ nonce
         if verbose:
             print(f"---FSCX_REVOLVE_N_PRINT UP:{prev} DOWN:{B} Step {n + 1}: {result}")
     return result
@@ -181,20 +181,20 @@ def main ():
 	print(f"ALICE:")
 	print(f"{A} A [Secret 1]")
 	print(f"{B} B [Secret 2]")
-	D=fscx_revolve(A,B,keybits,pubkeybits,verbose) #for 64 keybits, 63 and 31 pubkeybits are weak; 3/4 or 1/4 seems best.
+	D=fscx_revolve(A,B,pubkeybits,verbose) #for 64 keybits, 63 and 31 pubkeybits are weak; 3/4 or 1/4 seems best.
 	print(f"{D} [FSCX_REVOLVE(A,B,{pubkeybits})] ->")
 	print(f"    BOB:")
 	print(f"    A2 {A2} [Secret 3]")
 	print(f"    B2 {B2} [Secret 4]")
-	D2=fscx_revolve(A2,B2,keybits,pubkeybits,verbose)
+	D2=fscx_revolve(A2,B2,pubkeybits,verbose)
 	print(f" <- D2 {D2} [FSCX_REVOLVE(A2,B2,{pubkeybits})]")
 	hkex_nonce = D ^ D2
 	print(f"{hkex_nonce} hkex_nonce [D xor D2]")
 	print(f"ALICE:")
-	FA=fscx_revolve_n(D2,B,hkex_nonce,keybits,privkeybits,verbose)^A #---for 64 keybits, 1 and 33 pubkeybits are weak; 1 - pubkeybits seems best.
+	FA=fscx_revolve_n(D2,B,hkex_nonce,privkeybits,verbose)^A #---for 64 keybits, 1 and 33 pubkeybits are weak; 1 - pubkeybits seems best.
 	print(f"{FA} FA [FSCX_REVOLVE_N(D2,B,{privkeybits}) xor A]")
 	print(f"    BOB:")
-	FA2=fscx_revolve_n(D,B2,hkex_nonce,keybits,privkeybits,verbose)^A2
+	FA2=fscx_revolve_n(D,B2,hkex_nonce,privkeybits,verbose)^A2
 	if FA == FA2:
 		print(f"    FA2 == FA {FA2} [FSCX_REVOLVE_N(D,B2,{privkeybits}) xor A2]")
 	else:

--- a/Herradura_tests.c
+++ b/Herradura_tests.c
@@ -16,13 +16,17 @@
 #include <string.h>
 #include <time.h>
 
-/* Key size in bits — must be a positive multiple of 8.
+/* Key size in bits -- must be a positive multiple of 8 and >= 16.
    Matches the default in "Herradura cryptographic suite.c", and in
    the Go and Python implementations. */
 #define KEYBITS  256
 #define KEYBYTES (KEYBITS / 8)
 #define I_VALUE  (KEYBITS / 4)       /* 64  for 256-bit */
 #define R_VALUE  (3 * KEYBITS / 4)   /* 192 for 256-bit */
+
+#if KEYBYTES < 2
+#  error "KEYBITS must be >= 16 for the single-pass ba_fscx implementation"
+#endif
 
 /* Target wall time per benchmark (seconds). */
 #define BENCH_SEC 1.0
@@ -49,6 +53,7 @@ static void ba_rand(BitArray *dst)
     }
 }
 
+/* dst = a XOR b.  Aliasing dst == a or dst == b is safe. */
 static void ba_xor(BitArray *dst, const BitArray *a, const BitArray *b)
 {
     int i;
@@ -56,42 +61,17 @@ static void ba_xor(BitArray *dst, const BitArray *a, const BitArray *b)
         dst->b[i] = a->b[i] ^ b->b[i];
 }
 
-/* dst = src rotated left by 1 bit (big-endian, b[0] is MSB). */
-static void ba_rol1(BitArray *dst, const BitArray *src)
-{
-    int i;
-    uint8_t msbit = (src->b[0] >> 7) & 1;
-    for (i = 0; i < KEYBYTES - 1; i++)
-        dst->b[i] = (uint8_t)((src->b[i] << 1) | (src->b[i + 1] >> 7));
-    dst->b[KEYBYTES - 1] = (uint8_t)((src->b[KEYBYTES - 1] << 1) | msbit);
-}
-
-/* dst = src rotated right by 1 bit (big-endian, b[0] is MSB). */
-static void ba_ror1(BitArray *dst, const BitArray *src)
-{
-    int i;
-    uint8_t lsbit = src->b[KEYBYTES - 1] & 1;
-    for (i = KEYBYTES - 1; i > 0; i--)
-        dst->b[i] = (uint8_t)((src->b[i] >> 1) | (src->b[i - 1] << 7));
-    dst->b[0] = (uint8_t)((src->b[0] >> 1) | (lsbit << 7));
-}
-
 static int ba_equal(const BitArray *a, const BitArray *b)
 {
     return memcmp(a->b, b->b, KEYBYTES) == 0;
 }
 
-/* Count set bits across all bytes. */
+/* Count set bits using the hardware popcount instruction when available. */
 static int ba_popcount(const BitArray *a)
 {
     int cnt = 0, i;
-    for (i = 0; i < KEYBYTES; i++) {
-        uint8_t v = a->b[i];
-        while (v) {
-            cnt += (v & 1);
-            v >>= 1;
-        }
-    }
+    for (i = 0; i < KEYBYTES; i++)
+        cnt += __builtin_popcount(a->b[i]);
     return cnt;
 }
 
@@ -116,43 +96,75 @@ static void ba_flip_bit(BitArray *dst, const BitArray *src, int pos)
 /* FSCX primitives                                                     */
 /* ------------------------------------------------------------------ */
 
+/* Full Surroundings Cyclic XOR:
+   result = a XOR b XOR ROL(a) XOR ROL(b) XOR ROR(a) XOR ROR(b)
+
+   Fused single-pass implementation: ROL and ROR are computed inline from
+   adjacent bytes, avoiding 4 temporary BitArray allocations and 5 separate
+   memory passes.  Requires KEYBYTES >= 2. */
 static void ba_fscx(BitArray *result, const BitArray *a, const BitArray *b)
 {
-    BitArray rol_a, rol_b, ror_a, ror_b;
+    /* Wrap-around bits extracted before the loop */
+    uint8_t a_msbit = a->b[0] >> 7;
+    uint8_t b_msbit = b->b[0] >> 7;
+    uint8_t a_lsbit = a->b[KEYBYTES - 1] & 1;
+    uint8_t b_lsbit = b->b[KEYBYTES - 1] & 1;
     int i;
-    ba_rol1(&rol_a, a);
-    ba_rol1(&rol_b, b);
-    ba_ror1(&ror_a, a);
-    ba_ror1(&ror_b, b);
-    for (i = 0; i < KEYBYTES; i++)
+
+    /* byte 0: ROR wraps in from the last byte */
+    result->b[0] = a->b[0] ^ b->b[0]
+        ^ (uint8_t)((a->b[0] << 1) | (a->b[1] >> 7))   /* ROL(a)[0] */
+        ^ (uint8_t)((b->b[0] << 1) | (b->b[1] >> 7))   /* ROL(b)[0] */
+        ^ (uint8_t)((a->b[0] >> 1) | (a_lsbit << 7))   /* ROR(a)[0] */
+        ^ (uint8_t)((b->b[0] >> 1) | (b_lsbit << 7));  /* ROR(b)[0] */
+
+    /* middle bytes: no wrap-around */
+    for (i = 1; i < KEYBYTES - 1; i++)
         result->b[i] = a->b[i] ^ b->b[i]
-                     ^ rol_a.b[i] ^ rol_b.b[i]
-                     ^ ror_a.b[i] ^ ror_b.b[i];
+            ^ (uint8_t)((a->b[i] << 1) | (a->b[i + 1] >> 7))
+            ^ (uint8_t)((b->b[i] << 1) | (b->b[i + 1] >> 7))
+            ^ (uint8_t)((a->b[i] >> 1) | (a->b[i - 1] << 7))
+            ^ (uint8_t)((b->b[i] >> 1) | (b->b[i - 1] << 7));
+
+    /* last byte: ROL wraps in from the first byte */
+    result->b[KEYBYTES - 1] = a->b[KEYBYTES-1] ^ b->b[KEYBYTES-1]
+        ^ (uint8_t)((a->b[KEYBYTES-1] << 1) | a_msbit)
+        ^ (uint8_t)((b->b[KEYBYTES-1] << 1) | b_msbit)
+        ^ (uint8_t)((a->b[KEYBYTES-1] >> 1) | (a->b[KEYBYTES-2] << 7))
+        ^ (uint8_t)((b->b[KEYBYTES-1] >> 1) | (b->b[KEYBYTES-2] << 7));
 }
 
+/* FSCX_REVOLVE: iterate fscx(a, b) n times keeping b constant.
+   Double-buffered: alternates between two local buffers to avoid
+   copying the result back every step. */
 static void ba_fscx_revolve(BitArray *result, const BitArray *a,
                              const BitArray *b, int steps)
 {
-    BitArray tmp;
-    int i;
-    *result = *a;
+    BitArray buf[2];
+    int idx = 0, i;
+    buf[0] = *a;
     for (i = 0; i < steps; i++) {
-        ba_fscx(&tmp, result, b);
-        *result = tmp;
+        ba_fscx(&buf[1 - idx], &buf[idx], b);
+        idx ^= 1;
     }
+    *result = buf[idx];
 }
 
+/* FSCX_REVOLVE_N (v1.1): nonce-augmented iteration.
+   Each step: result = FSCX(result, b) XOR nonce */
 static void ba_fscx_revolve_n(BitArray *result, const BitArray *a,
                                const BitArray *b, const BitArray *nonce,
                                int steps)
 {
-    BitArray tmp;
-    int i;
-    *result = *a;
+    BitArray buf[2];
+    int idx = 0, i;
+    buf[0] = *a;
     for (i = 0; i < steps; i++) {
-        ba_fscx(&tmp, result, b);
-        ba_xor(result, &tmp, nonce);
+        ba_fscx(&buf[1 - idx], &buf[idx], b);
+        ba_xor(&buf[1 - idx], &buf[1 - idx], nonce);
+        idx ^= 1;
     }
+    *result = buf[idx];
 }
 
 /* ------------------------------------------------------------------ */

--- a/Herradura_tests.go
+++ b/Herradura_tests.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"math/bits"
 	"time"
 )
 
@@ -48,7 +49,7 @@ func NewFromBytes(data []byte, _ int, size int) *BitArray {
 	return ba
 }
 
-func New_rand_bitarray(bitlength int) *BitArray {
+func newRandBitArray(bitlength int) *BitArray {
 	buf := make([]byte, bitlength/8)
 	_, err := rand.Read(buf)
 	if err != nil {
@@ -58,7 +59,7 @@ func New_rand_bitarray(bitlength int) *BitArray {
 }
 
 func randBA(size int) *BitArray {
-	return New_rand_bitarray(size)
+	return newRandBitArray(size)
 }
 
 func (ba *BitArray) Xor(other *BitArray) *BitArray {
@@ -95,15 +96,11 @@ func (ba *BitArray) Format(f fmt.State, verb rune) {
 	fmt.Fprint(f, s)
 }
 
-// Popcount counts set bits by iterating over bytes.
+// Popcount counts set bits using the hardware popcount instruction when available.
 func (ba *BitArray) Popcount() int {
 	cnt := 0
 	for _, b := range ba.val.Bytes() {
-		v := b
-		for v != 0 {
-			cnt += int(v & 1)
-			v >>= 1
-		}
+		cnt += bits.OnesCount8(b)
 	}
 	return cnt
 }
@@ -112,12 +109,7 @@ func (ba *BitArray) Popcount() int {
 func (ba *BitArray) FlipBit(pos int) *BitArray {
 	result := &BitArray{size: ba.size}
 	result.val.Set(&ba.val)
-	cur := result.val.Bit(pos)
-	if cur == 0 {
-		result.val.SetBit(&result.val, pos, 1)
-	} else {
-		result.val.SetBit(&result.val, pos, 0)
-	}
+	result.val.SetBit(&result.val, pos, result.val.Bit(pos)^1)
 	return result
 }
 
@@ -125,15 +117,15 @@ func (ba *BitArray) FlipBit(pos int) *BitArray {
 // FSCX functions
 // ---------------------------------------------------------------------------
 
-func Fscx(ba, bb *BitArray) *BitArray {
-	result := ba.Xor(bb)
-	ba = ba.RotateLeft(1)
-	bb = bb.RotateLeft(1)
-	result = result.Xor(ba).Xor(bb)
-	ba = ba.RotateLeft(-2)
-	bb = bb.RotateLeft(-2)
-	result = result.Xor(ba).Xor(bb)
-	return result
+// Fscx computes the Full Surroundings Cyclic XOR:
+//
+//	result = A ⊕ B ⊕ ROL(A) ⊕ ROL(B) ⊕ ROR(A) ⊕ ROR(B)
+//
+// Each term maps directly to the formula; no parameter shadowing.
+func Fscx(a, b *BitArray) *BitArray {
+	return a.Xor(b).
+		Xor(a.RotateLeft(1)).Xor(b.RotateLeft(1)).
+		Xor(a.RotateLeft(-1)).Xor(b.RotateLeft(-1))
 }
 
 func FscxRevolve(ba, bb *BitArray, steps int) *BitArray {

--- a/Herradura_tests.py
+++ b/Herradura_tests.py
@@ -62,6 +62,14 @@ class BitArray:
     def copy(self) -> 'BitArray':
         return BitArray(self._size, self._val)
 
+    def rotated(self, n: int) -> 'BitArray':
+        """Return a new BitArray rotated left by n bits (right if n < 0)."""
+        n %= self._size
+        if n == 0:
+            return BitArray(self._size, self._val)
+        return BitArray(self._size,
+                        ((self._val << n) | (self._val >> (self._size - n))) & self._mask)
+
     def rol(self, n: int) -> None:
         """Rotate left in-place by n bits."""
         n %= self._size
@@ -113,11 +121,9 @@ class BitArray:
 # ---------------------------------------------------------------------------
 
 def fscx(A: BitArray, B: BitArray) -> BitArray:
-    a, b = A.copy(), B.copy()
-    result = a ^ b
-    a.ror(1); b.ror(1); result = result ^ a ^ b
-    a.rol(2); b.rol(2); result = result ^ a ^ b
-    return result
+    """Full Surroundings Cyclic XOR: A ^ B ^ ROL(A) ^ ROL(B) ^ ROR(A) ^ ROR(B).
+    Uses rotated() — does not mutate its inputs."""
+    return A ^ B ^ A.rotated(1) ^ B.rotated(1) ^ A.rotated(-1) ^ B.rotated(-1)
 
 
 def fscx_revolve(A: BitArray, B: BitArray, steps: int) -> BitArray:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,45 @@ gcc -m32 -o HAEN HAEN.o asm_io.o
 ./HAEN
 ```
 
+# Performance (v1.3.2, Raspberry Pi 5 — ARM Cortex-A76)
+
+Benchmarks from `Herradura_tests.{c,go,py}` at 256-bit parameters
+(1 second wall time per benchmark, `-O2` for C, default `go run` for Go).
+
+## C (gcc -O2)
+
+| Benchmark | Throughput |
+|-----------|-----------|
+| FSCX single step | 11.0 M ops/sec |
+| FSCX_REVOLVE_N (i=64 steps) | 167 K ops/sec |
+| FSCX_REVOLVE_N (r=192 steps) | 55.6 K ops/sec |
+| HKEX full handshake | 20.9 K ops/sec |
+| HSKE encrypt+decrypt round-trip | 41.4 K ops/sec |
+
+## Go (go run)
+
+| Benchmark | 64-bit | 128-bit | 256-bit |
+|-----------|--------|---------|---------|
+| FSCX single step | 235 K ops/sec | 265 K ops/sec | 239 K ops/sec |
+| FSCX_REVOLVE_N (i steps) | 15.8 K | 7.87 K | 3.46 K ops/sec |
+| FSCX_REVOLVE_N (r steps) | 5.36 K | 2.60 K | 1.22 K ops/sec |
+| HKEX full handshake | 2.01 K | 0.98 K | 0.43 K ops/sec |
+| HSKE encrypt+decrypt round-trip | 4.01 K | 1.86 K | 0.81 K ops/sec |
+
+## Python 3
+
+| Benchmark | 64-bit | 128-bit | 256-bit |
+|-----------|--------|---------|---------|
+| FSCX single step | 163 K ops/sec | 162 K ops/sec | 158 K ops/sec |
+| FSCX_REVOLVE_N (i steps) | 9.28 K | 4.70 K | 2.24 K ops/sec |
+| FSCX_REVOLVE_N (r steps) | 3.14 K | 1.57 K | 748 ops/sec |
+| HKEX full handshake | 1.20 K | 601 | 299 ops/sec |
+| HSKE encrypt+decrypt round-trip | 2.30 K | 1.16 K | 570 ops/sec |
+
+*The C implementation is ~45× faster than Go and ~70× faster than Python at
+the HKEX handshake level (256-bit), owing to the byte-parallel fused `ba_fscx`
+and hardware `POPCNT` leveraged through GCC `-O2`.*
+
 # Final note
 These cryptographic algorithms and protocols are released in the hope that they will be useful for building efficient and robust schemes, based on bitwise operations.
 


### PR DESCRIPTION
## Summary

- **C** (`suite.c`, `tests.c`): fused `ba_fscx` into a single-pass loop (5 passes → 1, 4 temp allocations eliminated); double-buffered `ba_fscx_revolve`/`ba_fscx_revolve_n` (no per-step struct copy); `__builtin_popcount` in tests; `ba_xor_into` removed; `ba_rol1`/`ba_ror1` inlined.
- **Go** (`suite.go`, `tests.go`): `Fscx` rewritten without parameter shadowing; renamed `Fscx_revolve→FscxRevolve`, `Fscx_revolve_n→FscxRevolveN`, `New_rand_bitarray→NewRandBitArray` (idiomatic Go PascalCase); `math/bits.OnesCount8` in tests; `FlipBit` simplified.
- **Python** (`suite.py`, `tests.py`, `Herradura_KEx.py`): `BitArray.rotated(n)` non-mutating method added to all three; `fscx` rewritten using `rotated()` (formula-direct, no input mutation); suite gains `BitArray.random()` classmethod, `main()` guard, and module-level constants; `keybits` removed from KEx demo (was unused).
- **Docs**: `README.md` performance table (C/Go/Python at 64/128/256-bit on Raspberry Pi 5); `CHANGELOG.md` v1.3.2 entry with per-file notes and applicability assessment for all files including assembly.

## Performance results (256-bit, Raspberry Pi 5 / ARM Cortex-A76, gcc -O2)

| Benchmark | C | Go | Python |
|-----------|---|----|--------|
| FSCX single step | **11.0 M ops/s** | 239 K ops/s | 158 K ops/s |
| FSCX_REVOLVE_N (i=64) | **167 K ops/s** | 3.46 K ops/s | 2.24 K ops/s |
| HKEX handshake | **20.9 K ops/s** | 0.43 K ops/s | 299 ops/s |
| HSKE round-trip | **41.4 K ops/s** | 0.81 K ops/s | 570 ops/s |

## Test plan

- [x] All 6/6 security tests pass: C (256-bit), Go (64/128/256-bit), Python (64/128/256-bit)
- [x] `Herradura cryptographic suite.{c,go,py}` — all 4 protocols + EVE bypass tests produce correct output
- [x] `Herradura_KEx.py -b 64 -v` — FA == FA2 confirmed
- [x] Builds: `gcc -O2`, `go run`, `python3` — no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)