### PR TITLE
v1.3.3: HPKE encrypt+decrypt round-trip benchmark [11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3.3] - 2026-03-30
+
+### Added — HPKE performance benchmark across all three test files
+
+#### `Herradura_tests.c`, `Herradura_tests.go`, `Herradura_tests.py`
+
+- **Benchmark [11] — HPKE encrypt+decrypt round-trip** added to all three test
+  files. Each iteration performs the full HPKE protocol cycle:
+  1. Key setup: `C = fscx_revolve(A, B, i)`, `C2 = fscx_revolve(A2, B2, i)`,
+     `hn = C ⊕ C2`
+  2. Bob encrypts: `E = fscx_revolve_n(C, B2, hn, r) ⊕ A2 ⊕ P`
+  3. Alice decrypts: `D = fscx_revolve_n(C2, B, hn, r) ⊕ A ⊕ E`
+
+  Throughput on Raspberry Pi 5 (ARM Cortex-A76):
+
+  | Implementation | 64-bit | 128-bit | 256-bit |
+  |----------------|--------|---------|---------|
+  | C (`gcc -O2`)  | — | — | 21.1 K ops/sec |
+  | Go (`go run`)  | 2.80 K | 1.29 K | 0.61 K ops/sec |
+  | Python 3       | 1.20 K | 604 | 303 ops/sec |
+
+  HPKE throughput is comparable to HKEX because both require the same compute:
+  2× `fscx_revolve(i)` for key setup and 2× `fscx_revolve_n(r)` for the
+  encrypt/decrypt pair.
+
+- **Version comment** added to each test file header referencing v1.3.3.
+
+---
+
 ## [1.3.2] - 2026-03-29
 
 ### Changed — performance, readability, and cross-language structural consistency

--- a/Herradura_tests.c
+++ b/Herradura_tests.c
@@ -1,6 +1,7 @@
 /* Build: gcc -O2 -o Herradura_tests Herradura_tests.c */
 
 /*  Herradura KEx -- Security & Performance Tests (C, 256-bit BitArray)
+    v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -506,6 +507,49 @@ static void bench_hske_roundtrip(void)
     putchar('\n');
 }
 
+/* HPKE (public key encryption) full round-trip:
+   Key setup: C = fscx_revolve(A,B,i), C2 = fscx_revolve(A2,B2,i), hn = C^C2
+   Bob encrypts:   E = fscx_revolve_n(C, B2, hn, r) ^ A2 ^ P
+   Alice decrypts: D = fscx_revolve_n(C2, B,  hn, r) ^ A  ^ E  (== P) */
+static void bench_hpke_roundtrip(void)
+{
+    struct timespec t0, t1;
+    long long ops = 0;
+    double secs;
+    int i;
+    BitArray a, b, a2, b2, c, c2, hn, pt, E, D, tmp;
+
+    printf("[11] HPKE encrypt+decrypt round-trip  (bits=%d)\n    ", KEYBITS);
+    /* warm up */
+    for (i = 0; i < 3; i++) {
+        ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2); ba_rand(&pt);
+        ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+        ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+        ba_xor(&hn, &c, &c2);
+        ba_fscx_revolve_n(&tmp, &c,  &b2, &hn, R_VALUE);
+        ba_xor(&E, &tmp, &a2); ba_xor(&E, &E, &pt);         /* Bob encrypts   */
+        ba_fscx_revolve_n(&tmp, &c2, &b,  &hn, R_VALUE);
+        ba_xor(&D, &tmp, &a);  ba_xor(&D, &D, &E);          /* Alice decrypts */
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        for (i = 0; i < 10; i++) {
+            ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2); ba_rand(&pt);
+            ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+            ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+            ba_xor(&hn, &c, &c2);
+            ba_fscx_revolve_n(&tmp, &c,  &b2, &hn, R_VALUE);
+            ba_xor(&E, &tmp, &a2); ba_xor(&E, &E, &pt);
+            ba_fscx_revolve_n(&tmp, &c2, &b,  &hn, R_VALUE);
+            ba_xor(&D, &tmp, &a);  ba_xor(&D, &D, &E);
+        }
+        ops += 10;
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    print_rate(ops, secs);
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -535,6 +579,7 @@ int main(void)
     bench_fscx_revolve_n_throughput();
     bench_hkex_handshake();
     bench_hske_roundtrip();
+    bench_hpke_roundtrip();
 
     fclose(urnd_fp);
     return 0;

--- a/Herradura_tests.go
+++ b/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -483,6 +484,35 @@ func benchHskeRoundTrip() {
 	fmt.Println()
 }
 
+// HPKE (public key encryption) full round-trip:
+// Key setup: C = FscxRevolve(A,B,i), C2 = FscxRevolve(A2,B2,i), hn = C^C2
+// Bob encrypts:   E = FscxRevolveN(C, B2, hn, r) ^ A2 ^ pt
+// Alice decrypts: D = FscxRevolveN(C2, B,  hn, r) ^ A  ^ E  (== pt)
+func benchHpkeRoundTrip() {
+	fmt.Println("[11] HPKE encrypt+decrypt round-trip")
+	for _, size := range sizes {
+		iv := iVal(size)
+		rv := rVal(size)
+		sink := randBA(size)
+		ops, elapsed := bench("", func() {
+			A := randBA(size)
+			B := randBA(size)
+			A2 := randBA(size)
+			B2 := randBA(size)
+			pt := randBA(size)
+			C := FscxRevolve(A, B, iv)
+			C2 := FscxRevolve(A2, B2, iv)
+			hn := C.Xor(C2)
+			E := FscxRevolveN(C, B2, hn, rv).Xor(A2).Xor(pt) // Bob encrypts
+			D := FscxRevolveN(C2, B, hn, rv).Xor(A).Xor(E)   // Alice decrypts
+			sink = sink.Xor(D)
+		})
+		fmt.Printf("    bits=%3d                          : %s  (%d ops in %.2fs)\n",
+			size, fmtRate(ops, elapsed), ops, elapsed.Seconds())
+	}
+	fmt.Println()
+}
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -504,4 +534,5 @@ func main() {
 	benchFscxRevolveN()
 	benchHkexHandshake()
 	benchHskeRoundTrip()
+	benchHpkeRoundTrip()
 }

--- a/Herradura_tests.py
+++ b/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx -- Security & Performance Tests (Python)
+    v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -413,6 +414,33 @@ def bench_hske_roundtrip():
     print()
 
 
+# HPKE (public key encryption) full round-trip:
+# Key setup: C = fscx_revolve(A,B,i), C2 = fscx_revolve(A2,B2,i), hn = C^C2
+# Bob encrypts:   E = fscx_revolve_n(C, B2, hn, r) ^ A2 ^ pt
+# Alice decrypts: D = fscx_revolve_n(C2, B,  hn, r) ^ A  ^ E  (== pt)
+def bench_hpke_roundtrip():
+    print("[11] HPKE encrypt+decrypt round-trip")
+    for size in SIZES:
+        iv = i_val(size)
+        rv = r_val(size)
+        sink = BitArray(size, 0)
+        def fn():
+            nonlocal sink
+            A  = BitArray.random(size)
+            B  = BitArray.random(size)
+            A2 = BitArray.random(size)
+            B2 = BitArray.random(size)
+            pt = BitArray.random(size)
+            C  = fscx_revolve(A, B, iv)
+            C2 = fscx_revolve(A2, B2, iv)
+            hn = C ^ C2
+            E  = fscx_revolve_n(C, B2, hn, rv) ^ A2 ^ pt  # Bob encrypts
+            D  = fscx_revolve_n(C2, B, hn, rv) ^ A ^ E    # Alice decrypts
+            sink ^= D
+        _bench(f"bits={size:3d}", fn)
+    print()
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -434,3 +462,4 @@ if __name__ == '__main__':
     bench_fscx_revolve_n()
     bench_hkex_handshake()
     bench_hske_roundtrip()
+    bench_hpke_roundtrip()

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ gcc -m32 -o HAEN HAEN.o asm_io.o
 ./HAEN
 ```
 
-# Performance (v1.3.2, Raspberry Pi 5 — ARM Cortex-A76)
+# Performance (v1.3.3, Raspberry Pi 5 — ARM Cortex-A76)
 
 Benchmarks from `Herradura_tests.{c,go,py}` at 256-bit parameters
 (1 second wall time per benchmark, `-O2` for C, default `go run` for Go).
@@ -192,34 +192,37 @@ Benchmarks from `Herradura_tests.{c,go,py}` at 256-bit parameters
 
 | Benchmark | Throughput |
 |-----------|-----------|
-| FSCX single step | 11.0 M ops/sec |
+| FSCX single step | 11.1 M ops/sec |
 | FSCX_REVOLVE_N (i=64 steps) | 167 K ops/sec |
-| FSCX_REVOLVE_N (r=192 steps) | 55.6 K ops/sec |
-| HKEX full handshake | 20.9 K ops/sec |
-| HSKE encrypt+decrypt round-trip | 41.4 K ops/sec |
+| FSCX_REVOLVE_N (r=192 steps) | 56.0 K ops/sec |
+| HKEX full handshake | 21.1 K ops/sec |
+| HSKE encrypt+decrypt round-trip | 41.8 K ops/sec |
+| HPKE encrypt+decrypt round-trip | 21.1 K ops/sec |
 
 ## Go (go run)
 
 | Benchmark | 64-bit | 128-bit | 256-bit |
 |-----------|--------|---------|---------|
-| FSCX single step | 235 K ops/sec | 265 K ops/sec | 239 K ops/sec |
-| FSCX_REVOLVE_N (i steps) | 15.8 K | 7.87 K | 3.46 K ops/sec |
-| FSCX_REVOLVE_N (r steps) | 5.36 K | 2.60 K | 1.22 K ops/sec |
-| HKEX full handshake | 2.01 K | 0.98 K | 0.43 K ops/sec |
-| HSKE encrypt+decrypt round-trip | 4.01 K | 1.86 K | 0.81 K ops/sec |
+| FSCX single step | 372 K ops/sec | 383 K ops/sec | 318 K ops/sec |
+| FSCX_REVOLVE_N (i steps) | 22.6 K | 10.9 K | 4.65 K ops/sec |
+| FSCX_REVOLVE_N (r steps) | 7.38 K | 3.60 K | 1.56 K ops/sec |
+| HKEX full handshake | 2.75 K | 1.33 K | 0.58 K ops/sec |
+| HSKE encrypt+decrypt round-trip | 5.30 K | 2.46 K | 1.20 K ops/sec |
+| HPKE encrypt+decrypt round-trip | 2.80 K | 1.29 K | 0.61 K ops/sec |
 
 ## Python 3
 
 | Benchmark | 64-bit | 128-bit | 256-bit |
 |-----------|--------|---------|---------|
-| FSCX single step | 163 K ops/sec | 162 K ops/sec | 158 K ops/sec |
-| FSCX_REVOLVE_N (i steps) | 9.28 K | 4.70 K | 2.24 K ops/sec |
-| FSCX_REVOLVE_N (r steps) | 3.14 K | 1.57 K | 748 ops/sec |
-| HKEX full handshake | 1.20 K | 601 | 299 ops/sec |
-| HSKE encrypt+decrypt round-trip | 2.30 K | 1.16 K | 570 ops/sec |
+| FSCX single step | 166 K ops/sec | 165 K ops/sec | 156 K ops/sec |
+| FSCX_REVOLVE_N (i steps) | 9.20 K | 4.64 K | 2.32 K ops/sec |
+| FSCX_REVOLVE_N (r steps) | 3.08 K | 1.54 K | 747 ops/sec |
+| HKEX full handshake | 1.16 K | 585 | 290 ops/sec |
+| HSKE encrypt+decrypt round-trip | 2.28 K | 1.16 K | 563 ops/sec |
+| HPKE encrypt+decrypt round-trip | 1.20 K | 604 | 303 ops/sec |
 
-*The C implementation is ~45× faster than Go and ~70× faster than Python at
-the HKEX handshake level (256-bit), owing to the byte-parallel fused `ba_fscx`
+*The C implementation is ~35× faster than Go and ~70× faster than Python at
+the HPKE round-trip level (256-bit), owing to the byte-parallel fused `ba_fscx`
 and hardware `POPCNT` leveraged through GCC `-O2`.*
 
 # Final note


### PR DESCRIPTION
## Summary

- Adds benchmark **[11] HPKE encrypt+decrypt round-trip** to `Herradura_tests.c`, `Herradura_tests.go`, and `Herradura_tests.py`
- Each iteration covers the full HPKE cycle: key setup (`2× fscx_revolve(i)`) + Bob encrypts + Alice decrypts (`2× fscx_revolve_n(r)`)
- All 6 security tests continue to pass in all three languages at all bit sizes
- Updates `CHANGELOG.md` (v1.3.3 entry) and `README.md` performance tables

**Throughput at 256-bit (Raspberry Pi 5):**

| Implementation | HPKE round-trip |
|----------------|----------------|
| C (`gcc -O2`)  | 21.1 K ops/sec |
| Go (`go run`)  | 0.61 K ops/sec |
| Python 3       | 303 ops/sec    |

HPKE throughput matches HKEX because both require the same compute: `2× fscx_revolve(i)` + `2× fscx_revolve_n(r)`.

## Test plan

- [x] `gcc -O2 -o Herradura_tests Herradura_tests.c && ./Herradura_tests` — all 6 tests PASS, benchmark [11] runs
- [x] `go run Herradura_tests.go` — all 6 tests PASS, benchmark [11] runs across 64/128/256-bit
- [x] `python3 Herradura_tests.py` — all 6 tests PASS, benchmark [11] runs across 64/128/256-bit

🤖 Generated with [Claude Code](https://claude.com/claude-code)