### PR TITLE
v1.3.5/v1.3.6: FSCX_REVOLVE_N usage guidance + HPKS sign/verify test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3.6] - 2026-04-01
+
+### Added — HPKS sign+verify correctness test across all three test files
+
+#### `Herradura_tests.c`, `Herradura_tests.go`, `Herradura_tests.py`
+
+- **Security test [7] — HPKS sign+verify correctness** added to all three test
+  files. Each of 10 000 trials generates fresh random keys (A, B, A2, B2) and a
+  random plaintext, then checks:
+
+  ```
+  C  = fscx_revolve(A, B, i)
+  C2 = fscx_revolve(A2, B2, i)
+  hn = C ⊕ C2
+  S  = fscx_revolve_n(C2, B, hn, r) ⊕ A ⊕ P   (sign)
+  V  = fscx_revolve_n(C,  B2, hn, r) ⊕ A2 ⊕ S  (verify)
+  assert V == P
+  ```
+
+  Correctness follows from the HKEX equality: both sides of the shared-key
+  computation equal `fscx_revolve_n(·, ·, hn, r) ⊕ A[2]`, so the XOR terms
+  cancel and `V = P` holds for all valid key pairs. Expected: 10 000/10 000.
+
+- **Benchmarks renumbered [8–12]** (were [7–11]) to accommodate the new test.
+
+- **Version comment** updated to v1.3.6 in each test file header.
+
+---
+
+## [1.3.5] - 2026-04-01
+
+### Added — README: guidance on when to use FSCX_REVOLVE vs FSCX_REVOLVE_N
+
+#### `README.md`
+
+- New subsection **'When to use FSCX_REVOLVE vs FSCX_REVOLVE_N'** added under
+  the existing FSCX_REVOLVE_N section. Includes a per-operation reference table
+  covering HKEX key setup, HKEX key derivation, HSKE, HPKS, and HPKE, with the
+  function to use and the security rationale for each choice.
+
+---
+
 ## [1.3.4] - 2026-04-01
 
 ### Fixed — SecurityProofs.md: formula corrections and HPKS₂ protocol

--- a/Herradura_tests.c
+++ b/Herradura_tests.c
@@ -1,6 +1,7 @@
 /* Build: gcc -O2 -o Herradura_tests Herradura_tests.c */
 
 /*  Herradura KEx -- Security & Performance Tests (C, 256-bit BitArray)
+    v1.3.6: added HPKS sign+verify correctness test [7]; benchmarks renumbered [8-12].
     v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -388,6 +389,34 @@ static void test_avalanche_revolve_n(void)
     putchar('\n');
 }
 
+static void test_hpks_sign_verify(void)
+{
+    int i, ok = 0;
+    BitArray a, b, a2, b2, c, c2, hn, plaintext, S, V, tmp;
+    printf("[7] HPKS sign+verify correctness: V == plaintext\n");
+    for (i = 0; i < 10000; i++) {
+        ba_rand(&a);  ba_rand(&b);
+        ba_rand(&a2); ba_rand(&b2);
+        ba_rand(&plaintext);
+        ba_fscx_revolve(&c,  &a,  &b,  I_VALUE);
+        ba_fscx_revolve(&c2, &a2, &b2, I_VALUE);
+        ba_xor(&hn, &c, &c2);
+        /* sign: S = fscx_revolve_n(C2, B, hn, r) ^ A ^ P */
+        ba_fscx_revolve_n(&tmp, &c2, &b, &hn, R_VALUE);
+        ba_xor(&S, &tmp, &a);
+        ba_xor(&S, &S, &plaintext);
+        /* verify: V = fscx_revolve_n(C, B2, hn, r) ^ A2 ^ S */
+        ba_fscx_revolve_n(&tmp, &c, &b2, &hn, R_VALUE);
+        ba_xor(&V, &tmp, &a2);
+        ba_xor(&V, &V, &S);
+        if (ba_equal(&V, &plaintext))
+            ok++;
+    }
+    printf("    bits=%d  %d / 10000 verified  [%s]\n",
+           KEYBITS, ok, ok == 10000 ? "PASS" : "FAIL");
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
 /* Performance benchmarks                                              */
 /* ------------------------------------------------------------------ */
@@ -400,7 +429,7 @@ static void bench_fscx_throughput(void)
     double secs;
     int i;
 
-    printf("[7] FSCX throughput  (bits=%d)\n    ", KEYBITS);
+    printf("[8] FSCX throughput  (bits=%d)\n    ", KEYBITS);
     ba_rand(&a); ba_rand(&b);
     /* warm up */
     for (i = 0; i < 10; i++) ba_fscx(&tmp, &a, &b);
@@ -421,7 +450,7 @@ static void bench_fscx_revolve_n_throughput(void)
     int s, i;
     struct timespec t0, t1;
 
-    printf("[8] FSCX_REVOLVE_N throughput  (bits=%d)\n", KEYBITS);
+    printf("[9] FSCX_REVOLVE_N throughput  (bits=%d)\n", KEYBITS);
     for (s = 0; s < 2; s++) {
         BitArray a, b, nonce, tmp;
         long long ops = 0;
@@ -451,7 +480,7 @@ static void bench_hkex_handshake(void)
     int i;
     BitArray a, b, a2, b2, c, c2, hn, keyA, keyB, tmp;
 
-    printf("[9] HKEX full handshake  (bits=%d)\n    ", KEYBITS);
+    printf("[10] HKEX full handshake  (bits=%d)\n    ", KEYBITS);
     /* warm up */
     for (i = 0; i < 3; i++) {
         ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2);
@@ -486,7 +515,7 @@ static void bench_hske_roundtrip(void)
     int i;
     BitArray pt, key, enc, dec;
 
-    printf("[10] HSKE round-trip: encrypt+decrypt  (bits=%d)\n    ", KEYBITS);
+    printf("[11] HSKE round-trip: encrypt+decrypt  (bits=%d)\n    ", KEYBITS);
     /* warm up */
     for (i = 0; i < 5; i++) {
         ba_rand(&pt); ba_rand(&key);
@@ -519,7 +548,7 @@ static void bench_hpke_roundtrip(void)
     int i;
     BitArray a, b, a2, b2, c, c2, hn, pt, E, D, tmp;
 
-    printf("[11] HPKE encrypt+decrypt round-trip  (bits=%d)\n    ", KEYBITS);
+    printf("[12] HPKE encrypt+decrypt round-trip  (bits=%d)\n    ", KEYBITS);
     /* warm up */
     for (i = 0; i < 3; i++) {
         ba_rand(&a); ba_rand(&b); ba_rand(&a2); ba_rand(&b2); ba_rand(&pt);
@@ -573,6 +602,7 @@ int main(void)
     test_key_sensitivity();
 
     test_avalanche_revolve_n();
+    test_hpks_sign_verify();
 
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();

--- a/Herradura_tests.go
+++ b/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.3.6: added HPKS sign+verify correctness test [7]; benchmarks renumbered [8-12].
     v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -400,12 +401,42 @@ func testAvalancheRevolveN() {
 	fmt.Println()
 }
 
+func testHpksSignVerify() {
+	fmt.Println("[7] HPKS sign+verify correctness: V == plaintext")
+	for _, size := range sizes {
+		iv := iVal(size)
+		rv := rVal(size)
+		ok := 0
+		for i := 0; i < 10000; i++ {
+			a := randBA(size)
+			b := randBA(size)
+			a2 := randBA(size)
+			b2 := randBA(size)
+			pt := randBA(size)
+			c := FscxRevolve(a, b, iv)
+			c2 := FscxRevolve(a2, b2, iv)
+			hn := c.Xor(c2)
+			S := FscxRevolveN(c2, b, hn, rv).Xor(a).Xor(pt)  // sign
+			V := FscxRevolveN(c, b2, hn, rv).Xor(a2).Xor(S)  // verify
+			if V.Equal(pt) {
+				ok++
+			}
+		}
+		status := "PASS"
+		if ok != 10000 {
+			status = "FAIL"
+		}
+		fmt.Printf("    bits=%3d  %5d / 10000 verified  [%s]\n", size, ok, status)
+	}
+	fmt.Println()
+}
+
 // ---------------------------------------------------------------------------
 // Performance benchmarks
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[7] FSCX throughput")
+	fmt.Println("[8] FSCX throughput")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -419,7 +450,7 @@ func benchFscx() {
 }
 
 func benchFscxRevolveN() {
-	fmt.Println("[8] FSCX_REVOLVE_N throughput")
+	fmt.Println("[9] FSCX_REVOLVE_N throughput")
 	for _, size := range sizes {
 		for _, stepsLabel := range []struct {
 			steps int
@@ -444,7 +475,7 @@ func benchFscxRevolveN() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[9] HKEX full handshake")
+	fmt.Println("[10] HKEX full handshake")
 	for _, size := range sizes {
 		iv := iVal(size)
 		rv := rVal(size)
@@ -466,7 +497,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[10] HSKE round-trip: encrypt+decrypt")
+	fmt.Println("[11] HSKE round-trip: encrypt+decrypt")
 	for _, size := range sizes {
 		iv := iVal(size)
 		rv := rVal(size)
@@ -489,7 +520,7 @@ func benchHskeRoundTrip() {
 // Bob encrypts:   E = FscxRevolveN(C, B2, hn, r) ^ A2 ^ pt
 // Alice decrypts: D = FscxRevolveN(C2, B,  hn, r) ^ A  ^ E  (== pt)
 func benchHpkeRoundTrip() {
-	fmt.Println("[11] HPKE encrypt+decrypt round-trip")
+	fmt.Println("[12] HPKE encrypt+decrypt round-trip")
 	for _, size := range sizes {
 		iv := iVal(size)
 		rv := rVal(size)
@@ -528,6 +559,7 @@ func main() {
 	testKeySensitivity()
 
 	testAvalancheRevolveN()
+	testHpksSignVerify()
 
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()

--- a/Herradura_tests.py
+++ b/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx -- Security & Performance Tests (Python)
+    v1.3.6: added HPKS sign+verify correctness test [7]; benchmarks renumbered [8-12].
     v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -325,6 +326,34 @@ def test_avalanche_revolve_n():
     print()
 
 
+def test_hpks_sign_verify():
+    # HPKS: S = fscx_revolve_n(C2, B, hn, r) ^ A ^ P   (sign)
+    #        V = fscx_revolve_n(C,  B2, hn, r) ^ A2 ^ S (verify)
+    # Correctness follows from the HKEX equality: both sides equal the shared key,
+    # so V = shared_key ^ A2 ^ (shared_key ^ A ^ P) = A ^ A2 ^ A2 ^ P = ... = P.
+    print("[7] HPKS sign+verify correctness: V == plaintext")
+    for size in SIZES:
+        iv = i_val(size)
+        rv = r_val(size)
+        ok = 0
+        for _ in range(10000):
+            a  = BitArray.random(size)
+            b  = BitArray.random(size)
+            a2 = BitArray.random(size)
+            b2 = BitArray.random(size)
+            pt = BitArray.random(size)
+            c  = fscx_revolve(a, b, iv)
+            c2 = fscx_revolve(a2, b2, iv)
+            hn = c ^ c2
+            S = fscx_revolve_n(c2, b, hn, rv) ^ a ^ pt   # sign
+            V = fscx_revolve_n(c, b2, hn, rv) ^ a2 ^ S   # verify
+            if V == pt:
+                ok += 1
+        status = "PASS" if ok == 10000 else "FAIL"
+        print(f"    bits={size:3d}  {ok:5d} / 10000 verified  [{status}]")
+    print()
+
+
 # ---------------------------------------------------------------------------
 # Performance benchmarks
 # ---------------------------------------------------------------------------
@@ -354,7 +383,7 @@ def _bench(label: str, fn):
 
 
 def bench_fscx():
-    print("[7] FSCX throughput")
+    print("[8] FSCX throughput")
     for size in SIZES:
         a = BitArray.random(size)
         b = BitArray.random(size)
@@ -366,7 +395,7 @@ def bench_fscx():
 
 
 def bench_fscx_revolve_n():
-    print("[8] FSCX_REVOLVE_N throughput")
+    print("[9] FSCX_REVOLVE_N throughput")
     for size in SIZES:
         for steps, label in [(i_val(size), f"i({i_val(size)})"), (r_val(size), f"r({r_val(size)})")]:
             a = BitArray.random(size)
@@ -379,7 +408,7 @@ def bench_fscx_revolve_n():
 
 
 def bench_hkex_handshake():
-    print("[9] HKEX full handshake")
+    print("[10] HKEX full handshake")
     for size in SIZES:
         iv = i_val(size)
         rv = r_val(size)
@@ -398,7 +427,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[10] HSKE round-trip: encrypt+decrypt")
+    print("[11] HSKE round-trip: encrypt+decrypt")
     for size in SIZES:
         iv = i_val(size)
         rv = r_val(size)
@@ -419,7 +448,7 @@ def bench_hske_roundtrip():
 # Bob encrypts:   E = fscx_revolve_n(C, B2, hn, r) ^ A2 ^ pt
 # Alice decrypts: D = fscx_revolve_n(C2, B,  hn, r) ^ A  ^ E  (== pt)
 def bench_hpke_roundtrip():
-    print("[11] HPKE encrypt+decrypt round-trip")
+    print("[12] HPKE encrypt+decrypt round-trip")
     for size in SIZES:
         iv = i_val(size)
         rv = r_val(size)
@@ -456,6 +485,7 @@ if __name__ == '__main__':
     test_key_sensitivity()
 
     test_avalanche_revolve_n()
+    test_hpks_sign_verify()
 
     print("--- Performance Benchmarks ---\n")
     bench_fscx()

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ This is identical to the condition without the nonce — N cancels from both sid
 
 **Orbit properties** are preserved: FSCX_REVOLVE_N(·, B, N, ·) is a bijection on GF(2)^P, so all orbits are finite. Empirical validation confirms orbit lengths remain ≤ 2P.
 
+## When to use FSCX_REVOLVE vs FSCX_REVOLVE_N
+
+The rule is straightforward: use FSCX_REVOLVE_N wherever the **same key material could produce multiple outputs** (encryption), and plain FSCX_REVOLVE for **key setup where the inputs are already fresh random values** per session.
+
+| Operation | Function | Reason |
+|-----------|----------|--------|
+| HKEX public value setup: `C = fscx_revolve(A, B, i)` | FSCX_REVOLVE | A and B are ephemeral random secrets generated fresh per session — C is already session-unique. A nonce would add overhead without any security benefit. |
+| HKEX shared key derivation | FSCX_REVOLVE_N (nonce = C⊕C2) | Breaks the linear structure for the derived key. Nonce is computable from public values; no extra secret needed. |
+| HSKE encrypt / decrypt | FSCX_REVOLVE_N (nonce = key) | **Essential.** Without a nonce, HSKE is a deterministic cipher: same plaintext + same key = same ciphertext, breaking semantic security (IND-CPA). The key is injected at every step, not just at boundaries. |
+| HPKS sign / verify | FSCX_REVOLVE_N (nonce = C⊕C2) | Same as HKEX derivation — breaks linearity for the signature computation. |
+| HPKE encrypt / decrypt | FSCX_REVOLVE_N (nonce = C⊕C2) | Session-specific nonce binds the ciphertext to the current key exchange, preventing ciphertext reuse across sessions. |
+
+**Summary:** The performance cost of FSCX_REVOLVE_N over plain FSCX_REVOLVE is one extra XOR per step. This overhead is worthwhile everywhere except key setup with ephemeral inputs, where the randomness comes from key generation rather than the iteration function. Using FSCX_REVOLVE for key setup avoids requiring nonce negotiation at that stage while preserving all security properties.
+
 # Build & Run Instructions
 
 ## C


### PR DESCRIPTION
## Summary

### v1.3.5 — README documentation
- New **'When to use FSCX_REVOLVE vs FSCX_REVOLVE_N'** subsection in `README.md` with a per-operation table explaining which variant is correct for each protocol step (HKEX setup, HKEX derivation, HSKE, HPKS, HPKE) and why.
- All source and test files audited and confirmed correct — no code changes required.

### v1.3.6 — HPKS sign+verify correctness test
- **Security test [7]** added to `Herradura_tests.{c,go,py}`: verifies `V == P` across 10 000 random trials for the full HPKS sign+verify cycle using `fscx_revolve_n`.
- Existing performance benchmarks renumbered **[8–12]** (were [7–11]).

## Test results

All 7 security tests PASS across all three implementations:

| Test | C (256-bit) | Go (64/128/256-bit) | Python (64/128/256-bit) |
|------|-------------|---------------------|-------------------------|
| [7] HPKS sign+verify | 10000/10000 ✓ | 10000/10000 ✓ | 10000/10000 ✓ |

## Test plan
- [ ] Verify README section renders correctly on GitHub
- [ ] Confirm all 7 security tests pass: `gcc -O2 -o Herradura_tests Herradura_tests.c && ./Herradura_tests`
- [ ] Confirm all 7 security tests pass: `go run Herradura_tests.go`
- [ ] Confirm all 7 security tests pass: `python3 Herradura_tests.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)