### PR TITLE
v1.3.7: NASM i386, ARM Thumb, and Arduino suite+test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.3.7] - 2026-04-01
+
+### Added — NASM i386, ARM Thumb, and Arduino implementations
+
+Six new source files bring full HKEX + HSKE + HPKS + HPKE coverage to assembly
+and embedded platforms.
+
+#### `Herradura cryptographic suite.asm` (new — NASM i386)
+
+- Full four-protocol suite (HKEX, HSKE, HPKS, HPKE) in NASM i386 assembly.
+- Pure Linux syscall interface (`int 0x80`); no libc or `asm_io` dependency.
+- 32-bit operands: `KEYBITS=32`, `I_VALUE=8`, `R_VALUE=24`.
+- Fixed test values: A=0xDEADBEEF, B=0xCAFEBABE, A2=0x12345678, B2=0xABCDEF01,
+  key=0x5A5A5A5A, plaintext=0xDEADC0DE.
+- Build: `nasm -f elf32 … -o suite32.o && x86_64-linux-gnu-ld -m elf_i386 -o … suite32.o`
+- Run: `qemu-i386 "./Herradura cryptographic suite_i386"` (or natively on x86/x86_64)
+
+#### `Herradura_tests.asm` (new — NASM i386)
+
+- Four correctness tests × 100 LCG-random trials each (HKEX, HSKE, HPKS, HPKE).
+- LCG PRNG: Numerical Recipes constants (multiplier 1664525, addend 1013904223,
+  seed 0x12345678).
+- Outer loops use `dec ecx / jnz near` to avoid the ±127-byte limit of `loop`.
+- All four tests verified: 100/100 passed.
+
+#### `Herradura cryptographic suite.s` (new — GAS ARM 32-bit Thumb)
+
+- Full four-protocol suite in ARM Thumb-2 assembly (`.cpu cortex-a7`).
+- Defines both `fscx_revolve` and `fscx_revolve_n` (the existing
+  `HKEX_arm_linux.s` calls `fscx_revolve_n` but never defines it).
+- `.thumb_func` annotations required for ARM/Thumb interworking.
+- Build: `arm-linux-gnueabi-gcc -o "Herradura cryptographic suite_arm" "Herradura cryptographic suite.s"`
+- Run: `qemu-arm -L /usr/arm-linux-gnueabi "./Herradura cryptographic suite_arm"`
+
+#### `Herradura_tests.s` (new — GAS ARM 32-bit Thumb)
+
+- Four correctness tests × 100 LCG-random trials each (HKEX, HSKE, HPKS, HPKE).
+- All four tests verified: 100/100 passed on qemu-arm.
+
+#### `Herradura cryptographic suite.ino` (new — Arduino)
+
+- Full four-protocol suite for Arduino (32-bit `unsigned long`).
+- `Serial` output at 9600 baud; `printHex` / `printHexLine` helpers for
+  zero-padded hex display.
+- Compatible with boards using `unsigned long` as a 32-bit type (Uno, Nano,
+  Mega, etc.).
+
+#### `Herradura_tests.ino` (new — Arduino)
+
+- Four correctness tests × 100 LCG-random trials each (HKEX, HSKE, HPKS, HPKE).
+- Results printed over Serial; `loop()` reruns every 30 seconds.
+
+#### `README.md`
+
+- Updated Assembly build section with commands for the new NASM and ARM suite
+  and test binaries.
+- Added Arduino section with `arduino-cli` compile-check command.
+
+---
+
 ## [1.3.6] - 2026-04-01
 
 ### Added — HPKS sign+verify correctness test across all three test files

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,0 +1,487 @@
+;  Herradura Cryptographic Suite v1.3.7
+;  NASM i386 Assembly -- HKEX, HSKE, HPKS, HPKE with FSCX_REVOLVE_N
+;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
+;
+;  Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+;  MIT License / GPL v3.0 -- choose either.
+;
+;  Assemble: nasm -f elf32 "Herradura cryptographic suite.asm" -o suite32.o
+;  Link:     ld -m elf_i386 -o "Herradura cryptographic suite_i386" suite32.o
+;  Run:      ./suite_i386   (x86_32 Linux) or  qemu-i386 ./suite_i386
+
+%define SYS_EXIT   1
+%define SYS_WRITE  4
+%define STDOUT     1
+%define I_VALUE    8
+%define R_VALUE    24
+
+section .data
+
+    val_A     dd 0xDEADBEEF
+    val_B     dd 0xCAFEBABE
+    val_A2    dd 0x12345678
+    val_B2    dd 0xABCDEF01
+    val_key   dd 0x5A5A5A5A
+    val_plain dd 0xDEADC0DE
+    val_C     dd 0
+    val_C2    dd 0
+    val_hn    dd 0
+    val_skA   dd 0
+    val_skB   dd 0
+    val_E     dd 0
+    val_D     dd 0
+    val_S     dd 0
+    val_V     dd 0
+    val_nonce dd 0          ; ESI-pointed nonce for fscx_revolve_n
+
+    hdr       db "=== Herradura Cryptographic Suite (NASM i386, KEYBITS=32) ===", 10
+    hdr_l     equ $-hdr
+
+    lbl_A     db "A         : "
+    lbl_A_l   equ $-lbl_A
+    lbl_B     db "B         : "
+    lbl_B_l   equ $-lbl_B
+    lbl_A2    db "A2        : "
+    lbl_A2_l  equ $-lbl_A2
+    lbl_B2    db "B2        : "
+    lbl_B2_l  equ $-lbl_B2
+    lbl_key   db "key       : "
+    lbl_key_l equ $-lbl_key
+    lbl_plain db "plaintext : "
+    lbl_pl_l  equ $-lbl_plain
+    lbl_C     db "C         : "
+    lbl_C_l   equ $-lbl_C
+    lbl_C2    db "C2        : "
+    lbl_C2_l  equ $-lbl_C2
+    lbl_hn    db "hkex_nonce: "
+    lbl_hn_l  equ $-lbl_hn
+
+    hkex_hdr  db 10, "--- HKEX (key exchange)", 10
+    hkex_hdr_l equ $-hkex_hdr
+    lbl_skA   db "skeyA (Alice): "
+    lbl_skA_l equ $-lbl_skA
+    lbl_skB   db "skeyB (Bob)  : "
+    lbl_skB_l equ $-lbl_skB
+
+    hske_hdr  db 10, "--- HSKE (symmetric key encryption)", 10
+    hske_hdr_l equ $-hske_hdr
+    lbl_E     db "E (encrypted): "
+    lbl_E_l   equ $-lbl_E
+    lbl_D     db "D (decrypted): "
+    lbl_D_l   equ $-lbl_D
+
+    hpks_hdr  db 10, "--- HPKS (public key signature)", 10
+    hpks_hdr_l equ $-hpks_hdr
+    lbl_S     db "S (signature): "
+    lbl_S_l   equ $-lbl_S
+    lbl_V     db "V (verified) : "
+    lbl_V_l   equ $-lbl_V
+
+    hpke_hdr  db 10, "--- HPKE (public key encryption)", 10
+    hpke_hdr_l equ $-hpke_hdr
+    lbl_Eb    db "E (Bob)  : "
+    lbl_Eb_l  equ $-lbl_Eb
+    lbl_Da    db "D (Alice): "
+    lbl_Da_l  equ $-lbl_Da
+
+    pass_msg  db "+ correct!", 10
+    pass_l    equ $-pass_msg
+    fail_msg  db "- INCORRECT!", 10
+    fail_l    equ $-fail_msg
+
+section .bss
+    hex_buf resb 12         ; "0x" + 8 hex digits + newline + spare
+
+section .text
+global _start
+
+_start:
+    ; ------------------------------------------------------------------ header
+    mov  eax, hdr
+    mov  ecx, hdr_l
+    call print_str
+
+    ; ------------------------------------------------------------------ print inputs
+    mov  eax, lbl_A
+    mov  ecx, lbl_A_l
+    call print_str
+    mov  eax, [val_A]
+    call print_hex32
+
+    mov  eax, lbl_B
+    mov  ecx, lbl_B_l
+    call print_str
+    mov  eax, [val_B]
+    call print_hex32
+
+    mov  eax, lbl_A2
+    mov  ecx, lbl_A2_l
+    call print_str
+    mov  eax, [val_A2]
+    call print_hex32
+
+    mov  eax, lbl_B2
+    mov  ecx, lbl_B2_l
+    call print_str
+    mov  eax, [val_B2]
+    call print_hex32
+
+    mov  eax, lbl_key
+    mov  ecx, lbl_key_l
+    call print_str
+    mov  eax, [val_key]
+    call print_hex32
+
+    mov  eax, lbl_plain
+    mov  ecx, lbl_pl_l
+    call print_str
+    mov  eax, [val_plain]
+    call print_hex32
+
+    ; ---- C = fscx_revolve(A, B, I_VALUE)
+    mov  eax, [val_A]
+    mov  ebx, [val_B]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [val_C], eax
+
+    mov  eax, lbl_C
+    mov  ecx, lbl_C_l
+    call print_str
+    mov  eax, [val_C]
+    call print_hex32
+
+    ; ---- C2 = fscx_revolve(A2, B2, I_VALUE)
+    mov  eax, [val_A2]
+    mov  ebx, [val_B2]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [val_C2], eax
+
+    mov  eax, lbl_C2
+    mov  ecx, lbl_C2_l
+    call print_str
+    mov  eax, [val_C2]
+    call print_hex32
+
+    ; ---- hkex_nonce = C ^ C2
+    mov  eax, [val_C]
+    xor  eax, [val_C2]
+    mov  [val_hn], eax
+
+    mov  eax, lbl_hn
+    mov  ecx, lbl_hn_l
+    call print_str
+    mov  eax, [val_hn]
+    call print_hex32
+
+    ; ================================================================== HKEX
+    mov  eax, hkex_hdr
+    mov  ecx, hkex_hdr_l
+    call print_str
+
+    ; skeyA = fscx_revolve_n(C2, B, R_VALUE, &val_hn) ^ A
+    mov  eax, [val_C2]
+    mov  ebx, [val_B]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A]
+    mov  [val_skA], eax
+
+    mov  eax, lbl_skA
+    mov  ecx, lbl_skA_l
+    call print_str
+    mov  eax, [val_skA]
+    call print_hex32
+
+    ; skeyB = fscx_revolve_n(C, B2, R_VALUE, &val_hn) ^ A2
+    mov  eax, [val_C]
+    mov  ebx, [val_B2]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A2]
+    mov  [val_skB], eax
+
+    mov  eax, lbl_skB
+    mov  ecx, lbl_skB_l
+    call print_str
+    mov  eax, [val_skB]
+    call print_hex32
+
+    ; pass/fail
+    mov  eax, [val_skA]
+    cmp  eax, [val_skB]
+    jne  .hkex_fail
+    mov  eax, pass_msg
+    mov  ecx, pass_l
+    call print_str
+    jmp  .hkex_done
+.hkex_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_l
+    call print_str
+.hkex_done:
+
+    ; ================================================================== HSKE
+    mov  eax, hske_hdr
+    mov  ecx, hske_hdr_l
+    call print_str
+
+    ; E = fscx_revolve_n(plaintext, key, I_VALUE, &val_key)
+    mov  eax, [val_plain]
+    mov  ebx, [val_key]
+    mov  ecx, I_VALUE
+    mov  esi, val_key
+    call FSCX_revolve_n
+    mov  [val_E], eax
+
+    mov  eax, lbl_E
+    mov  ecx, lbl_E_l
+    call print_str
+    mov  eax, [val_E]
+    call print_hex32
+
+    ; D = fscx_revolve_n(E, key, R_VALUE, &val_key)
+    mov  eax, [val_E]
+    mov  ebx, [val_key]
+    mov  ecx, R_VALUE
+    mov  esi, val_key
+    call FSCX_revolve_n
+    mov  [val_D], eax
+
+    mov  eax, lbl_D
+    mov  ecx, lbl_D_l
+    call print_str
+    mov  eax, [val_D]
+    call print_hex32
+
+    ; pass/fail: D == plaintext
+    mov  eax, [val_D]
+    cmp  eax, [val_plain]
+    jne  .hske_fail
+    mov  eax, pass_msg
+    mov  ecx, pass_l
+    call print_str
+    jmp  .hske_done
+.hske_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_l
+    call print_str
+.hske_done:
+
+    ; ================================================================== HPKS
+    mov  eax, hpks_hdr
+    mov  ecx, hpks_hdr_l
+    call print_str
+
+    ; S = fscx_revolve_n(C2, B, R_VALUE, &val_hn) ^ A ^ plaintext
+    mov  eax, [val_C2]
+    mov  ebx, [val_B]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A]
+    xor  eax, [val_plain]
+    mov  [val_S], eax
+
+    mov  eax, lbl_S
+    mov  ecx, lbl_S_l
+    call print_str
+    mov  eax, [val_S]
+    call print_hex32
+
+    ; V = fscx_revolve_n(C, B2, R_VALUE, &val_hn) ^ A2 ^ S   (should == plaintext)
+    mov  eax, [val_C]
+    mov  ebx, [val_B2]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A2]
+    xor  eax, [val_S]
+    mov  [val_V], eax
+
+    mov  eax, lbl_V
+    mov  ecx, lbl_V_l
+    call print_str
+    mov  eax, [val_V]
+    call print_hex32
+
+    ; pass/fail: V == plaintext
+    mov  eax, [val_V]
+    cmp  eax, [val_plain]
+    jne  .hpks_fail
+    mov  eax, pass_msg
+    mov  ecx, pass_l
+    call print_str
+    jmp  .hpks_done
+.hpks_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_l
+    call print_str
+.hpks_done:
+
+    ; ================================================================== HPKE
+    mov  eax, hpke_hdr
+    mov  ecx, hpke_hdr_l
+    call print_str
+
+    ; E = fscx_revolve_n(C, B2, R_VALUE, &val_hn) ^ A2 ^ plaintext   (Bob encrypts)
+    mov  eax, [val_C]
+    mov  ebx, [val_B2]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A2]
+    xor  eax, [val_plain]
+    mov  [val_E], eax
+
+    mov  eax, lbl_Eb
+    mov  ecx, lbl_Eb_l
+    call print_str
+    mov  eax, [val_E]
+    call print_hex32
+
+    ; D = fscx_revolve_n(C2, B, R_VALUE, &val_hn) ^ A ^ E   (Alice decrypts, should == plaintext)
+    mov  eax, [val_C2]
+    mov  ebx, [val_B]
+    mov  ecx, R_VALUE
+    mov  esi, val_hn
+    call FSCX_revolve_n
+    xor  eax, [val_A]
+    xor  eax, [val_E]
+    mov  [val_D], eax
+
+    mov  eax, lbl_Da
+    mov  ecx, lbl_Da_l
+    call print_str
+    mov  eax, [val_D]
+    call print_hex32
+
+    ; pass/fail: D == plaintext
+    mov  eax, [val_D]
+    cmp  eax, [val_plain]
+    jne  .hpke_fail
+    mov  eax, pass_msg
+    mov  ecx, pass_l
+    call print_str
+    jmp  .hpke_done
+.hpke_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_l
+    call print_str
+.hpke_done:
+
+    ; ------------------------------------------------------------------ exit
+    mov  eax, SYS_EXIT
+    xor  ebx, ebx
+    int  0x80
+
+; ============================================================
+; print_str: EAX = pointer, ECX = length
+; ============================================================
+print_str:
+    push ebx
+    push edx
+    mov  edx, ecx       ; length
+    mov  ecx, eax       ; buffer
+    mov  eax, SYS_WRITE
+    mov  ebx, STDOUT
+    int  0x80
+    pop  edx
+    pop  ebx
+    ret
+
+; ============================================================
+; print_hex32: EAX = 32-bit value  -->  prints "0x########\n"
+; ============================================================
+print_hex32:
+    push ebx
+    push ecx
+    push edx
+    push esi
+    push edi
+
+    mov  byte [hex_buf],    '0'
+    mov  byte [hex_buf+1],  'x'
+    mov  byte [hex_buf+10], 10      ; newline
+
+    ; fill nibbles LSB-first into positions 9..2
+    mov  edi, hex_buf+9
+    mov  ecx, 8
+.nh_loop:
+    mov  edx, eax
+    and  edx, 0x0F
+    cmp  dl, 10
+    jl   .nh_decimal
+    add  dl, 'a'-10
+    jmp  .nh_store
+.nh_decimal:
+    add  dl, '0'
+.nh_store:
+    mov  [edi], dl
+    dec  edi
+    shr  eax, 4
+    loop .nh_loop
+
+    mov  eax, SYS_WRITE
+    mov  ebx, STDOUT
+    mov  ecx, hex_buf
+    mov  edx, 11
+    int  0x80
+
+    pop  edi
+    pop  esi
+    pop  edx
+    pop  ecx
+    pop  ebx
+    ret
+
+; ============================================================
+; FSCX_revolve: EAX=A, EBX=B, ECX=rounds  -->  EAX=result
+; FSCX(A,B) = A ^ B ^ ROL(A,1) ^ ROL(B,1) ^ ROR(A,1) ^ ROR(B,1)
+; B is kept constant across all iterations.
+; ============================================================
+FSCX_revolve:
+    push eax
+    pop  edx            ; edx = running result (starts as A)
+.fscx_loop:
+    xor  edx, ebx       ; edx ^= B
+    rol  eax, 1         ; eax = ROL(A,1)
+    xor  edx, eax       ; edx ^= ROL(A)
+    ror  eax, 2         ; eax = ROR(A,1)  [undo ROL, then ROR]
+    xor  edx, eax       ; edx ^= ROR(A)
+    rol  ebx, 1         ; ebx = ROL(B,1)
+    xor  edx, ebx       ; edx ^= ROL(B)
+    ror  ebx, 2         ; ebx = ROR(B,1)
+    xor  edx, ebx       ; edx ^= ROR(B)
+    rol  ebx, 1         ; ebx restored to B
+    mov  eax, edx       ; eax = FSCX result (new A for next iteration)
+    loop .fscx_loop
+    ret                 ; EAX = result
+
+; ============================================================
+; FSCX_revolve_n: EAX=A, EBX=B, ECX=rounds, ESI=&nonce
+;                 -->  EAX=result
+; Like FSCX_revolve but XORs [ESI] (nonce) after each step.
+; ESI is not clobbered.
+; ============================================================
+FSCX_revolve_n:
+    push eax
+    pop  edx            ; edx = running result (starts as A)
+.fscxn_loop:
+    xor  edx, ebx       ; edx ^= B
+    rol  eax, 1
+    xor  edx, eax       ; edx ^= ROL(A)
+    ror  eax, 2
+    xor  edx, eax       ; edx ^= ROR(A)
+    rol  ebx, 1
+    xor  edx, ebx       ; edx ^= ROL(B)
+    ror  ebx, 2
+    xor  edx, ebx       ; edx ^= ROR(B)
+    rol  ebx, 1         ; ebx restored to B
+    xor  edx, [esi]     ; edx ^= nonce  (nonce-augmented step)
+    mov  eax, edx       ; eax = new A for next iteration
+    loop .fscxn_loop
+    ret                 ; EAX = result

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,0 +1,165 @@
+/*  Herradura Cryptographic Suite v1.3.7 — Arduino (32-bit)
+    HKEX, HSKE, HPKS, HPKE with FSCX_REVOLVE_N, KEYBITS = 32
+
+    Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+    MIT License / GPL v3.0 — choose either.
+
+    Target: Arduino Uno/Mega/Leonardo or any board with Serial support.
+    Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno Herradura\ cryptographic\ suite.ino
+    Monitor: 9600 baud serial monitor.
+*/
+
+#define KEYBITS  32
+#define I_VALUE  (KEYBITS / 4)        /* 8  */
+#define R_VALUE  (3 * KEYBITS / 4)    /* 24 */
+
+typedef unsigned long uint32;
+
+/* Fixed test vectors (same as C suite) */
+const uint32 A     = 0xDEADBEEFUL;
+const uint32 B     = 0xCAFEBABEUL;
+const uint32 A2    = 0x12345678UL;
+const uint32 B2    = 0xABCDEF01UL;
+const uint32 K     = 0x5A5A5A5AUL;   /* preshared key   */
+const uint32 PLAIN = 0xDEADC0DEUL;
+
+/* ------------------------------------------------------------------ */
+/* FSCX primitives                                                     */
+/* ------------------------------------------------------------------ */
+
+uint32 rol32(uint32 x) { return (x << 1) | (x >> 31); }
+uint32 ror32(uint32 x) { return (x >> 1) | (x << 31); }
+
+uint32 fscx(uint32 a, uint32 b) {
+    return a ^ b ^ rol32(a) ^ rol32(b) ^ ror32(a) ^ ror32(b);
+}
+
+uint32 fscx_revolve(uint32 a, uint32 b, int steps) {
+    for (int i = 0; i < steps; i++) a = fscx(a, b);
+    return a;
+}
+
+uint32 fscx_revolve_n(uint32 a, uint32 b, uint32 nonce, int steps) {
+    for (int i = 0; i < steps; i++) a = fscx(a, b) ^ nonce;
+    return a;
+}
+
+/* ------------------------------------------------------------------ */
+/* Hex printing helpers                                                */
+/* ------------------------------------------------------------------ */
+
+/* Print an 8-digit zero-padded hex value followed by a newline. */
+static void printHex(uint32 val) {
+    /* Print leading zeros manually so output is always 8 hex digits. */
+    char buf[9];
+    for (int i = 7; i >= 0; i--) {
+        buf[i] = "0123456789ABCDEF"[val & 0xF];
+        val >>= 4;
+    }
+    buf[8] = '\0';
+    Serial.println(buf);
+}
+
+/* Print label, then zero-padded 8-digit hex, then newline. */
+static void printHexLine(const char *label, uint32 val) {
+    Serial.print(label);
+    printHex(val);
+}
+
+/* ------------------------------------------------------------------ */
+/* Arduino entry points                                                */
+/* ------------------------------------------------------------------ */
+
+void setup() {
+    Serial.begin(9600);
+    while (!Serial) {
+        ; /* wait for serial port — needed for Leonardo/Due */
+    }
+}
+
+void loop() {
+    Serial.println("=== Herradura Cryptographic Suite (Arduino, 32-bit) ===");
+    Serial.println();
+
+    /* --- Shared public values --- */
+    uint32 C  = fscx_revolve(A,  B,  I_VALUE);
+    uint32 C2 = fscx_revolve(A2, B2, I_VALUE);
+    uint32 hn = C ^ C2;   /* HKEX nonce derived from public values */
+
+    printHexLine("A      : ", A);
+    printHexLine("B      : ", B);
+    printHexLine("A2     : ", A2);
+    printHexLine("B2     : ", B2);
+    printHexLine("K      : ", K);
+    printHexLine("PLAIN  : ", PLAIN);
+    printHexLine("C      : ", C);
+    printHexLine("C2     : ", C2);
+    printHexLine("hn     : ", hn);
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* HKEX (key exchange)                                              */
+    /* skeyA = fscx_revolve_n(C2, B,  hn, R) ^ A                       */
+    /* skeyB = fscx_revolve_n(C,  B2, hn, R) ^ A2                      */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- HKEX (key exchange)");
+    uint32 skeyA = fscx_revolve_n(C2, B,  hn, R_VALUE) ^ A;
+    uint32 skeyB = fscx_revolve_n(C,  B2, hn, R_VALUE) ^ A2;
+    printHexLine("skeyA (Alice): ", skeyA);
+    printHexLine("skeyB (Bob)  : ", skeyB);
+    if (skeyA == skeyB)
+        Serial.println("+ session keys skeyA and skeyB are equal!");
+    else
+        Serial.println("- session keys skeyA and skeyB are different!");
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* HSKE (symmetric key encryption)                                  */
+    /* E = fscx_revolve_n(PLAIN, K, K, I)                               */
+    /* D = fscx_revolve_n(E,     K, K, R)   => PLAIN                   */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- HSKE (symmetric key encryption)");
+    uint32 hskeE = fscx_revolve_n(PLAIN, K, K, I_VALUE);
+    uint32 hskeD = fscx_revolve_n(hskeE, K, K, R_VALUE);
+    printHexLine("E (Alice) : ", hskeE);
+    printHexLine("D (Bob)   : ", hskeD);
+    if (hskeD == PLAIN)
+        Serial.println("+ plaintext is correctly decrypted from E with preshared key");
+    else
+        Serial.println("- plaintext is different from decrypted E with preshared key!");
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* HPKS (public key signature)                                      */
+    /* S = fscx_revolve_n(C2, B,  hn, R) ^ A  ^ PLAIN                  */
+    /* V = fscx_revolve_n(C,  B2, hn, R) ^ A2 ^ S     => PLAIN         */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- HPKS (public key signature)");
+    uint32 hpksS = fscx_revolve_n(C2, B,  hn, R_VALUE) ^ A  ^ PLAIN;
+    uint32 hpksV = fscx_revolve_n(C,  B2, hn, R_VALUE) ^ A2 ^ hpksS;
+    printHexLine("S (Alice) : ", hpksS);
+    printHexLine("V (Bob)   : ", hpksV);
+    if (hpksV == PLAIN)
+        Serial.println("+ signature S from plaintext is correct!");
+    else
+        Serial.println("- signature S from plaintext is incorrect!");
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* HPKE (public key encryption)                                     */
+    /* E = fscx_revolve_n(C,  B2, hn, R) ^ A2 ^ PLAIN                  */
+    /* D = fscx_revolve_n(C2, B,  hn, R) ^ A  ^ E      => PLAIN        */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- HPKE (public key encryption)");
+    uint32 hpkeE = fscx_revolve_n(C,  B2, hn, R_VALUE) ^ A2 ^ PLAIN;
+    uint32 hpkeD = fscx_revolve_n(C2, B,  hn, R_VALUE) ^ A  ^ hpkeE;
+    printHexLine("E (Bob)   : ", hpkeE);
+    printHexLine("D (Alice) : ", hpkeD);
+    if (hpkeD == PLAIN)
+        Serial.println("+ plaintext is correctly decrypted from E with private key!");
+    else
+        Serial.println("- plaintext is different from decrypted E with private key!");
+    Serial.println();
+
+    delay(10000);
+}

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,0 +1,541 @@
+/*  Herradura Cryptographic Suite v1.3.7
+    ARM 32-bit Thumb Assembly (GAS) — HKEX, HSKE, HPKS, HPKE with FSCX_REVOLVE_N
+    KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
+
+    Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+    MIT License / GPL v3.0 — choose either.
+
+    Build: arm-linux-gnueabi-gcc -o "Herradura cryptographic suite_arm" "Herradura cryptographic suite.s"
+    Run:   qemu-arm "./Herradura cryptographic suite_arm"
+        or directly on ARM hardware
+*/
+
+    .syntax unified
+    .cpu cortex-a7
+    .thumb
+
+    .extern printf
+    .extern exit
+
+/* ------------------------------------------------------------------ */
+/* .data section: constants, test vectors, result storage             */
+/* ------------------------------------------------------------------ */
+    .data
+    .balign 4
+
+/* -- format strings -- */
+fmt_header: .asciz "=== Herradura Cryptographic Suite (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_hex:    .asciz "%s: 0x%08x\n"
+fmt_nl:     .asciz "\n"
+
+lbl_A:      .asciz "A        "
+lbl_B:      .asciz "B        "
+lbl_A2:     .asciz "A2       "
+lbl_B2:     .asciz "B2       "
+lbl_key:    .asciz "key      "
+lbl_plain:  .asciz "plain    "
+lbl_C:      .asciz "C        "
+lbl_C2:     .asciz "C2       "
+lbl_hn:     .asciz "hkex_nonce"
+lbl_skeyA:  .asciz "skeyA    "
+lbl_skeyB:  .asciz "skeyB    "
+lbl_E_hske: .asciz "E (HSKE) "
+lbl_D_hske: .asciz "D (HSKE) "
+lbl_S_hpks: .asciz "S (HPKS) "
+lbl_V_hpks: .asciz "V (HPKS) "
+lbl_E_hpke: .asciz "E (HPKE) "
+lbl_D_hpke: .asciz "D (HPKE) "
+
+fmt_hkex_hdr:   .asciz "-- HKEX --\n"
+fmt_hske_hdr:   .asciz "-- HSKE --\n"
+fmt_hpks_hdr:   .asciz "-- HPKS --\n"
+fmt_hpke_hdr:   .asciz "-- HPKE --\n"
+
+fmt_hkex_ok:    .asciz "+ HKEX correct!\n"
+fmt_hkex_fail:  .asciz "- HKEX INCORRECT!\n"
+fmt_hske_ok:    .asciz "+ HSKE correct!\n"
+fmt_hske_fail:  .asciz "- HSKE INCORRECT!\n"
+fmt_hpks_ok:    .asciz "+ HPKS correct!\n"
+fmt_hpks_fail:  .asciz "- HPKS INCORRECT!\n"
+fmt_hpke_ok:    .asciz "+ HPKE correct!\n"
+fmt_hpke_fail:  .asciz "- HPKE INCORRECT!\n"
+
+    .balign 4
+/* -- fixed test vectors -- */
+val_A:      .word 0xDEADBEEF
+val_B:      .word 0xCAFEBABE
+val_A2:     .word 0x12345678
+val_B2:     .word 0xABCDEF01
+val_key:    .word 0x5A5A5A5A
+val_plain:  .word 0xDEADC0DE
+
+/* -- derived / result storage -- */
+val_C:      .word 0
+val_C2:     .word 0
+val_hn:     .word 0
+val_skeyA:  .word 0
+val_skeyB:  .word 0
+val_E_hske: .word 0
+val_D_hske: .word 0
+val_S_hpks: .word 0
+val_V_hpks: .word 0
+val_E_hpke: .word 0
+val_D_hpke: .word 0
+
+/* ------------------------------------------------------------------ */
+/* .text section                                                       */
+/* ------------------------------------------------------------------ */
+    .text
+    .global main
+    .thumb_func
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+main:
+    push    {r4-r11, lr}
+
+    /* ---- print header ---- */
+    ldr     r0, =fmt_header
+    bl      printf
+
+    /* ================================================================
+       Compute C = fscx_revolve(A, B, I_VALUE=8)
+       ================================================================ */
+    ldr     r0, =val_A
+    ldr     r0, [r0]
+    ldr     r1, =val_B
+    ldr     r1, [r1]
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =val_C
+    str     r0, [r3]
+
+    /* ================================================================
+       Compute C2 = fscx_revolve(A2, B2, I_VALUE=8)
+       ================================================================ */
+    ldr     r0, =val_A2
+    ldr     r0, [r0]
+    ldr     r1, =val_B2
+    ldr     r1, [r1]
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =val_C2
+    str     r0, [r3]
+
+    /* ================================================================
+       Compute hkex_nonce = C ^ C2
+       ================================================================ */
+    ldr     r0, =val_C
+    ldr     r0, [r0]
+    ldr     r1, =val_C2
+    ldr     r1, [r1]
+    eor     r0, r0, r1
+    ldr     r3, =val_hn
+    str     r0, [r3]
+
+    /* ----------------------------------------------------------------
+       Print shared values
+       ---------------------------------------------------------------- */
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_A
+    ldr     r2, =val_A
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_B
+    ldr     r2, =val_B
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_A2
+    ldr     r2, =val_A2
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_B2
+    ldr     r2, =val_B2
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_C
+    ldr     r2, =val_C
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_C2
+    ldr     r2, =val_C2
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_hn
+    ldr     r2, =val_hn
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_nl
+    bl      printf
+
+    /* ================================================================
+       HKEX
+       skeyA = fscx_revolve_n(C2, B, R_VALUE=24, hn) ^ A
+       skeyB = fscx_revolve_n(C,  B2, R_VALUE=24, hn) ^ A2
+       ================================================================ */
+    ldr     r0, =fmt_hkex_hdr
+    bl      printf
+
+    /* skeyA */
+    ldr     r0, =val_C2
+    ldr     r0, [r0]
+    ldr     r1, =val_B
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_skeyA
+    str     r0, [r3]
+
+    /* skeyB */
+    ldr     r0, =val_C
+    ldr     r0, [r0]
+    ldr     r1, =val_B2
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A2
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_skeyB
+    str     r0, [r3]
+
+    /* print skeyA, skeyB */
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_skeyA
+    ldr     r2, =val_skeyA
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_skeyB
+    ldr     r2, =val_skeyB
+    ldr     r2, [r2]
+    bl      printf
+
+    /* verify HKEX */
+    ldr     r0, =val_skeyA
+    ldr     r0, [r0]
+    ldr     r1, =val_skeyB
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hkex_fail
+    ldr     r0, =fmt_hkex_ok
+    bl      printf
+    b       hkex_done
+hkex_fail:
+    ldr     r0, =fmt_hkex_fail
+    bl      printf
+hkex_done:
+    ldr     r0, =fmt_nl
+    bl      printf
+
+    /* ================================================================
+       HSKE
+       E = fscx_revolve_n(plain, key, I_VALUE=8, key)
+       D = fscx_revolve_n(E,     key, R_VALUE=24, key)
+       assert D == plain
+       ================================================================ */
+    ldr     r0, =fmt_hske_hdr
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_key
+    ldr     r2, =val_key
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_plain
+    ldr     r2, =val_plain
+    ldr     r2, [r2]
+    bl      printf
+
+    /* E = fscx_revolve_n(plain, key, 8, key) */
+    ldr     r0, =val_plain
+    ldr     r0, [r0]
+    ldr     r1, =val_key
+    ldr     r1, [r1]
+    mov     r2, #8
+    ldr     r3, =val_key
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_E_hske
+    str     r0, [r3]
+
+    /* D = fscx_revolve_n(E, key, 24, key) */
+    ldr     r0, =val_E_hske
+    ldr     r0, [r0]
+    ldr     r1, =val_key
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_key
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_D_hske
+    str     r0, [r3]
+
+    /* print */
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_E_hske
+    ldr     r2, =val_E_hske
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_D_hske
+    ldr     r2, =val_D_hske
+    ldr     r2, [r2]
+    bl      printf
+
+    /* verify */
+    ldr     r0, =val_D_hske
+    ldr     r0, [r0]
+    ldr     r1, =val_plain
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hske_fail
+    ldr     r0, =fmt_hske_ok
+    bl      printf
+    b       hske_done
+hske_fail:
+    ldr     r0, =fmt_hske_fail
+    bl      printf
+hske_done:
+    ldr     r0, =fmt_nl
+    bl      printf
+
+    /* ================================================================
+       HPKS
+       S = fscx_revolve_n(C2, B, R=24, hn) ^ A ^ plain
+       V = fscx_revolve_n(C, B2, R=24, hn) ^ A2 ^ S
+       assert V == plain
+       ================================================================ */
+    ldr     r0, =fmt_hpks_hdr
+    bl      printf
+
+    /* S = fscx_revolve_n(C2, B, 24, hn) ^ A ^ plain */
+    ldr     r0, =val_C2
+    ldr     r0, [r0]
+    ldr     r1, =val_B
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_plain
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_S_hpks
+    str     r0, [r3]
+
+    /* V = fscx_revolve_n(C, B2, 24, hn) ^ A2 ^ S */
+    ldr     r0, =val_C
+    ldr     r0, [r0]
+    ldr     r1, =val_B2
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A2
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_S_hpks
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_V_hpks
+    str     r0, [r3]
+
+    /* print */
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_S_hpks
+    ldr     r2, =val_S_hpks
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_V_hpks
+    ldr     r2, =val_V_hpks
+    ldr     r2, [r2]
+    bl      printf
+
+    /* verify */
+    ldr     r0, =val_V_hpks
+    ldr     r0, [r0]
+    ldr     r1, =val_plain
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hpks_fail
+    ldr     r0, =fmt_hpks_ok
+    bl      printf
+    b       hpks_done
+hpks_fail:
+    ldr     r0, =fmt_hpks_fail
+    bl      printf
+hpks_done:
+    ldr     r0, =fmt_nl
+    bl      printf
+
+    /* ================================================================
+       HPKE
+       E = fscx_revolve_n(C, B2, R=24, hn) ^ A2 ^ plain
+       D = fscx_revolve_n(C2, B, R=24, hn) ^ A ^ E
+       assert D == plain
+       ================================================================ */
+    ldr     r0, =fmt_hpke_hdr
+    bl      printf
+
+    /* E = fscx_revolve_n(C, B2, 24, hn) ^ A2 ^ plain */
+    ldr     r0, =val_C
+    ldr     r0, [r0]
+    ldr     r1, =val_B2
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A2
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_plain
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_E_hpke
+    str     r0, [r3]
+
+    /* D = fscx_revolve_n(C2, B, 24, hn) ^ A ^ E */
+    ldr     r0, =val_C2
+    ldr     r0, [r0]
+    ldr     r1, =val_B
+    ldr     r1, [r1]
+    mov     r2, #24
+    ldr     r3, =val_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    ldr     r3, =val_A
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_E_hpke
+    ldr     r3, [r3]
+    eor     r0, r0, r3
+    ldr     r3, =val_D_hpke
+    str     r0, [r3]
+
+    /* print */
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_E_hpke
+    ldr     r2, =val_E_hpke
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_D_hpke
+    ldr     r2, =val_D_hpke
+    ldr     r2, [r2]
+    bl      printf
+
+    /* verify */
+    ldr     r0, =val_D_hpke
+    ldr     r0, [r0]
+    ldr     r1, =val_plain
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hpke_fail
+    ldr     r0, =fmt_hpke_ok
+    bl      printf
+    b       hpke_done
+hpke_fail:
+    ldr     r0, =fmt_hpke_fail
+    bl      printf
+hpke_done:
+
+    mov     r0, #0
+    bl      exit
+
+    .ltorg
+
+/* ------------------------------------------------------------------ */
+/* fscx_revolve: r0=A, r1=B, r2=rounds -> r0=result                  */
+/*   FSCX(A,B) = A^B^ROL(A,1)^ROL(B,1)^ROR(A,1)^ROR(B,1)            */
+/*   ROL(x,1)  = ROR(x,31)  in ARM rotate terms                       */
+/*   ROR(x,1)  = ROR(x,1)                                             */
+/*   Clobbers r4-r6 (saved/restored via push/pop)                     */
+/* ------------------------------------------------------------------ */
+    .thumb_func
+fscx_revolve:
+    push    {r4-r7, lr}
+    mov     r4, r0              @ r4 = current A (evolves each round)
+                                @ r1 = B (constant)
+1:
+    eor     r5, r4, r1          @ r5 = A ^ B
+    ror     r6, r4, #1
+    eor     r5, r5, r6          @ ^ ROR(A,1)
+    ror     r6, r1, #1
+    eor     r5, r5, r6          @ ^ ROR(B,1)
+    ror     r6, r4, #31
+    eor     r5, r5, r6          @ ^ ROL(A,1)
+    ror     r6, r1, #31
+    eor     r5, r5, r6          @ ^ ROL(B,1)
+    mov     r4, r5
+    subs    r2, r2, #1
+    bne     1b
+    mov     r0, r4
+    pop     {r4-r7, pc}
+
+    .ltorg
+
+/* ------------------------------------------------------------------ */
+/* fscx_revolve_n: r0=A, r1=B, r2=rounds, r3=nonce -> r0=result      */
+/*   Each step: result = FSCX(result, B) ^ nonce                      */
+/*   Clobbers r4-r6 (saved/restored via push/pop)                     */
+/* ------------------------------------------------------------------ */
+    .thumb_func
+fscx_revolve_n:
+    push    {r4-r7, lr}
+    mov     r4, r0              @ r4 = current A
+                                @ r1 = B (constant)
+                                @ r3 = nonce (constant)
+2:
+    eor     r5, r4, r1          @ r5 = A ^ B
+    ror     r6, r4, #1
+    eor     r5, r5, r6          @ ^ ROR(A,1)
+    ror     r6, r1, #1
+    eor     r5, r5, r6          @ ^ ROR(B,1)
+    ror     r6, r4, #31
+    eor     r5, r5, r6          @ ^ ROL(A,1)
+    ror     r6, r1, #31
+    eor     r5, r5, r6          @ ^ ROL(B,1)
+    eor     r5, r5, r3          @ ^ nonce
+    mov     r4, r5
+    subs    r2, r2, #1
+    bne     2b
+    mov     r0, r4
+    pop     {r4-r7, pc}
+
+    .ltorg
+
+    .section .note.GNU-stack,"",%progbits

--- a/Herradura_tests.asm
+++ b/Herradura_tests.asm
@@ -1,0 +1,431 @@
+;  Herradura KEx -- Correctness Tests v1.3.7
+;  NASM i386 Assembly -- HKEX, HSKE, HPKS, HPKE correctness tests
+;  100 LCG-random iterations per test, KEYBITS=32, I_VALUE=8, R_VALUE=24
+;
+;  Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+;  MIT License / GPL v3.0 -- choose either.
+;
+;  Assemble: nasm -f elf32 Herradura_tests.asm -o tests32.o
+;  Link:     ld -m elf_i386 -o Herradura_tests_i386 tests32.o
+;  Run:      ./Herradura_tests_i386  (x86_32 Linux) or  qemu-i386 ./Herradura_tests_i386
+
+%define SYS_EXIT   1
+%define SYS_WRITE  4
+%define STDOUT     1
+%define I_VALUE    8
+%define R_VALUE    24
+
+section .data
+
+    prng_state dd 0x12345678
+
+    hdr        db "=== Herradura KEx -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr_l      equ $-hdr
+
+    t1_hdr     db "[1] HKEX key exchange correctness: skeyA == skeyB", 10
+    t1_hdr_l   equ $-t1_hdr
+    t2_hdr     db "[2] HSKE encrypt+decrypt round-trip: D == plaintext", 10
+    t2_hdr_l   equ $-t2_hdr
+    t3_hdr     db "[3] HPKS sign+verify correctness: V == plaintext", 10
+    t3_hdr_l   equ $-t3_hdr
+    t4_hdr     db "[4] HPKE encrypt+decrypt round-trip: D == plaintext", 10
+    t4_hdr_l   equ $-t4_hdr
+
+    pass100    db "    100 / 100 passed  [PASS]", 10
+    pass100_l  equ $-pass100
+    fail_msg   db "    FAILED            [FAIL]", 10
+    fail_msg_l equ $-fail_msg
+
+section .bss
+
+    t_A        resd 1
+    t_B        resd 1
+    t_A2       resd 1
+    t_B2       resd 1
+    t_C        resd 1
+    t_C2       resd 1
+    t_hn       resd 1
+    t_val      resd 1   ; scratch / plaintext / key
+    t_key      resd 1
+    t_E        resd 1
+    t_S        resd 1
+
+    hex_buf    resb 12
+
+section .text
+global _start
+
+_start:
+    mov  eax, hdr
+    mov  ecx, hdr_l
+    call print_str
+
+    ; ================================================================== [1] HKEX
+    mov  eax, t1_hdr
+    mov  ecx, t1_hdr_l
+    call print_str
+
+    mov  ecx, 100
+    xor  ebp, ebp           ; pass counter
+
+.t1_loop:
+    push ecx
+
+    ; A, B, A2, B2 = prng_next()
+    call prng_next
+    mov  [t_A], eax
+    call prng_next
+    mov  [t_B], eax
+    call prng_next
+    mov  [t_A2], eax
+    call prng_next
+    mov  [t_B2], eax
+
+    ; C = fscx_revolve(A, B, I_VALUE)
+    mov  eax, [t_A]
+    mov  ebx, [t_B]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C], eax
+
+    ; C2 = fscx_revolve(A2, B2, I_VALUE)
+    mov  eax, [t_A2]
+    mov  ebx, [t_B2]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C2], eax
+
+    ; hkex_nonce = C ^ C2
+    mov  eax, [t_C]
+    xor  eax, [t_C2]
+    mov  [t_hn], eax
+
+    ; skeyA = fscx_revolve_n(C2, B, R_VALUE, &t_hn) ^ A
+    mov  eax, [t_C2]
+    mov  ebx, [t_B]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A]
+    mov  [t_val], eax       ; save skeyA
+
+    ; skeyB = fscx_revolve_n(C, B2, R_VALUE, &t_hn) ^ A2
+    mov  eax, [t_C]
+    mov  ebx, [t_B2]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A2]        ; eax = skeyB
+
+    cmp  eax, [t_val]       ; skeyB == skeyA?
+    jne  .t1_skip
+    inc  ebp
+.t1_skip:
+    pop  ecx
+    dec  ecx
+    jnz  near .t1_loop
+
+    cmp  ebp, 100
+    jne  .t1_fail
+    mov  eax, pass100
+    mov  ecx, pass100_l
+    call print_str
+    jmp  .t1_done
+.t1_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_msg_l
+    call print_str
+.t1_done:
+
+    ; ================================================================== [2] HSKE
+    mov  eax, t2_hdr
+    mov  ecx, t2_hdr_l
+    call print_str
+
+    mov  ecx, 100
+    xor  ebp, ebp
+
+.t2_loop:
+    push ecx
+
+    call prng_next
+    mov  [t_val], eax       ; plaintext
+    call prng_next
+    mov  [t_key], eax       ; key (also used as nonce)
+
+    ; E = fscx_revolve_n(plain, key, I_VALUE, &t_key)
+    mov  eax, [t_val]
+    mov  ebx, [t_key]
+    mov  ecx, I_VALUE
+    mov  esi, t_key
+    call FSCX_revolve_n
+    mov  [t_E], eax
+
+    ; D = fscx_revolve_n(E, key, R_VALUE, &t_key)
+    mov  eax, [t_E]
+    mov  ebx, [t_key]
+    mov  ecx, R_VALUE
+    mov  esi, t_key
+    call FSCX_revolve_n     ; eax = D
+
+    cmp  eax, [t_val]       ; D == plaintext?
+    jne  .t2_skip
+    inc  ebp
+.t2_skip:
+    pop  ecx
+    dec  ecx
+    jnz  near .t2_loop
+
+    cmp  ebp, 100
+    jne  .t2_fail
+    mov  eax, pass100
+    mov  ecx, pass100_l
+    call print_str
+    jmp  .t2_done
+.t2_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_msg_l
+    call print_str
+.t2_done:
+
+    ; ================================================================== [3] HPKS
+    mov  eax, t3_hdr
+    mov  ecx, t3_hdr_l
+    call print_str
+
+    mov  ecx, 100
+    xor  ebp, ebp
+
+.t3_loop:
+    push ecx
+
+    ; A, B, A2, B2 = prng_next()
+    call prng_next
+    mov  [t_A], eax
+    call prng_next
+    mov  [t_B], eax
+    call prng_next
+    mov  [t_A2], eax
+    call prng_next
+    mov  [t_B2], eax
+    call prng_next
+    mov  [t_val], eax       ; plaintext
+
+    ; C = fscx_revolve(A, B, I_VALUE)
+    mov  eax, [t_A]
+    mov  ebx, [t_B]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C], eax
+
+    ; C2 = fscx_revolve(A2, B2, I_VALUE)
+    mov  eax, [t_A2]
+    mov  ebx, [t_B2]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C2], eax
+
+    ; hkex_nonce = C ^ C2
+    mov  eax, [t_C]
+    xor  eax, [t_C2]
+    mov  [t_hn], eax
+
+    ; S = fscx_revolve_n(C2, B, R_VALUE, &t_hn) ^ A ^ plaintext
+    mov  eax, [t_C2]
+    mov  ebx, [t_B]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A]
+    xor  eax, [t_val]
+    mov  [t_S], eax
+
+    ; V = fscx_revolve_n(C, B2, R_VALUE, &t_hn) ^ A2 ^ S  (should == plaintext)
+    mov  eax, [t_C]
+    mov  ebx, [t_B2]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A2]
+    xor  eax, [t_S]         ; eax = V
+
+    cmp  eax, [t_val]       ; V == plaintext?
+    jne  .t3_skip
+    inc  ebp
+.t3_skip:
+    pop  ecx
+    dec  ecx
+    jnz  near .t3_loop
+
+    cmp  ebp, 100
+    jne  .t3_fail
+    mov  eax, pass100
+    mov  ecx, pass100_l
+    call print_str
+    jmp  .t3_done
+.t3_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_msg_l
+    call print_str
+.t3_done:
+
+    ; ================================================================== [4] HPKE
+    mov  eax, t4_hdr
+    mov  ecx, t4_hdr_l
+    call print_str
+
+    mov  ecx, 100
+    xor  ebp, ebp
+
+.t4_loop:
+    push ecx
+
+    ; A, B, A2, B2 = prng_next()
+    call prng_next
+    mov  [t_A], eax
+    call prng_next
+    mov  [t_B], eax
+    call prng_next
+    mov  [t_A2], eax
+    call prng_next
+    mov  [t_B2], eax
+    call prng_next
+    mov  [t_val], eax       ; plaintext
+
+    ; C = fscx_revolve(A, B, I_VALUE)
+    mov  eax, [t_A]
+    mov  ebx, [t_B]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C], eax
+
+    ; C2 = fscx_revolve(A2, B2, I_VALUE)
+    mov  eax, [t_A2]
+    mov  ebx, [t_B2]
+    mov  ecx, I_VALUE
+    call FSCX_revolve
+    mov  [t_C2], eax
+
+    ; hkex_nonce = C ^ C2
+    mov  eax, [t_C]
+    xor  eax, [t_C2]
+    mov  [t_hn], eax
+
+    ; E = fscx_revolve_n(C, B2, R_VALUE, &t_hn) ^ A2 ^ plaintext   (Bob encrypts)
+    mov  eax, [t_C]
+    mov  ebx, [t_B2]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A2]
+    xor  eax, [t_val]
+    mov  [t_E], eax
+
+    ; D = fscx_revolve_n(C2, B, R_VALUE, &t_hn) ^ A ^ E   (Alice decrypts, should == plaintext)
+    mov  eax, [t_C2]
+    mov  ebx, [t_B]
+    mov  ecx, R_VALUE
+    mov  esi, t_hn
+    call FSCX_revolve_n
+    xor  eax, [t_A]
+    xor  eax, [t_E]         ; eax = D
+
+    cmp  eax, [t_val]       ; D == plaintext?
+    jne  .t4_skip
+    inc  ebp
+.t4_skip:
+    pop  ecx
+    dec  ecx
+    jnz  near .t4_loop
+
+    cmp  ebp, 100
+    jne  .t4_fail
+    mov  eax, pass100
+    mov  ecx, pass100_l
+    call print_str
+    jmp  .t4_done
+.t4_fail:
+    mov  eax, fail_msg
+    mov  ecx, fail_msg_l
+    call print_str
+.t4_done:
+
+    ; ------------------------------------------------------------------ exit
+    mov  eax, SYS_EXIT
+    xor  ebx, ebx
+    int  0x80
+
+; ============================================================
+; prng_next: LCG  state = state * 1664525 + 1013904223
+;            returns new state in EAX
+; ============================================================
+prng_next:
+    push ebx
+    push edx
+    mov  eax, [prng_state]
+    mov  ebx, 1664525
+    imul eax, ebx           ; lower 32 bits of state * 1664525
+    add  eax, 1013904223
+    mov  [prng_state], eax
+    pop  edx
+    pop  ebx
+    ret
+
+; ============================================================
+; print_str: EAX = pointer, ECX = length
+; ============================================================
+print_str:
+    push ebx
+    push edx
+    mov  edx, ecx
+    mov  ecx, eax
+    mov  eax, SYS_WRITE
+    mov  ebx, STDOUT
+    int  0x80
+    pop  edx
+    pop  ebx
+    ret
+
+; ============================================================
+; FSCX_revolve: EAX=A, EBX=B, ECX=rounds  -->  EAX=result
+; ============================================================
+FSCX_revolve:
+    push eax
+    pop  edx
+.fscx_loop:
+    xor  edx, ebx
+    rol  eax, 1
+    xor  edx, eax
+    ror  eax, 2
+    xor  edx, eax
+    rol  ebx, 1
+    xor  edx, ebx
+    ror  ebx, 2
+    xor  edx, ebx
+    rol  ebx, 1
+    mov  eax, edx
+    loop .fscx_loop
+    ret
+
+; ============================================================
+; FSCX_revolve_n: EAX=A, EBX=B, ECX=rounds, ESI=&nonce
+;                 -->  EAX=result  (ESI not clobbered)
+; ============================================================
+FSCX_revolve_n:
+    push eax
+    pop  edx
+.fscxn_loop:
+    xor  edx, ebx
+    rol  eax, 1
+    xor  edx, eax
+    ror  eax, 2
+    xor  edx, eax
+    rol  ebx, 1
+    xor  edx, ebx
+    ror  ebx, 2
+    xor  edx, ebx
+    rol  ebx, 1
+    xor  edx, [esi]         ; XOR nonce from memory
+    mov  eax, edx
+    loop .fscxn_loop
+    ret

--- a/Herradura_tests.ino
+++ b/Herradura_tests.ino
@@ -1,0 +1,169 @@
+/*  Herradura KEx — Security Tests v1.3.7 (Arduino, 32-bit)
+    HKEX, HSKE, HPKS, HPKE correctness tests with LCG PRNG (100 iterations each)
+
+    Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+    MIT License / GPL v3.0 — choose either.
+
+    Target: Any Arduino board with Serial support.
+    Upload via Arduino IDE. Monitor at 9600 baud.
+*/
+
+#define KEYBITS  32
+#define I_VALUE  (KEYBITS / 4)        /* 8  */
+#define R_VALUE  (3 * KEYBITS / 4)    /* 24 */
+
+typedef unsigned long uint32;
+
+/* ------------------------------------------------------------------ */
+/* LCG PRNG                                                            */
+/* ------------------------------------------------------------------ */
+
+uint32 prng_state = 0x12345678UL;
+
+uint32 prng_next() {
+    prng_state = prng_state * 1664525UL + 1013904223UL;
+    return prng_state;
+}
+
+/* ------------------------------------------------------------------ */
+/* FSCX primitives                                                     */
+/* ------------------------------------------------------------------ */
+
+uint32 rol32(uint32 x) { return (x << 1) | (x >> 31); }
+uint32 ror32(uint32 x) { return (x >> 1) | (x << 31); }
+
+uint32 fscx(uint32 a, uint32 b) {
+    return a ^ b ^ rol32(a) ^ rol32(b) ^ ror32(a) ^ ror32(b);
+}
+
+uint32 fscx_revolve(uint32 a, uint32 b, int steps) {
+    for (int i = 0; i < steps; i++) a = fscx(a, b);
+    return a;
+}
+
+uint32 fscx_revolve_n(uint32 a, uint32 b, uint32 nonce, int steps) {
+    for (int i = 0; i < steps; i++) a = fscx(a, b) ^ nonce;
+    return a;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test functions                                                      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * [1] HKEX key exchange correctness
+ *     skeyA = fscx_revolve_n(C2, B,  hn, R) ^ A
+ *     skeyB = fscx_revolve_n(C,  B2, hn, R) ^ A2
+ *     Pass condition: skeyA == skeyB
+ */
+void test_hkex() {
+    Serial.println("[1] HKEX key exchange correctness");
+    int pass = 0;
+    for (int i = 0; i < 100; i++) {
+        uint32 a  = prng_next(), b  = prng_next();
+        uint32 a2 = prng_next(), b2 = prng_next();
+        uint32 c  = fscx_revolve(a,  b,  I_VALUE);
+        uint32 c2 = fscx_revolve(a2, b2, I_VALUE);
+        uint32 hn = c ^ c2;
+        uint32 skA = fscx_revolve_n(c2, b,  hn, R_VALUE) ^ a;
+        uint32 skB = fscx_revolve_n(c,  b2, hn, R_VALUE) ^ a2;
+        if (skA == skB) pass++;
+    }
+    Serial.print("    "); Serial.print(pass); Serial.print(" / 100 passed  [");
+    Serial.println(pass == 100 ? "PASS]" : "FAIL]");
+    Serial.println();
+}
+
+/*
+ * [2] HSKE symmetric encryption correctness
+ *     E = fscx_revolve_n(P, key, key, I)
+ *     D = fscx_revolve_n(E, key, key, R)
+ *     Pass condition: D == P
+ */
+void test_hske() {
+    Serial.println("[2] HSKE symmetric encryption correctness");
+    int pass = 0;
+    for (int i = 0; i < 100; i++) {
+        uint32 p   = prng_next();
+        uint32 key = prng_next();
+        uint32 enc = fscx_revolve_n(p,   key, key, I_VALUE);
+        uint32 dec = fscx_revolve_n(enc, key, key, R_VALUE);
+        if (dec == p) pass++;
+    }
+    Serial.print("    "); Serial.print(pass); Serial.print(" / 100 passed  [");
+    Serial.println(pass == 100 ? "PASS]" : "FAIL]");
+    Serial.println();
+}
+
+/*
+ * [3] HPKS public key signature correctness
+ *     S = fscx_revolve_n(C2, B,  hn, R) ^ A  ^ P
+ *     V = fscx_revolve_n(C,  B2, hn, R) ^ A2 ^ S
+ *     Pass condition: V == P
+ */
+void test_hpks() {
+    Serial.println("[3] HPKS public key signature correctness");
+    int pass = 0;
+    for (int i = 0; i < 100; i++) {
+        uint32 a  = prng_next(), b  = prng_next();
+        uint32 a2 = prng_next(), b2 = prng_next();
+        uint32 p  = prng_next();
+        uint32 c  = fscx_revolve(a,  b,  I_VALUE);
+        uint32 c2 = fscx_revolve(a2, b2, I_VALUE);
+        uint32 hn = c ^ c2;
+        uint32 S  = fscx_revolve_n(c2, b,  hn, R_VALUE) ^ a  ^ p;
+        uint32 V  = fscx_revolve_n(c,  b2, hn, R_VALUE) ^ a2 ^ S;
+        if (V == p) pass++;
+    }
+    Serial.print("    "); Serial.print(pass); Serial.print(" / 100 passed  [");
+    Serial.println(pass == 100 ? "PASS]" : "FAIL]");
+    Serial.println();
+}
+
+/*
+ * [4] HPKE public key encryption correctness
+ *     E = fscx_revolve_n(C,  B2, hn, R) ^ A2 ^ P
+ *     D = fscx_revolve_n(C2, B,  hn, R) ^ A  ^ E
+ *     Pass condition: D == P
+ */
+void test_hpke() {
+    Serial.println("[4] HPKE public key encryption correctness");
+    int pass = 0;
+    for (int i = 0; i < 100; i++) {
+        uint32 a  = prng_next(), b  = prng_next();
+        uint32 a2 = prng_next(), b2 = prng_next();
+        uint32 p  = prng_next();
+        uint32 c  = fscx_revolve(a,  b,  I_VALUE);
+        uint32 c2 = fscx_revolve(a2, b2, I_VALUE);
+        uint32 hn = c ^ c2;
+        uint32 E  = fscx_revolve_n(c,  b2, hn, R_VALUE) ^ a2 ^ p;
+        uint32 D  = fscx_revolve_n(c2, b,  hn, R_VALUE) ^ a  ^ E;
+        if (D == p) pass++;
+    }
+    Serial.print("    "); Serial.print(pass); Serial.print(" / 100 passed  [");
+    Serial.println(pass == 100 ? "PASS]" : "FAIL]");
+    Serial.println();
+}
+
+/* ------------------------------------------------------------------ */
+/* Arduino entry points                                                */
+/* ------------------------------------------------------------------ */
+
+void setup() {
+    Serial.begin(9600);
+    while (!Serial) {
+        ; /* wait for serial port — needed for Leonardo/Due */
+    }
+}
+
+void loop() {
+    Serial.println("=== Herradura KEx - Security Tests (Arduino, 32-bit) ===");
+    Serial.println();
+
+    test_hkex();
+    test_hske();
+    test_hpks();
+    test_hpke();
+
+    delay(30000);
+}

--- a/Herradura_tests.s
+++ b/Herradura_tests.s
@@ -1,0 +1,551 @@
+/*  Herradura Cryptographic Suite v1.3.7 — Security Correctness Tests
+    ARM 32-bit Thumb Assembly (GAS) — HKEX, HSKE, HPKS, HPKE
+    KEYBITS = 32, I_VALUE = 8, R_VALUE = 24, 100 PRNG iterations each
+
+    Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
+    MIT License / GPL v3.0 — choose either.
+
+    Build: arm-linux-gnueabi-gcc -o Herradura_tests_arm Herradura_tests.s
+    Run:   qemu-arm ./Herradura_tests_arm
+        or directly on ARM hardware
+*/
+
+    .syntax unified
+    .cpu cortex-a7
+    .thumb
+
+    .extern printf
+    .extern exit
+
+/* ------------------------------------------------------------------ */
+/* .data section                                                       */
+/* ------------------------------------------------------------------ */
+    .data
+    .balign 4
+
+/* -- format strings -- */
+fmt_main_hdr: .asciz "=== Herradura KEx \xe2\x80\x94 Security Tests (ARM 32-bit Thumb) ===\n\n"
+
+fmt_t1_hdr:   .asciz "[1] HKEX key exchange correctness\n"
+fmt_t2_hdr:   .asciz "[2] HSKE encrypt+decrypt round-trip\n"
+fmt_t3_hdr:   .asciz "[3] HPKS sign+verify correctness\n"
+fmt_t4_hdr:   .asciz "[4] HPKE encrypt+decrypt round-trip\n"
+
+/* "    %d / 100 passed  [%s]\n" */
+fmt_result:   .asciz "    %d / 100 passed  [%s]\n\n"
+
+str_pass:     .asciz "PASS"
+str_fail:     .asciz "FAIL"
+
+/* -- PRNG state -- */
+    .balign 4
+prng_state:   .word 0x12345678
+
+/* -- scratch memory for intermediate values -- */
+    .balign 4
+test_C:       .word 0
+test_C2:      .word 0
+test_hn:      .word 0
+test_val:     .word 0     @ general temp
+
+/* LCG constants */
+    .balign 4
+lcg_mul:      .word 1664525
+lcg_add:      .word 1013904223
+
+/* ------------------------------------------------------------------ */
+/* .text section                                                       */
+/* ------------------------------------------------------------------ */
+    .text
+    .global main
+    .thumb_func
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+main:
+    push    {r4-r11, lr}
+
+    ldr     r0, =fmt_main_hdr
+    bl      printf
+
+    bl      test_hkex
+    bl      test_hske
+    bl      test_hpks
+    bl      test_hpke
+
+    mov     r0, #0
+    bl      exit
+
+    .ltorg
+
+/* ================================================================
+   test_hkex
+   [1] HKEX key exchange correctness: skeyA == skeyB
+   Uses: r4=loop_counter, r5=pass_counter
+         r6=A, r7=B, r8=A2, r9=B2
+   ================================================================ */
+    .thumb_func
+test_hkex:
+    push    {r4-r11, lr}
+
+    ldr     r0, =fmt_t1_hdr
+    bl      printf
+
+    mov     r4, #100            @ loop counter
+    mov     r5, #0              @ pass counter
+
+hkex_loop:
+    /* generate A, B, A2, B2 */
+    bl      prng_next
+    mov     r6, r0              @ A
+
+    bl      prng_next
+    mov     r7, r0              @ B
+
+    bl      prng_next
+    mov     r8, r0              @ A2
+
+    bl      prng_next
+    mov     r9, r0              @ B2
+
+    /* C = fscx_revolve(A, B, 8) */
+    mov     r0, r6
+    mov     r1, r7
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C
+    str     r0, [r3]            @ test_C = C
+                                @ r6=A, r7=B, r8=A2, r9=B2 preserved (fscx_revolve saves r4-r7)
+
+    /* C2 = fscx_revolve(A2, B2, 8) */
+    mov     r0, r8
+    mov     r1, r9
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C2
+    str     r0, [r3]            @ test_C2 = C2
+
+    /* hn = C ^ C2 */
+    ldr     r0, =test_C
+    ldr     r0, [r0]
+    ldr     r1, =test_C2
+    ldr     r1, [r1]
+    eor     r0, r0, r1
+    ldr     r3, =test_hn
+    str     r0, [r3]
+
+    /* skeyA = fscx_revolve_n(C2, B, 24, hn) ^ A */
+    ldr     r0, =test_C2
+    ldr     r0, [r0]
+    mov     r1, r7              @ B
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r6          @ ^ A
+    ldr     r3, =test_val
+    str     r0, [r3]            @ save skeyA
+
+    /* skeyB = fscx_revolve_n(C, B2, 24, hn) ^ A2 */
+    ldr     r0, =test_C
+    ldr     r0, [r0]
+    mov     r1, r9              @ B2
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r8          @ ^ A2
+
+    /* compare skeyA == skeyB */
+    ldr     r1, =test_val
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hkex_no_pass
+    add     r5, r5, #1
+hkex_no_pass:
+    subs    r4, r4, #1
+    bne     hkex_loop
+
+    /* print result */
+    ldr     r0, =fmt_result
+    mov     r1, r5
+    cmp     r5, #100
+    bne     hkex_print_fail
+    ldr     r2, =str_pass
+    b       hkex_do_print
+hkex_print_fail:
+    ldr     r2, =str_fail
+hkex_do_print:
+    bl      printf
+
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ================================================================
+   test_hske
+   [2] HSKE encrypt+decrypt round-trip: decrypt(encrypt(P)) == P
+   Uses: r4=loop_counter, r5=pass_counter
+         r6=plain, r7=key
+   ================================================================ */
+    .thumb_func
+test_hske:
+    push    {r4-r11, lr}
+
+    ldr     r0, =fmt_t2_hdr
+    bl      printf
+
+    mov     r4, #100
+    mov     r5, #0
+
+hske_loop:
+    bl      prng_next
+    mov     r6, r0              @ plain
+
+    bl      prng_next
+    mov     r7, r0              @ key
+
+    /* E = fscx_revolve_n(plain, key, 8, key) */
+    mov     r0, r6
+    mov     r1, r7
+    mov     r2, #8
+    mov     r3, r7
+    bl      fscx_revolve_n
+    ldr     r3, =test_val
+    str     r0, [r3]            @ save E
+                                @ r6=plain, r7=key preserved
+
+    /* D = fscx_revolve_n(E, key, 24, key) */
+    ldr     r0, =test_val
+    ldr     r0, [r0]
+    mov     r1, r7
+    mov     r2, #24
+    mov     r3, r7
+    bl      fscx_revolve_n
+
+    /* compare D == plain */
+    cmp     r0, r6
+    bne     hske_no_pass
+    add     r5, r5, #1
+hske_no_pass:
+    subs    r4, r4, #1
+    bne     hske_loop
+
+    ldr     r0, =fmt_result
+    mov     r1, r5
+    cmp     r5, #100
+    bne     hske_print_fail
+    ldr     r2, =str_pass
+    b       hske_do_print
+hske_print_fail:
+    ldr     r2, =str_fail
+hske_do_print:
+    bl      printf
+
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ================================================================
+   test_hpks
+   [3] HPKS sign+verify correctness: V == plain
+   Uses: r4=loop_counter, r5=pass_counter
+         r6=A, r7=B, r8=A2, r9=B2
+         plain stored in test_val between calls
+   ================================================================ */
+    .thumb_func
+test_hpks:
+    push    {r4-r11, lr}
+
+    ldr     r0, =fmt_t3_hdr
+    bl      printf
+
+    mov     r4, #100
+    mov     r5, #0
+
+hpks_loop:
+    bl      prng_next
+    mov     r6, r0              @ A
+
+    bl      prng_next
+    mov     r7, r0              @ B
+
+    bl      prng_next
+    mov     r8, r0              @ A2
+
+    bl      prng_next
+    mov     r9, r0              @ B2
+
+    bl      prng_next
+    ldr     r3, =test_val
+    str     r0, [r3]            @ plain -> test_val
+
+    /* C = fscx_revolve(A, B, 8) */
+    mov     r0, r6
+    mov     r1, r7
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C
+    str     r0, [r3]
+
+    /* C2 = fscx_revolve(A2, B2, 8) */
+    mov     r0, r8
+    mov     r1, r9
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C2
+    str     r0, [r3]
+
+    /* hn = C ^ C2 */
+    ldr     r0, =test_C
+    ldr     r0, [r0]
+    ldr     r1, =test_C2
+    ldr     r1, [r1]
+    eor     r0, r0, r1
+    ldr     r3, =test_hn
+    str     r0, [r3]
+
+    /* S = fscx_revolve_n(C2, B, 24, hn) ^ A ^ plain */
+    ldr     r0, =test_C2
+    ldr     r0, [r0]
+    mov     r1, r7              @ B
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r6          @ ^ A
+    ldr     r3, =test_val
+    ldr     r3, [r3]            @ plain
+    eor     r0, r0, r3          @ ^ plain  => S
+    /* store S in test_C2 (reuse; C2 no longer needed, C must be preserved) */
+    ldr     r3, =test_C2
+    str     r0, [r3]            @ test_C2 = S
+
+    /* V = fscx_revolve_n(C, B2, 24, hn) ^ A2 ^ S */
+    ldr     r0, =test_C
+    ldr     r0, [r0]            @ C (Alice's public value)
+    mov     r1, r9              @ B2
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r8          @ ^ A2
+    ldr     r3, =test_C2
+    ldr     r3, [r3]            @ S
+    eor     r0, r0, r3          @ ^ S  => V
+
+    /* compare V == plain */
+    ldr     r1, =test_val
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hpks_no_pass
+    add     r5, r5, #1
+hpks_no_pass:
+    subs    r4, r4, #1
+    bne     hpks_loop
+
+    ldr     r0, =fmt_result
+    mov     r1, r5
+    cmp     r5, #100
+    bne     hpks_print_fail
+    ldr     r2, =str_pass
+    b       hpks_do_print
+hpks_print_fail:
+    ldr     r2, =str_fail
+hpks_do_print:
+    bl      printf
+
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ================================================================
+   test_hpke
+   [4] HPKE encrypt+decrypt round-trip: D == plain
+   Uses: r4=loop_counter, r5=pass_counter
+         r6=A, r7=B, r8=A2, r9=B2
+         plain stored in test_val
+   ================================================================ */
+    .thumb_func
+test_hpke:
+    push    {r4-r11, lr}
+
+    ldr     r0, =fmt_t4_hdr
+    bl      printf
+
+    mov     r4, #100
+    mov     r5, #0
+
+hpke_loop:
+    bl      prng_next
+    mov     r6, r0              @ A
+
+    bl      prng_next
+    mov     r7, r0              @ B
+
+    bl      prng_next
+    mov     r8, r0              @ A2
+
+    bl      prng_next
+    mov     r9, r0              @ B2
+
+    bl      prng_next
+    ldr     r3, =test_val
+    str     r0, [r3]            @ plain -> test_val
+
+    /* C = fscx_revolve(A, B, 8) */
+    mov     r0, r6
+    mov     r1, r7
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C
+    str     r0, [r3]
+
+    /* C2 = fscx_revolve(A2, B2, 8) */
+    mov     r0, r8
+    mov     r1, r9
+    mov     r2, #8
+    bl      fscx_revolve
+    ldr     r3, =test_C2
+    str     r0, [r3]
+
+    /* hn = C ^ C2 */
+    ldr     r0, =test_C
+    ldr     r0, [r0]
+    ldr     r1, =test_C2
+    ldr     r1, [r1]
+    eor     r0, r0, r1
+    ldr     r3, =test_hn
+    str     r0, [r3]
+
+    /* E = fscx_revolve_n(C, B2, 24, hn) ^ A2 ^ plain */
+    ldr     r0, =test_C
+    ldr     r0, [r0]
+    mov     r1, r9              @ B2
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r8          @ ^ A2
+    ldr     r3, =test_val
+    ldr     r3, [r3]
+    eor     r0, r0, r3          @ ^ plain
+    /* store E in test_C (reuse) */
+    ldr     r3, =test_C
+    str     r0, [r3]            @ test_C = E
+
+    /* D = fscx_revolve_n(C2, B, 24, hn) ^ A ^ E */
+    ldr     r0, =test_C2
+    ldr     r0, [r0]
+    mov     r1, r7              @ B
+    mov     r2, #24
+    ldr     r3, =test_hn
+    ldr     r3, [r3]
+    bl      fscx_revolve_n
+    eor     r0, r0, r6          @ ^ A
+    ldr     r3, =test_C
+    ldr     r3, [r3]            @ E
+    eor     r0, r0, r3          @ ^ E  => D
+
+    /* compare D == plain */
+    ldr     r1, =test_val
+    ldr     r1, [r1]
+    cmp     r0, r1
+    bne     hpke_no_pass
+    add     r5, r5, #1
+hpke_no_pass:
+    subs    r4, r4, #1
+    bne     hpke_loop
+
+    ldr     r0, =fmt_result
+    mov     r1, r5
+    cmp     r5, #100
+    bne     hpke_print_fail
+    ldr     r2, =str_pass
+    b       hpke_do_print
+hpke_print_fail:
+    ldr     r2, =str_fail
+hpke_do_print:
+    bl      printf
+
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ------------------------------------------------------------------ */
+/* prng_next: LCG — no args, returns new state in r0                  */
+/*   state = state * 1664525 + 1013904223                             */
+/*   Clobbers r1, r2                                                  */
+/* ------------------------------------------------------------------ */
+    .thumb_func
+prng_next:
+    ldr     r1, =prng_state
+    ldr     r0, [r1]
+    ldr     r2, =lcg_mul
+    ldr     r2, [r2]
+    mul     r0, r0, r2
+    ldr     r2, =lcg_add
+    ldr     r2, [r2]
+    add     r0, r0, r2
+    str     r0, [r1]
+    bx      lr
+
+    .ltorg
+
+/* ------------------------------------------------------------------ */
+/* fscx_revolve: r0=A, r1=B, r2=rounds -> r0=result                  */
+/*   FSCX(A,B) = A^B^ROL(A,1)^ROL(B,1)^ROR(A,1)^ROR(B,1)            */
+/*   Clobbers r4-r6 (saved/restored)                                  */
+/* ------------------------------------------------------------------ */
+    .thumb_func
+fscx_revolve:
+    push    {r4-r7, lr}
+    mov     r4, r0
+3:
+    eor     r5, r4, r1          @ A ^ B
+    ror     r6, r4, #1
+    eor     r5, r5, r6          @ ^ ROR(A,1)
+    ror     r6, r1, #1
+    eor     r5, r5, r6          @ ^ ROR(B,1)
+    ror     r6, r4, #31
+    eor     r5, r5, r6          @ ^ ROL(A,1)
+    ror     r6, r1, #31
+    eor     r5, r5, r6          @ ^ ROL(B,1)
+    mov     r4, r5
+    subs    r2, r2, #1
+    bne     3b
+    mov     r0, r4
+    pop     {r4-r7, pc}
+
+    .ltorg
+
+/* ------------------------------------------------------------------ */
+/* fscx_revolve_n: r0=A, r1=B, r2=rounds, r3=nonce -> r0=result      */
+/*   Each step: result = FSCX(result, B) ^ nonce                      */
+/*   Clobbers r4-r6 (saved/restored)                                  */
+/* ------------------------------------------------------------------ */
+    .thumb_func
+fscx_revolve_n:
+    push    {r4-r7, lr}
+    mov     r4, r0
+4:
+    eor     r5, r4, r1          @ A ^ B
+    ror     r6, r4, #1
+    eor     r5, r5, r6          @ ^ ROR(A,1)
+    ror     r6, r1, #1
+    eor     r5, r5, r6          @ ^ ROR(B,1)
+    ror     r6, r4, #31
+    eor     r5, r5, r6          @ ^ ROL(A,1)
+    ror     r6, r1, #31
+    eor     r5, r5, r6          @ ^ ROL(B,1)
+    eor     r5, r5, r3          @ ^ nonce
+    mov     r4, r5
+    subs    r2, r2, #1
+    bne     4b
+    mov     r0, r4
+    pop     {r4-r7, pc}
+
+    .ltorg
+
+    .section .note.GNU-stack,"",%progbits

--- a/README.md
+++ b/README.md
@@ -186,15 +186,43 @@ python3 Herradura_tests.py
 ## Assembly
 
 ```bash
-# ARM Linux (requires arm-linux-gnueabi-gcc; run with QEMU on non-ARM host)
+# ARM Linux — basic HKEX only (requires arm-linux-gnueabi-gcc)
 arm-linux-gnueabi-gcc -o HKEX_arm HKEX_arm_linux.s
-./HKEX_arm          # on ARM hardware
-qemu-arm ./HKEX_arm # on non-ARM host
+./HKEX_arm                           # on ARM hardware
+qemu-arm -L /usr/arm-linux-gnueabi ./HKEX_arm  # on non-ARM host
 
-# x86 NASM assembly (requires NASM and asm_io.o library)
+# ARM Linux — full suite + tests (HKEX + HSKE + HPKS + HPKE, 32-bit Thumb)
+arm-linux-gnueabi-gcc -o "Herradura cryptographic suite_arm" "Herradura cryptographic suite.s"
+arm-linux-gnueabi-gcc -o Herradura_tests_arm Herradura_tests.s
+qemu-arm -L /usr/arm-linux-gnueabi "./Herradura cryptographic suite_arm"
+qemu-arm -L /usr/arm-linux-gnueabi ./Herradura_tests_arm
+
+# NASM i386 — legacy asymmetric encryption (requires NASM and asm_io.o library)
 nasm -f elf HAEN.asm
 gcc -m32 -o HAEN HAEN.o asm_io.o
 ./HAEN
+
+# NASM i386 — full suite + tests (HKEX + HSKE + HPKS + HPKE, pure Linux syscalls)
+# Requires: nasm, x86_64-linux-gnu-ld (or ld with elf_i386 support), qemu-i386
+nasm -f elf32 "Herradura cryptographic suite.asm" -o suite32.o
+nasm -f elf32 Herradura_tests.asm -o tests32.o
+x86_64-linux-gnu-ld -m elf_i386 -o "Herradura cryptographic suite_i386" suite32.o
+x86_64-linux-gnu-ld -m elf_i386 -o Herradura_tests_i386 tests32.o
+qemu-i386 "./Herradura cryptographic suite_i386"
+qemu-i386 ./Herradura_tests_i386
+# On a native x86/x86_64 Linux host the binaries run directly without qemu-i386
+```
+
+## Arduino
+
+The `.ino` files require the Arduino IDE or `arduino-cli` with the AVR board
+package installed (e.g. Arduino Uno / Nano). Open the file in the IDE and
+upload to a board with a serial monitor at 9600 baud, or:
+
+```bash
+# Compile-check only (requires arduino-cli with arduino:avr board package)
+arduino-cli compile --fqbn arduino:avr:uno "Herradura cryptographic suite.ino"
+arduino-cli compile --fqbn arduino:avr:uno Herradura_tests.ino
 ```
 
 # Performance (v1.3.3, Raspberry Pi 5 — ARM Cortex-A76)


### PR DESCRIPTION
## Summary

- **`Herradura cryptographic suite.asm` + `Herradura_tests.asm`** — NASM i386, pure Linux `int 0x80` syscalls (no libc/asm_io). All four protocols (HKEX, HSKE, HPKS, HPKE) implemented. Tests: 100/100 passed via `qemu-i386`.
- **`Herradura cryptographic suite.s` + `Herradura_tests.s`** — GAS ARM 32-bit Thumb (`.cpu cortex-a7`). Defines both `fscx_revolve` and `fscx_revolve_n` (fixes the missing `fscx_revolve_n` definition in the existing `HKEX_arm_linux.s`). Tests: 100/100 passed via `qemu-arm`.
- **`Herradura cryptographic suite.ino` + `Herradura_tests.ino`** — Arduino, 32-bit `unsigned long`. Serial output at 9600 baud. 100 LCG-random trials per protocol test.
- **README.md** — updated Assembly build section; added Arduino section with `arduino-cli` commands.
- **CHANGELOG.md** — v1.3.7 entry.

All assembly files use 32-bit operands: `KEYBITS=32`, `I_VALUE=8`, `R_VALUE=24`.

## Test plan

- [x] NASM i386 suite: `qemu-i386 "./Herradura cryptographic suite_i386"` — all 4 protocols correct
- [x] NASM i386 tests: `qemu-i386 ./Herradura_tests_i386` — 4×100/100 passed
- [x] ARM Thumb suite: `qemu-arm -L /usr/arm-linux-gnueabi "./Herradura cryptographic suite_arm"` — all 4 protocols correct
- [x] ARM Thumb tests: `qemu-arm -L /usr/arm-linux-gnueabi ./Herradura_tests_arm` — 4×100/100 passed
- [ ] Arduino: requires physical board or `arduino-cli` with AVR package; logic mirrors verified C/Go/Python implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)