### PR TITLE
v1.5.1: fix KaTeX rendering errors + test execution limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.1] - 2026-04-11
+
+### Fixed / Added
+
+#### Test execution limits (C, Python, Go)
+
+- `CryptosuiteTests/Herradura_tests.c` — `--rounds`/`-r` and `--time`/`-t` CLI flags;
+  `HTEST_ROUNDS` / `HTEST_TIME` environment variable fallbacks; wall-clock timeout
+  via `CLOCK_MONOTONIC`; all 16 security tests scale iteration counts and pass
+  thresholds to actual runs completed.
+- `CryptosuiteTests/Herradura_tests.py` — same flags via `argparse`; `_trange()`
+  generator checks `time.monotonic()` every 64 iterations.
+- `CryptosuiteTests/Herradura_tests.go` — same flags via `flag` package;
+  `timeExceeded()` helper with `time.Since()`.
+
+#### Documentation — KaTeX rendering fix (README.md, SecurityProofs.md)
+
+- Fixed `'_' allowed only in math mode` errors on GitHub: moved `\_` out of
+  `\text{}` blocks (text mode) into math mode.  Pattern is now
+  `\text{FSCX}\_\text{REVOLVE}` / `\text{FSCX}\_\text{REVOLVE}\_\text{N}` /
+  `\text{fscx}\_\text{revolve}` throughout both files (42 occurrences fixed).
+- `README.md`: also fixed `\mathit{enc\_key}` → `\mathit{enc}\_\mathit{key}` and
+  `\mathit{dec\_key}` → `\mathit{dec}\_\mathit{key}`.
+
+---
+
 ## [1.5.0] - 2026-04-11
 
 ### Added — NL-FSCX v2, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL across all implementations

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -1,4 +1,8 @@
-/* Build: gcc -O2 -o Herradura_tests Herradura_tests.c */
+/* Build: gcc -O2 -o Herradura_tests Herradura_tests.c
+   Usage: ./Herradura_tests [-r ROUNDS] [-t SECS]
+     -r, --rounds N   max iterations per security test (default: test-specific)
+     -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
+   Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, 256-bit BitArray + 32-bit GF)
     v1.5.0: HKEX-GF; Schnorr HPKS; El Gamal HPKE; NL-FSCX non-linear extension; PQC.
@@ -47,13 +51,18 @@
 #  error "GF polynomial constants are only defined for KEYBITS=256 in this build"
 #endif
 
-#define BENCH_SEC 1.0
+/* BENCH_SEC removed: use g_bench_sec (default 1.0, overridden by -t / HTEST_TIME) */
 
 typedef struct {
     uint8_t b[KEYBYTES];
 } BitArray;
 
 static FILE *urnd_fp;
+
+/* --- Runtime limits (set via CLI -r/-t or env HTEST_ROUNDS/HTEST_TIME) --- */
+static int    g_rounds     = 0;    /* 0 = use per-test default            */
+static double g_bench_sec  = 1.0;  /* benchmark duration (seconds)        */
+static double g_time_limit = 0.0;  /* per-test wall-clock cap; 0 = none   */
 
 /* ------------------------------------------------------------------ */
 /* BitArray primitives                                                 */
@@ -470,6 +479,18 @@ static void print_rate(long long ops, double secs)
                rate, ops, secs);
 }
 
+/* Effective iteration count: honours g_rounds when set, else per-test default. */
+#define TEST_ROUNDS(def)  ((g_rounds > 0) ? g_rounds : (def))
+
+/* Returns 1 when the per-test time cap is set and has been reached. */
+static int time_exceeded(struct timespec *t0)
+{
+    struct timespec t1;
+    if (g_time_limit <= 0.0) return 0;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    return elapsed_sec(t0, &t1) >= g_time_limit;
+}
+
 /* ------------------------------------------------------------------ */
 /* Security tests [1]-[6]: 256-bit HKEX-GF and FSCX primitives       */
 /* ------------------------------------------------------------------ */
@@ -478,9 +499,12 @@ static void print_rate(long long ops, double secs)
 static void test_hkex_gf_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     BitArray a_priv, b_priv, C, C2, skA, skB;
     printf("[1] HKEX-GF correctness: g^{ab} == g^{ba}  (field commutativity)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         ba_rand(&a_priv);
         ba_rand(&b_priv);
         a_priv.b[KEYBYTES - 1] |= 1;   /* odd exponents */
@@ -491,9 +515,10 @@ static void test_hkex_gf_correctness(void)
         gf_pow_ba(&skB, &C,  &b_priv);
         if (ba_equal(&skA, &skB))
             ok++;
+        if ((i & 7) == 7 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=%d  %d / 1000  [%s]\n",
-           KEYBITS, ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=%d  %d / %d  [%s]\n",
+           KEYBITS, ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -503,9 +528,12 @@ static void test_avalanche(void)
     int trial, bit;
     double total = 0.0;
     int gmin = KEYBITS + 1, gmax = -1;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     BitArray a, b, base_out, ap, flip_out, diff;
     printf("[2] FSCX single-step linear diffusion (expected: exactly 3 bits per flip)\n");
-    for (trial = 0; trial < 1000; trial++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (trial = 0; trial < N; trial++) {
         ba_rand(&a);
         ba_rand(&b);
         ba_fscx(&base_out, &a, &b);
@@ -519,9 +547,10 @@ static void test_avalanche(void)
             if (hd < gmin) gmin = hd;
             if (hd > gmax) gmax = hd;
         }
+        if ((trial & 63) == 63 && time_exceeded(&t0)) { N = trial + 1; break; }
     }
     {
-        double mean = total / (1000.0 * (double)KEYBITS);
+        double mean = total / ((double)N * (double)KEYBITS);
         printf("    bits=%d  mean=%.2f (expected 3/%d)  min=%d  max=%d  [%s]\n",
                KEYBITS, mean, KEYBITS, gmin, gmax,
                (mean >= 2.9 && mean <= 3.1) ? "PASS" : "FAIL");
@@ -534,9 +563,12 @@ static void test_orbit_period(void)
 {
     int trial, cntP = 0, cntHP = 0, other = 0;
     int cap = 2 * KEYBITS;
+    int N = TEST_ROUNDS(100);
+    struct timespec t0;
     BitArray a, b, cur, tmp;
     printf("[3] Orbit period: FSCX_REVOLVE(A,B,n) cycles back to A\n");
-    for (trial = 0; trial < 100; trial++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (trial = 0; trial < N; trial++) {
         int period = 1;
         ba_rand(&a);
         ba_rand(&b);
@@ -549,6 +581,7 @@ static void test_orbit_period(void)
         if      (period == KEYBITS)     cntP++;
         else if (period == KEYBITS / 2) cntHP++;
         else                            other++;
+        if ((trial & 15) == 15 && time_exceeded(&t0)) { N = trial + 1; break; }
     }
     printf("    bits=%d  period=%d: %3d  period=%d: %3d  other: %d  [%s]\n",
            KEYBITS, KEYBITS, cntP, KEYBITS / 2, cntHP, other,
@@ -562,10 +595,12 @@ static void test_bit_frequency(void)
     int bit, trial;
     long long counts[KEYBITS];
     double minpct, maxpct, meanpct;
-    int N = 100000;
+    int N = TEST_ROUNDS(100000);
+    struct timespec t0;
     BitArray a, b, out;
     printf("[4] Bit-frequency bias: %d FSCX outputs\n", N);
     memset(counts, 0, sizeof(counts));
+    clock_gettime(CLOCK_MONOTONIC, &t0);
     for (trial = 0; trial < N; trial++) {
         ba_rand(&a);
         ba_rand(&b);
@@ -573,6 +608,7 @@ static void test_bit_frequency(void)
         for (bit = 0; bit < KEYBITS; bit++)
             if (ba_get_bit(&out, bit))
                 counts[bit]++;
+        if ((trial & 255) == 255 && time_exceeded(&t0)) { N = trial + 1; break; }
     }
     minpct = 101.0; maxpct = -1.0; meanpct = 0.0;
     for (bit = 0; bit < KEYBITS; bit++) {
@@ -593,10 +629,13 @@ static void test_hkex_gf_key_sensitivity(void)
 {
     int i;
     double total = 0.0;
+    int N = TEST_ROUNDS(500);
+    struct timespec t0;
     BitArray a_priv, b_priv, C2, sk1, sk2, a_flip, diff;
     printf("[5] HKEX-GF key sensitivity: flip 1 bit of a -> mean Hamming(sk1, sk2) ~= %d\n",
            KEYBITS / 2);
-    for (i = 0; i < 500; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         ba_rand(&a_priv);
         ba_rand(&b_priv);
         a_priv.b[KEYBYTES - 1] |= 1;
@@ -607,9 +646,10 @@ static void test_hkex_gf_key_sensitivity(void)
         gf_pow_ba(&sk2, &C2, &a_flip);
         ba_xor(&diff, &sk1, &sk2);
         total += ba_popcount(&diff);
+        if ((i & 7) == 7 && time_exceeded(&t0)) { N = i + 1; break; }
     }
     {
-        double mean = total / 500.0;
+        double mean = total / (double)N;
         double lo = KEYBITS * 0.35, hi = KEYBITS * 0.65;
         printf("    bits=%d  mean HD=%.1f (expected ~%d)  [%s]\n",
                KEYBITS, mean, KEYBITS / 2,
@@ -622,12 +662,15 @@ static void test_hkex_gf_key_sensitivity(void)
 static void test_eve_attack_resistance(void)
 {
     int i, hits = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     BitArray a_priv, b_priv, C, C2, sk_real, eve_sk;
     BitArray delta, cur, zero, acc, next;
     int j;
     printf("[6] Eve classical attack: S_{r+1}(C XOR C2) != sk  (HKEX-GF resistance)\n");
     memset(zero.b, 0, KEYBYTES);
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         ba_rand(&a_priv);
         ba_rand(&b_priv);
         a_priv.b[KEYBYTES - 1] |= 1;
@@ -647,9 +690,10 @@ static void test_eve_attack_resistance(void)
         eve_sk = acc;
         if (ba_equal(&eve_sk, &sk_real))
             hits++;
+        if ((i & 7) == 7 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=%d  Eve succeeded %d / 1000  [%s]\n",
-           KEYBITS, hits, hits == 0 ? "PASS - attack fails" : "FAIL");
+    printf("    bits=%d  Eve succeeded %d / %d  [%s]\n",
+           KEYBITS, hits, N, hits == 0 ? "PASS - attack fails" : "FAIL");
     putchar('\n');
 }
 
@@ -661,10 +705,13 @@ static void test_eve_attack_resistance(void)
 static void test_hpks_schnorr_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     uint32_t a, plain, k, C32, R32, e32, s32;
     uint64_t ae, ord = 0xFFFFFFFFULL;
     printf("[7] HPKS Schnorr correctness: g^s * C^e == R  (bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         a     = rand32() | 1;
         plain = rand32();
         k     = rand32();
@@ -676,8 +723,9 @@ static void test_hpks_schnorr_correctness(void)
         if (gf_mul_32(gf_pow_32((uint32_t)GF_GEN32, s32),
                       gf_pow_32(C32, e32)) == R32)
             ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000  [%s]\n", ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d  [%s]\n", ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -685,9 +733,12 @@ static void test_hpks_schnorr_correctness(void)
 static void test_hpks_schnorr_eve(void)
 {
     int i, hits = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     uint32_t a, plain, C32, r_eve, s_eve, e_eve;
     printf("[8] HPKS Schnorr Eve resistance: random forgery fails  (bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         a      = rand32() | 1;
         plain  = rand32();
         r_eve  = rand32();
@@ -697,9 +748,10 @@ static void test_hpks_schnorr_eve(void)
         if (gf_mul_32(gf_pow_32((uint32_t)GF_GEN32, s_eve),
                       gf_pow_32(C32, e_eve)) == r_eve)
             hits++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000 Eve wins  [%s]\n",
-           hits, hits == 0 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d Eve wins  [%s]\n",
+           hits, N, hits == 0 ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -707,9 +759,12 @@ static void test_hpks_schnorr_eve(void)
 static void test_hpke_el_gamal(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     uint32_t a, plain, r, C32, R32, enc_key, E32, dec_key, D32;
     printf("[9] HPKE El Gamal encrypt+decrypt: D == plaintext  (bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         a        = rand32() | 1;
         plain    = rand32();
         r        = rand32() | 1;
@@ -720,8 +775,9 @@ static void test_hpke_el_gamal(void)
         dec_key  = gf_pow_32(R32, a);    /* R^a = g^{ra}  (Alice's dec key) */
         D32      = fscx_revolve32(E32, dec_key, 24);
         if (D32 == plain) ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000  [%s]\n", ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d  [%s]\n", ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -737,17 +793,23 @@ static void test_hpke_el_gamal(void)
 static void test_nl_fscx_v1_nonlinearity(void)
 {
     int i, violations = 0, no_period = 0;
+    int N1 = TEST_ROUNDS(1000);
+    int N2 = TEST_ROUNDS(200);
+    struct timespec t0;
     printf("[10] NL-FSCX v1 non-linearity and aperiodicity  (bits=32)\n");
     /* Linearity check: f(A,B) ^ f(0,B) == fscx(A,0) is the linear prediction;
        violations count how often NL-FSCX v1 differs from that prediction. */
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N1; i++) {
         uint32_t A = rand32(), B = rand32();
         uint32_t lin_pred = fscx32(A, 0) ^ nl_fscx_v1_32(0, B);
         if (nl_fscx_v1_32(A, B) != lin_pred)
             violations++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N1 = i + 1; break; }
     }
     /* Aperiodicity: orbit of 4*n=128 steps from a random start should not cycle */
-    for (i = 0; i < 200; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N2; i++) {
         uint32_t A = rand32(), B = rand32();
         uint32_t cur = nl_fscx_v1_32(A, B);
         int found = 0, step;
@@ -756,10 +818,11 @@ static void test_nl_fscx_v1_nonlinearity(void)
             if (cur == A) { found = 1; break; }
         }
         if (!found) no_period++;
+        if ((i & 31) == 31 && time_exceeded(&t0)) { N2 = i + 1; break; }
     }
-    printf("    bits=32  linearity violations=%d/1000  no-period=%d/200  [%s]\n",
-           violations, no_period,
-           (violations == 1000 && no_period >= 190) ? "PASS" : "FAIL");
+    printf("    bits=32  linearity violations=%d/%d  no-period=%d/%d  [%s]\n",
+           violations, N1, no_period, N2,
+           (violations == N1 && no_period >= N2 * 95 / 100) ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -767,29 +830,39 @@ static void test_nl_fscx_v1_nonlinearity(void)
 static void test_nl_fscx_v2_bijective_inverse(void)
 {
     int i, non_bij = 0, inv_ok = 0, nl_ok = 0;
+    int N1 = TEST_ROUNDS(500);
+    int N2 = TEST_ROUNDS(1000);
+    int N3 = TEST_ROUNDS(500);
+    struct timespec t0;
     printf("[11] NL-FSCX v2 bijectivity and exact inverse  (bits=32)\n");
-    /* Collision test: for 500 random B, draw pairs (A1,A2) and check no collision */
-    for (i = 0; i < 500; i++) {
+    /* Collision test: for N1 random B, draw pairs (A1,A2) and check no collision */
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N1; i++) {
         uint32_t B = rand32();
         uint32_t A1 = rand32(), A2 = rand32();
         if (A1 != A2 && nl_fscx_v2_32(A1, B) == nl_fscx_v2_32(A2, B))
             non_bij++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N1 = i + 1; break; }
     }
     /* Inverse correctness: nl_fscx_v2_inv(nl_fscx_v2(A,B), B) == A */
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N2; i++) {
         uint32_t A = rand32(), B = rand32();
         if (nl_fscx_v2_inv_32(nl_fscx_v2_32(A, B), B) == A)
             inv_ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N2 = i + 1; break; }
     }
     /* Non-linearity: f(A,B) != fscx(A,0) ^ f(0,B) for most inputs */
-    for (i = 0; i < 500; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N3; i++) {
         uint32_t A = rand32(), B = rand32();
         if (nl_fscx_v2_32(A, B) != (fscx32(A, 0) ^ nl_fscx_v2_32(0, B)))
             nl_ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N3 = i + 1; break; }
     }
-    printf("    bits=32  collisions=%d/500  inv=%d/1000  nonlinear=%d/500  [%s]\n",
-           non_bij, inv_ok, nl_ok,
-           (non_bij == 0 && inv_ok == 1000 && nl_ok >= 490) ? "PASS" : "FAIL");
+    printf("    bits=32  collisions=%d/%d  inv=%d/%d  nonlinear=%d/%d  [%s]\n",
+           non_bij, N1, inv_ok, N2, nl_ok, N3,
+           (non_bij == 0 && inv_ok == N2 && nl_ok >= N3 * 98 / 100) ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -797,8 +870,11 @@ static void test_nl_fscx_v2_bijective_inverse(void)
 static void test_hske_nl_a1_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     printf("[12] HSKE-NL-A1 counter-mode correctness: D == P  (bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         uint32_t K   = rand32();
         uint32_t P   = rand32();
         uint32_t ctr = (uint32_t)i & 0xFFFF;
@@ -806,9 +882,10 @@ static void test_hske_nl_a1_correctness(void)
         uint32_t E   = P ^ ks;
         uint32_t D   = E ^ ks;
         if (D == P) ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000 correct  [%s]\n",
-           ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d correct  [%s]\n",
+           ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -816,16 +893,20 @@ static void test_hske_nl_a1_correctness(void)
 static void test_hske_nl_a2_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     printf("[13] HSKE-NL-A2 revolve-mode correctness: D == P  (bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         uint32_t K = rand32();
         uint32_t P = rand32();
         uint32_t E = nl_fscx_revolve_v2_32(P, K, NL_R32);
         uint32_t D = nl_fscx_revolve_v2_inv_32(E, K, NL_R32);
         if (D == P) ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000 correct  [%s]\n",
-           ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d correct  [%s]\n",
+           ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -833,10 +914,13 @@ static void test_hske_nl_a2_correctness(void)
 static void test_hkex_rnl_correctness(void)
 {
     int i, ok_raw = 0;
+    int N = TEST_ROUNDS(200);
+    struct timespec t0;
     rnl32_poly_t m_base, a_rand, m_blind;
     printf("[14] HKEX-RNL key agreement: K_A == K_B  (n=%d, Ring-LWR)\n", RNL_N32);
     rnl32_m_poly(m_base);
-    for (i = 0; i < 200; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         int32_t s_A[RNL_N32], c_A[RNL_N32];
         int32_t s_B[RNL_N32], c_B[RNL_N32];
         uint32_t K_A, K_B;
@@ -847,9 +931,10 @@ static void test_hkex_rnl_correctness(void)
         K_A = rnl32_agree(s_A, c_B);
         K_B = rnl32_agree(s_B, c_A);
         if (K_A == K_B) ok_raw++;
+        if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    n=%d  raw agree=%d/200  [%s]\n",
-           RNL_N32, ok_raw, ok_raw >= 180 ? "PASS" : "FAIL");
+    printf("    n=%d  raw agree=%d/%d  [%s]\n",
+           RNL_N32, ok_raw, N, ok_raw >= N * 9 / 10 ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -857,11 +942,14 @@ static void test_hkex_rnl_correctness(void)
 static void test_hpks_nl_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     uint32_t a, plain, k, C32, R32;
     uint32_t e32, s32;
     uint64_t ae, ord = 0xFFFFFFFFULL;
     printf("[15] HPKS-NL correctness: g^s · C^e == R  (NL-FSCX v1 challenge, bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         a     = rand32() | 1;
         plain = rand32();
         k     = rand32();
@@ -873,8 +961,9 @@ static void test_hpks_nl_correctness(void)
         if (gf_mul_32(gf_pow_32((uint32_t)GF_GEN32, s32),
                       gf_pow_32(C32, e32)) == R32)
             ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000  [%s]\n", ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d  [%s]\n", ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -882,9 +971,12 @@ static void test_hpks_nl_correctness(void)
 static void test_hpke_nl_correctness(void)
 {
     int i, ok = 0;
+    int N = TEST_ROUNDS(1000);
+    struct timespec t0;
     uint32_t a, plain, r, C32, R32, enc_key, E32, dec_key, D32;
     printf("[16] HPKE-NL correctness: D == P  (NL-FSCX v2 encrypt/decrypt, bits=32)\n");
-    for (i = 0; i < 1000; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
         a        = rand32() | 1;
         plain    = rand32();
         r        = rand32() | 1;
@@ -895,8 +987,9 @@ static void test_hpke_nl_correctness(void)
         dec_key  = gf_pow_32(R32, a);
         D32      = nl_fscx_revolve_v2_inv_32(E32, dec_key, NL_I32);
         if (D32 == plain) ok++;
+        if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    bits=32  %d / 1000  [%s]\n", ok, ok == 1000 ? "PASS" : "FAIL");
+    printf("    bits=32  %d / %d  [%s]\n", ok, N, ok == N ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -920,7 +1013,7 @@ static void bench_fscx_throughput(void)
         for (i = 0; i < 100; i++) { ba_fscx(&tmp, &a, &b); a = tmp; }
         ops += 100;
         clock_gettime(CLOCK_MONOTONIC, &t1);
-    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
     print_rate(ops, secs);
     putchar('\n');
 }
@@ -942,7 +1035,7 @@ static void bench_gf_pow32_throughput(void)
         for (i = 0; i < 1000; i++) { tmp = gf_pow_32(base, exp); base = tmp | 1; }
         ops += 1000;
         clock_gettime(CLOCK_MONOTONIC, &t1);
-    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
     print_rate(ops, secs);
     putchar('\n');
 }
@@ -975,7 +1068,7 @@ static void bench_hkex_gf32_handshake(void)
         }
         ops += 100;
         clock_gettime(CLOCK_MONOTONIC, &t1);
-    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
     print_rate(ops, secs);
     putchar('\n');
 }
@@ -1003,7 +1096,7 @@ static void bench_hske_roundtrip(void)
         }
         ops += 20;
         clock_gettime(CLOCK_MONOTONIC, &t1);
-    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
     print_rate(ops, secs);
     putchar('\n');
 }
@@ -1039,7 +1132,7 @@ static void bench_hpke_el_gamal_roundtrip(void)
         }
         ops += 100;
         clock_gettime(CLOCK_MONOTONIC, &t1);
-    } while ((secs = elapsed_sec(&t0, &t1)) < BENCH_SEC);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
     print_rate(ops, secs);
     putchar('\n');
 }
@@ -1048,15 +1141,53 @@ static void bench_hpke_el_gamal_roundtrip(void)
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
-int main(void)
+int main(int argc, char *argv[])
 {
+    int i;
+    const char *env_r, *env_t;
+
+    /* --- env var defaults --- */
+    if ((env_r = getenv("HTEST_ROUNDS")) && atoi(env_r) > 0)
+        g_rounds = atoi(env_r);
+    if ((env_t = getenv("HTEST_TIME")) && atof(env_t) > 0.0) {
+        g_bench_sec  = atof(env_t);
+        g_time_limit = atof(env_t);
+    }
+
+    /* --- CLI args override env --- */
+    for (i = 1; i < argc; i++) {
+        if ((!strcmp(argv[i], "-r") || !strcmp(argv[i], "--rounds")) && i + 1 < argc) {
+            g_rounds = atoi(argv[++i]);
+        } else if ((!strcmp(argv[i], "-t") || !strcmp(argv[i], "--time")) && i + 1 < argc) {
+            double v = atof(argv[++i]);
+            g_bench_sec  = v;
+            g_time_limit = v;
+        } else {
+            fprintf(stderr,
+                "Usage: %s [-r ROUNDS] [-t SECS]\n"
+                "  -r, --rounds N   max iterations per security test\n"
+                "  -t, --time   T   benchmark duration and per-test time cap (seconds)\n"
+                "  Env: HTEST_ROUNDS=N  HTEST_TIME=T\n", argv[0]);
+            return 1;
+        }
+    }
+
     urnd_fp = fopen("/dev/urandom", "rb");
     if (!urnd_fp) {
         fputs("ERROR: cannot open /dev/urandom\n", stderr);
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.0 \xe2\x80\x94 Security & Performance Tests (C) ===\n\n");
+    printf("=== Herradura KEx v1.5.1 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    if (g_rounds > 0 || g_time_limit > 0.0) {
+        if (g_rounds > 0 && g_time_limit > 0.0)
+            printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);
+        else if (g_rounds > 0)
+            printf("    Config: rounds=%d\n", g_rounds);
+        else
+            printf("    Config: time_limit=%.2fs\n", g_time_limit);
+    }
+    putchar('\n');
 
     puts("--- Security Assumption Tests ---\n");
     test_hkex_gf_correctness();

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.1: added -rounds and -time CLI flags (also HTEST_ROUNDS / HTEST_TIME env vars).
     v1.5.0: added PQC extension tests [10-16] (NL-FSCX, HKEX-RNL, HPKS-NL, HPKE-NL);
             benchmarks renumbered [17-21] (were [10-14] in v1.4.0);
             new PQC benchmarks [22-25].
@@ -29,12 +30,41 @@ package main
 
 import (
 	"crypto/rand"
+	"flag"
 	"fmt"
 	"log"
 	"math/big"
 	"math/bits"
+	"os"
+	"strconv"
 	"time"
 )
+
+// ---------------------------------------------------------------------------
+// Runtime limits — set via CLI flags or env vars in main()
+// ---------------------------------------------------------------------------
+
+var (
+	gRounds    int           // 0 = use per-test default
+	gBenchDur  time.Duration // benchmark duration (default: 1s)
+	gTimeLimit time.Duration // per-test wall-clock cap; 0 = none
+)
+
+// testRounds returns the effective iteration count for a test.
+func testRounds(defaultN int) int {
+	if gRounds > 0 {
+		return gRounds
+	}
+	return defaultN
+}
+
+// timeExceeded reports whether the per-test time cap has been reached.
+func timeExceeded(t0 time.Time) bool {
+	if gTimeLimit <= 0 {
+		return false
+	}
+	return time.Since(t0) >= gTimeLimit
+}
 
 // ---------------------------------------------------------------------------
 // BitArray (self-contained)
@@ -400,6 +430,7 @@ func bench(label string, fn func()) (ops int, elapsed time.Duration) {
 	for i := 0; i < 10; i++ {
 		fn()
 	}
+	dur := gBenchDur
 	start := time.Now()
 	for {
 		for i := 0; i < 100; i++ {
@@ -407,7 +438,7 @@ func bench(label string, fn func()) (ops int, elapsed time.Duration) {
 		}
 		ops += 100
 		elapsed = time.Since(start)
-		if elapsed >= time.Second {
+		if elapsed >= dur {
 			break
 		}
 	}
@@ -443,8 +474,9 @@ func testHkexGFCorrectness() {
 	for _, size := range gfSizes {
 		poly := gfPoly[size]
 		g := big.NewInt(gfGen)
-		ok := 0
-		for i := 0; i < 1000; i++ {
+		ok, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			b := randBA(size)
 			C := GfPow(g, &a.val, poly, size)
@@ -452,12 +484,13 @@ func testHkexGFCorrectness() {
 			if GfPow(C2, &a.val, poly, size).Cmp(GfPow(C, &b.val, poly, size)) == 0 {
 				ok++
 			}
+			if i&7 == 7 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 1000 {
+		if ok != N {
 			status = "FAIL"
 		}
-		fmt.Printf("    bits=%3d  %5d / 1000 correct  [%s]\n", size, ok, status)
+		fmt.Printf("    bits=%3d  %5d / %d correct  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
@@ -468,7 +501,9 @@ func testAvalanche() {
 		total := 0.0
 		gmin := size + 1
 		gmax := -1
-		for trial := 0; trial < 1000; trial++ {
+		N := testRounds(1000)
+		t0 := time.Now()
+		for trial := 0; trial < N; trial++ {
 			a := randBA(size)
 			b := randBA(size)
 			base := Fscx(a, b)
@@ -476,15 +511,12 @@ func testAvalanche() {
 				ap := a.FlipBit(bit)
 				hd := Fscx(ap, b).Xor(base).Popcount()
 				total += float64(hd)
-				if hd < gmin {
-					gmin = hd
-				}
-				if hd > gmax {
-					gmax = hd
-				}
+				if hd < gmin { gmin = hd }
+				if hd > gmax { gmax = hd }
 			}
+			if trial&63 == 63 && timeExceeded(t0) { N = trial + 1; break }
 		}
-		mean := total / (1000.0 * float64(size))
+		mean := total / (float64(N) * float64(size))
 		status := "PASS"
 		if mean < 2.9 || mean > 3.1 {
 			status = "FAIL"
@@ -498,11 +530,11 @@ func testAvalanche() {
 func testOrbitPeriod() {
 	fmt.Println("[3] Orbit period: FSCX_REVOLVE cycles back to A  [CLASSICAL]")
 	for _, size := range sizes {
-		cntP := 0
-		cntHP := 0
-		other := 0
+		cntP, cntHP, other := 0, 0, 0
 		cap := 2 * size
-		for trial := 0; trial < 100; trial++ {
+		N := testRounds(100)
+		t0 := time.Now()
+		for trial := 0; trial < N; trial++ {
 			a := randBA(size)
 			b := randBA(size)
 			cur := Fscx(a, b)
@@ -511,18 +543,11 @@ func testOrbitPeriod() {
 				cur = Fscx(cur, b)
 				period++
 			}
-			if period == size {
-				cntP++
-			} else if period == size/2 {
-				cntHP++
-			} else {
-				other++
-			}
+			if period == size { cntP++ } else if period == size/2 { cntHP++ } else { other++ }
+			if trial&15 == 15 && timeExceeded(t0) { N = trial + 1; break }
 		}
 		status := "PASS"
-		if other != 0 {
-			status = "FAIL"
-		}
+		if other != 0 { status = "FAIL" }
 		fmt.Printf("    bits=%3d  period=%d: %3d  period=%d: %3d  other: %d  [%s]\n",
 			size, size, cntP, size/2, cntHP, other, status)
 	}
@@ -530,38 +555,33 @@ func testOrbitPeriod() {
 }
 
 func testBitFrequency() {
-	fmt.Println("[4] Bit-frequency bias: 10000 FSCX outputs per size  [CLASSICAL]")
-	N := 10000
+	N := testRounds(10000)
+	fmt.Printf("[4] Bit-frequency bias: %d FSCX outputs per size  [CLASSICAL]\n", N)
 	for _, size := range sizes {
 		counts := make([]int, size)
+		nRun := 0
+		t0 := time.Now()
 		for trial := 0; trial < N; trial++ {
+			nRun++
 			a := randBA(size)
 			b := randBA(size)
 			out := Fscx(a, b)
 			for bit := 0; bit < size; bit++ {
-				if out.val.Bit(bit) == 1 {
-					counts[bit]++
-				}
+				if out.val.Bit(bit) == 1 { counts[bit]++ }
 			}
+			if trial&255 == 255 && timeExceeded(t0) { break }
 		}
 		var mn, mx, mean float64
-		mn = 101.0
-		mx = -1.0
+		mn = 101.0; mx = -1.0
 		for bit := 0; bit < size; bit++ {
-			pct := float64(counts[bit]) / float64(N) * 100.0
+			pct := float64(counts[bit]) / float64(nRun) * 100.0
 			mean += pct
-			if pct < mn {
-				mn = pct
-			}
-			if pct > mx {
-				mx = pct
-			}
+			if pct < mn { mn = pct }
+			if pct > mx { mx = pct }
 		}
 		mean /= float64(size)
 		status := "PASS"
-		if mn <= 47.0 || mx >= 53.0 {
-			status = "FAIL"
-		}
+		if mn <= 47.0 || mx >= 53.0 { status = "FAIL" }
 		fmt.Printf("    bits=%3d  min=%.2f%%  max=%.2f%%  mean=%.2f%%  [%s]\n",
 			size, mn, mx, mean, status)
 	}
@@ -574,7 +594,9 @@ func testHkexGFKeySensitivity() {
 		poly := gfPoly[size]
 		g := big.NewInt(gfGen)
 		total := 0.0
-		for i := 0; i < 1000; i++ {
+		N := testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			b := randBA(size)
 			C2 := GfPow(g, &b.val, poly, size)
@@ -584,26 +606,27 @@ func testHkexGFKeySensitivity() {
 			diff := &BitArray{size: size}
 			diff.val.Xor(sk1, sk2)
 			total += float64(diff.Popcount())
+			if i&7 == 7 && timeExceeded(t0) { N = i + 1; break }
 		}
-		mean := total / 1000.0
+		mean := total / float64(N)
 		expected := size / 4
 		status := "PASS"
-		if mean < float64(expected) {
-			status = "FAIL"
-		}
+		if mean < float64(expected) { status = "FAIL" }
 		fmt.Printf("    bits=%3d  mean HD=%.2f (expected >=%d)  [%s]\n", size, mean, expected, status)
 	}
 	fmt.Println()
 }
 
 func testHkexGFEveResistance() {
-	fmt.Println("[6] HKEX-GF Eve resistance: S_op(C XOR C2, r) != sk for 1000 trials  [CLASSICAL]")
+	N := testRounds(1000)
+	fmt.Printf("[6] HKEX-GF Eve resistance: S_op(C XOR C2, r) != sk for %d trials  [CLASSICAL]\n", N)
 	for _, size := range gfSizes {
 		poly := gfPoly[size]
 		g := big.NewInt(gfGen)
 		rv := rVal(size)
 		successes := 0
-		for i := 0; i < 1000; i++ {
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			b := randBA(size)
 			C := newBA(size, GfPow(g, &a.val, poly, size))
@@ -611,15 +634,12 @@ func testHkexGFEveResistance() {
 			realSk := newBA(size, GfPow(&C2.val, &a.val, poly, size))
 			delta := C.Xor(C2)
 			eveGuess := SOpBA(delta, rv)
-			if eveGuess.Equal(realSk) {
-				successes++
-			}
+			if eveGuess.Equal(realSk) { successes++ }
+			if i&7 == 7 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if successes != 0 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %5d / 1000 Eve successes (expected 0)  [%s]\n", size, successes, status)
+		if successes != 0 { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %5d / %d Eve successes (expected 0)  [%s]\n", size, successes, N, status)
 	}
 	fmt.Println()
 }
@@ -631,8 +651,9 @@ func testHpksSchnorrCorrectness() {
 		g := big.NewInt(gfGen)
 		iv := iVal(size)
 		ord := gfOrd(size)
-		ok := 0
-		for i := 0; i < 1000; i++ {
+		ok, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			cVal := GfPow(g, &a.val, poly, size)
 			pt := randBA(size)
@@ -642,15 +663,12 @@ func testHpksSchnorrCorrectness() {
 			e := FscxRevolve(rB, pt, iv)
 			s := new(big.Int).Mod(new(big.Int).Sub(&k.val, new(big.Int).Mul(&a.val, &e.val)), ord)
 			lhs := GfMul(GfPow(g, s, poly, size), GfPow(cVal, &e.val, poly, size), poly, size)
-			if lhs.Cmp(rInt) == 0 {
-				ok++
-			}
+			if lhs.Cmp(rInt) == 0 { ok++ }
+			if i&63 == 63 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 1000 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %4d / 1000 verified  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %4d / %d verified  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
@@ -661,8 +679,9 @@ func testHpksSchnorrEveResistance() {
 		poly := gfPoly[size]
 		g := big.NewInt(gfGen)
 		iv := iVal(size)
-		wins := 0
-		for i := 0; i < 1000; i++ {
+		wins, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			cVal := GfPow(g, &a.val, poly, size)
 			decoy := randBA(size)
@@ -670,15 +689,12 @@ func testHpksSchnorrEveResistance() {
 			eEve := FscxRevolve(rEve, decoy, iv)
 			sEve := new(big.Int).Set(&randBA(size).val)
 			lhs := GfMul(GfPow(g, sEve, poly, size), GfPow(cVal, &eEve.val, poly, size), poly, size)
-			if lhs.Cmp(&rEve.val) == 0 {
-				wins++
-			}
+			if lhs.Cmp(&rEve.val) == 0 { wins++ }
+			if i&63 == 63 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if wins != 0 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %4d / 1000 Eve wins (expected 0)  [%s]\n", size, wins, status)
+		if wins != 0 { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %4d / %d Eve wins (expected 0)  [%s]\n", size, wins, N, status)
 	}
 	fmt.Println()
 }
@@ -690,8 +706,9 @@ func testHpkeRoundTrip() {
 		g := big.NewInt(gfGen)
 		iv := iVal(size)
 		rv := rVal(size)
-		ok := 0
-		for i := 0; i < 1000; i++ {
+		ok, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			pt := randBA(size)
 			cVal := GfPow(g, &a.val, poly, size)
@@ -701,15 +718,12 @@ func testHpkeRoundTrip() {
 			E := FscxRevolve(pt, encKey, iv)
 			decKey := newBA(size, GfPow(rVal2, &a.val, poly, size))
 			D := FscxRevolve(E, decKey, rv)
-			if D.Equal(pt) {
-				ok++
-			}
+			if D.Equal(pt) { ok++ }
+			if i&63 == 63 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 1000 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %4d / 1000 decrypted  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %4d / %d decrypted  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
@@ -725,39 +739,33 @@ func testNlFscxV1Nonlinearity() {
 	fmt.Println("[10] NL-FSCX v1 non-linearity and aperiodicity  [PQC-EXT]")
 	for _, size := range sizes {
 		zero := &BitArray{size: size}
+		N1, N2 := testRounds(1000), testRounds(200)
 		violations := 0
-		for i := 0; i < 1000; i++ {
-			A := randBA(size)
-			B := randBA(size)
+		t0 := time.Now()
+		for i := 0; i < N1; i++ {
+			A := randBA(size); B := randBA(size)
 			linPred := Fscx(A, zero).Xor(NlFscxV1(zero, B))
-			if !NlFscxV1(A, B).Equal(linPred) {
-				violations++
-			}
+			if !NlFscxV1(A, B).Equal(linPred) { violations++ }
+			if i&63 == 63 && timeExceeded(t0) { N1 = i + 1; break }
 		}
 		cap := 4 * size
 		noPeriod := 0
-		for i := 0; i < 200; i++ {
-			A := randBA(size)
-			B := randBA(size)
+		t0 = time.Now()
+		for i := 0; i < N2; i++ {
+			A := randBA(size); B := randBA(size)
 			cur := NlFscxV1(A, B)
 			found := false
 			for j := 1; j < cap; j++ {
 				cur = NlFscxV1(cur, B)
-				if cur.Equal(A) {
-					found = true
-					break
-				}
+				if cur.Equal(A) { found = true; break }
 			}
-			if !found {
-				noPeriod++
-			}
+			if !found { noPeriod++ }
+			if i&31 == 31 && timeExceeded(t0) { N2 = i + 1; break }
 		}
 		status := "PASS"
-		if violations != 1000 || noPeriod < 190 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  linearity violations=%d/1000  no-period=%d/200  [%s]\n",
-			size, violations, noPeriod, status)
+		if violations != N1 || noPeriod < N2*95/100 { status = "FAIL" }
+		fmt.Printf("    bits=%3d  linearity violations=%d/%d  no-period=%d/%d  [%s]\n",
+			size, violations, N1, noPeriod, N2, status)
 	}
 	fmt.Println()
 }
@@ -767,51 +775,45 @@ func testNlFscxV2BijectiveInverse() {
 	// the closed-form inverse must be correct, and v2 must be non-linear.
 	fmt.Println("[11] NL-FSCX v2 bijectivity and exact inverse  [PQC-EXT]")
 	for _, size := range sizes {
-		// Collision test: map A->NlFscxV2(A,B) must be injective for fixed B
+		N1, N2, N3 := testRounds(500), testRounds(1000), testRounds(500)
+		// Collision test
 		nonBij := 0
-		for i := 0; i < 500; i++ {
+		t0 := time.Now()
+		for i := 0; i < N1; i++ {
 			B := randBA(size)
 			seen := make(map[string]uint64)
 			samples := 256
-			if size < 8 {
-				samples = 1 << uint(size)
-			}
+			if size < 8 { samples = 1 << uint(size) }
 			for j := 0; j < samples; j++ {
 				A := randBA(size)
 				out := NlFscxV2(A, B).val.Text(16)
-				if prev, ok := seen[out]; ok && prev != A.val.Uint64() {
-					nonBij++
-					break
-				}
+				if prev, ok := seen[out]; ok && prev != A.val.Uint64() { nonBij++; break }
 				seen[out] = A.val.Uint64()
 			}
+			if i&63 == 63 && timeExceeded(t0) { N1 = i + 1; break }
 		}
 		// Inverse correctness
 		invOk := 0
-		for i := 0; i < 1000; i++ {
-			A := randBA(size)
-			B := randBA(size)
-			if NlFscxV2Inv(NlFscxV2(A, B), B).Equal(A) {
-				invOk++
-			}
+		t0 = time.Now()
+		for i := 0; i < N2; i++ {
+			A := randBA(size); B := randBA(size)
+			if NlFscxV2Inv(NlFscxV2(A, B), B).Equal(A) { invOk++ }
+			if i&63 == 63 && timeExceeded(t0) { N2 = i + 1; break }
 		}
 		// Non-linearity
 		zero := &BitArray{size: size}
 		nlOk := 0
-		for i := 0; i < 500; i++ {
-			A := randBA(size)
-			B := randBA(size)
+		t0 = time.Now()
+		for i := 0; i < N3; i++ {
+			A := randBA(size); B := randBA(size)
 			linPred := Fscx(A, zero).Xor(NlFscxV2(zero, B))
-			if !NlFscxV2(A, B).Equal(linPred) {
-				nlOk++
-			}
+			if !NlFscxV2(A, B).Equal(linPred) { nlOk++ }
+			if i&63 == 63 && timeExceeded(t0) { N3 = i + 1; break }
 		}
 		status := "PASS"
-		if nonBij != 0 || invOk != 1000 || nlOk < 490 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  collisions=%d/500  inv=%d/1000  nonlinear=%d/500  [%s]\n",
-			size, nonBij, invOk, nlOk, status)
+		if nonBij != 0 || invOk != N2 || nlOk < N3*98/100 { status = "FAIL" }
+		fmt.Printf("    bits=%3d  collisions=%d/%d  inv=%d/%d  nonlinear=%d/%d  [%s]\n",
+			size, nonBij, N1, invOk, N2, nlOk, N3, status)
 	}
 	fmt.Println()
 }
@@ -820,48 +822,42 @@ func testHskeNlA1Correctness() {
 	fmt.Println("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
-		ok := 0
-		for trial := 0; trial < 1000; trial++ {
-			K := randBA(size)
-			P := randBA(size)
+		ok, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for trial := 0; trial < N; trial++ {
+			K := randBA(size); P := randBA(size)
 			ctr := int64(trial % (1 << 16))
 			bCtr := newBA(size, new(big.Int).Xor(&K.val, big.NewInt(ctr)))
 			ks := NlFscxRevolveV1(K, bCtr, iv)
 			C := newBA(size, new(big.Int).Xor(&P.val, &ks.val))
 			D := newBA(size, new(big.Int).Xor(&C.val, &ks.val))
-			if D.Equal(P) {
-				ok++
-			}
+			if D.Equal(P) { ok++ }
+			if trial&63 == 63 && timeExceeded(t0) { N = trial + 1; break }
 		}
 		status := "PASS"
-		if ok != 1000 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %4d / 1000 correct  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %4d / %d correct  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
 
 func testHskeNlA2Correctness() {
-	// Trials reduced to 50: NlFscxV2Inv calls M^{n/2-1} per step — O(n^2) ops per trial.
+	// Default 50 trials: NlFscxV2Inv calls M^{n/2-1} per step — O(n^2) ops per trial.
 	fmt.Println("[13] HSKE-NL-A2 revolve-mode correctness: D == P  [PQC-EXT]")
 	for _, size := range sizes {
 		rv := rVal(size)
-		ok := 0
-		for i := 0; i < 50; i++ {
-			K := randBA(size)
-			P := randBA(size)
+		ok, N := 0, testRounds(50)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
+			K := randBA(size); P := randBA(size)
 			E := NlFscxRevolveV2(P, K, rv)
 			D := NlFscxRevolveV2Inv(E, K, rv)
-			if D.Equal(P) {
-				ok++
-			}
+			if D.Equal(P) { ok++ }
+			if i&15 == 15 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 50 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %3d / 50 correct  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %3d / %d correct  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
@@ -871,9 +867,9 @@ func testHkexRnlCorrectness() {
 	fmt.Printf("     (ring sizes %v; production size is n=256)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := rnlMPoly(nRnl)
-		okRaw := 0
-		okSk := 0
-		trials := 200
+		okRaw, okSk := 0, 0
+		trials := testRounds(200)
+		t0 := time.Now()
 		for i := 0; i < trials; i++ {
 			aRand := rnlRandPoly(nRnl, rnlQ)
 			mBlind := rnlPolyAdd(mBase, aRand, rnlQ)
@@ -885,15 +881,12 @@ func testHkexRnlCorrectness() {
 				okRaw++
 				skA := NlFscxRevolveV1(KA, KA, nRnl/4)
 				skB := NlFscxRevolveV1(KB, KB, nRnl/4)
-				if skA.Equal(skB) {
-					okSk++
-				}
+				if skA.Equal(skB) { okSk++ }
 			}
+			if i&15 == 15 && timeExceeded(t0) { trials = i + 1; break }
 		}
 		status := "PASS"
-		if okRaw < trials*90/100 {
-			status = "FAIL"
-		}
+		if okRaw < trials*90/100 { status = "FAIL" }
 		fmt.Printf("    n=%3d  raw agree=%d/%d  sk agree=%d/%d  [%s]\n",
 			nRnl, okRaw, trials, okSk, trials, status)
 	}
@@ -907,8 +900,9 @@ func testHpksNlCorrectness() {
 		g := big.NewInt(gfGen)
 		iv := iVal(size)
 		ord := gfOrd(size)
-		ok := 0
-		for i := 0; i < 1000; i++ {
+		ok, N := 0, testRounds(1000)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
 			a := randBA(size)
 			cVal := GfPow(g, &a.val, poly, size)
 			pt := randBA(size)
@@ -918,30 +912,27 @@ func testHpksNlCorrectness() {
 			e := NlFscxRevolveV1(rB, pt, iv)
 			s := new(big.Int).Mod(new(big.Int).Sub(&k.val, new(big.Int).Mul(&a.val, &e.val)), ord)
 			lhs := GfMul(GfPow(g, s, poly, size), GfPow(cVal, &e.val, poly, size), poly, size)
-			if lhs.Cmp(rInt) == 0 {
-				ok++
-			}
+			if lhs.Cmp(rInt) == 0 { ok++ }
+			if i&63 == 63 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 1000 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %4d / 1000 verified  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %4d / %d verified  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
 
 func testHpkeNlCorrectness() {
-	// Trials reduced to 200: NlFscxV2Inv calls M^{n/2-1} per step.
+	// Default 200 trials: NlFscxV2Inv calls M^{n/2-1} per step.
 	fmt.Println("[16] HPKE-NL correctness: D == P (NL-FSCX v2 encrypt/decrypt)  [PQC-EXT]")
 	for _, size := range gfSizes {
 		poly := gfPoly[size]
 		g := big.NewInt(gfGen)
 		iv := iVal(size)
-		ok := 0
-		for i := 0; i < 200; i++ {
-			a := randBA(size)
-			pt := randBA(size)
+		ok, N := 0, testRounds(200)
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
+			a := randBA(size); pt := randBA(size)
 			cVal := GfPow(g, &a.val, poly, size)
 			r := randBA(size)
 			rInt := GfPow(g, &r.val, poly, size)
@@ -949,15 +940,12 @@ func testHpkeNlCorrectness() {
 			E := NlFscxRevolveV2(pt, encKey, iv)
 			decKey := newBA(size, GfPow(rInt, &a.val, poly, size))
 			D := NlFscxRevolveV2Inv(E, decKey, iv)
-			if D.Equal(pt) {
-				ok++
-			}
+			if D.Equal(pt) { ok++ }
+			if i&31 == 31 && timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if ok != 200 {
-			status = "FAIL"
-		}
-		fmt.Printf("    bits=%3d  %3d / 200 decrypted  [%s]\n", size, ok, status)
+		if ok != N { status = "FAIL" }
+		fmt.Printf("    bits=%3d  %3d / %d decrypted  [%s]\n", size, ok, N, status)
 	}
 	fmt.Println()
 }
@@ -1145,7 +1133,57 @@ func benchHkexRnlHandshake() {
 // ---------------------------------------------------------------------------
 
 func main() {
-	fmt.Println("=== Herradura KEx \u2014 Security & Performance Tests (Go) ===\n")
+	// --- CLI flags ---
+	flagRounds := flag.Int("rounds", 0, "max iterations per security test (0 = test-specific default)")
+	flagR      := flag.Int("r", 0, "alias for -rounds")
+	flagTime   := flag.Float64("time", 0, "benchmark duration and per-test time cap in seconds (0 = defaults)")
+	flagT      := flag.Float64("t", 0, "alias for -time")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"Usage: Herradura_tests [-rounds N] [-time T]\n"+
+			"  -rounds, -r N   max iterations per security test\n"+
+			"  -time,   -t T   benchmark duration and per-test time cap (seconds)\n"+
+			"  Env: HTEST_ROUNDS=N  HTEST_TIME=T\n")
+	}
+	flag.Parse()
+
+	// env var fallbacks
+	if envR := os.Getenv("HTEST_ROUNDS"); envR != "" {
+		if v, err := strconv.Atoi(envR); err == nil && v > 0 && *flagRounds == 0 && *flagR == 0 {
+			gRounds = v
+		}
+	}
+	if envT := os.Getenv("HTEST_TIME"); envT != "" {
+		if v, err := strconv.ParseFloat(envT, 64); err == nil && v > 0 && *flagTime == 0 && *flagT == 0 {
+			gBenchDur  = time.Duration(v * float64(time.Second))
+			gTimeLimit = gBenchDur
+		}
+	}
+	// CLI overrides env
+	if r := *flagRounds; r > 0 { gRounds = r }
+	if r := *flagR;      r > 0 { gRounds = r }
+	if t := *flagTime;   t > 0 {
+		gBenchDur  = time.Duration(t * float64(time.Second))
+		gTimeLimit = gBenchDur
+	}
+	if t := *flagT; t > 0 {
+		gBenchDur  = time.Duration(t * float64(time.Second))
+		gTimeLimit = gBenchDur
+	}
+	if gBenchDur == 0 { gBenchDur = time.Second }
+
+	fmt.Println("=== Herradura KEx v1.5.1 \u2014 Security & Performance Tests (Go) ===")
+	if gRounds > 0 || gTimeLimit > 0 {
+		switch {
+		case gRounds > 0 && gTimeLimit > 0:
+			fmt.Printf("    Config: rounds=%d  time_limit=%.2fs\n", gRounds, gTimeLimit.Seconds())
+		case gRounds > 0:
+			fmt.Printf("    Config: rounds=%d\n", gRounds)
+		default:
+			fmt.Printf("    Config: time_limit=%.2fs\n", gTimeLimit.Seconds())
+		}
+	}
+	fmt.Println()
 
 	fmt.Println("--- Security Tests: Classical Protocols ---\n")
 	testHkexGFCorrectness()

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.1: added --rounds/-r and --time/-t CLI options (also HTEST_ROUNDS / HTEST_TIME env).
     v1.5.0: added PQC extension tests [10-16] and benchmarks [22-25].
             benchmarks renumbered [17-21] (were [10-14] in v1.4.0).
     v1.4.0: replaced broken fscx_revolve_n HKEX tests with HKEX-GF tests.
@@ -24,7 +25,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
+import argparse
 import os
+import sys
 import time
 
 # ---------------------------------------------------------------------------
@@ -284,7 +287,30 @@ RNLP  = 4096   # public-key rounding modulus
 RNLPP = 2      # reconciliation modulus (1 bit per coefficient)
 RNLB  = 1      # small-secret bound
 
-TARGET_SEC = 1.0
+TARGET_SEC = 1.0  # kept for reference; overridden by g_bench_sec at runtime
+
+# --- Runtime limits (set in __main__ via CLI / env vars) -----------------
+g_rounds     = 0    # 0 = use per-test default
+g_bench_sec  = 1.0  # benchmark duration (seconds)
+g_time_limit = 0.0  # per-test wall-clock cap; 0 = none
+
+
+def _iters(default_n: int) -> int:
+    """Effective iteration count: g_rounds if set, otherwise default_n."""
+    return g_rounds if g_rounds > 0 else default_n
+
+
+def _trange(n: int):
+    """Like range(n) but stops early when g_time_limit is reached.
+    Yields the iteration index so callers can use it as a loop variable."""
+    if g_time_limit <= 0:
+        yield from range(n)
+        return
+    t0 = time.monotonic()
+    for i in range(n):
+        yield i
+        if (i & 63) == 63 and time.monotonic() - t0 >= g_time_limit:
+            return
 
 
 # ---------------------------------------------------------------------------
@@ -310,31 +336,33 @@ def test_hkex_gf_correctness():
     print("[1] HKEX-GF correctness: g^{ab} == g^{ba} in GF(2^n)*  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425)
-        ok = 0
-        for _ in range(GF_TRIALS):
+        ok = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a = BitArray.random(size)
             b = BitArray.random(size)
             C  = gf_pow(GF_GEN, a.uint, poly, size)
             C2 = gf_pow(GF_GEN, b.uint, poly, size)
             if gf_pow(C2, a.uint, poly, size) == gf_pow(C, b.uint, poly, size):
                 ok += 1
-        status = "PASS" if ok == GF_TRIALS else "FAIL"
-        print(f"    bits={size:3d}  {ok:5d} / {GF_TRIALS} correct  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:5d} / {n_run} correct  [{status}]")
     print()
 
 
 def test_avalanche():
     print("[2] FSCX single-step linear diffusion (expected: exactly 3 bits per flip)  [CLASSICAL]")
     for size in SIZES:
-        total = 0.0; gmin = size + 1; gmax = -1
-        for _ in range(1000):
+        total = 0.0; gmin = size + 1; gmax = -1; n_run = 0
+        for _ in _trange(_iters(1000)):
+            n_run += 1
             a = BitArray.random(size); b = BitArray.random(size)
             base = fscx(a, b)
             for bit in range(size):
                 hd = (fscx(a.flip_bit(bit), b) ^ base).popcount()
                 total += hd
                 gmin = min(gmin, hd); gmax = max(gmax, hd)
-        mean = total / (1000.0 * size)
+        mean = total / (float(n_run) * size) if n_run > 0 else 0.0
         status = "PASS" if 2.9 <= mean <= 3.1 else "FAIL"
         print(f"    bits={size:3d}  mean={mean:.2f} (expected 3/{size})  min={gmin}  max={gmax}  [{status}]")
     print()
@@ -344,7 +372,7 @@ def test_orbit_period():
     print("[3] Orbit period: FSCX_REVOLVE cycles back to A  [CLASSICAL]")
     for size in SIZES:
         cnt_p = 0; cnt_hp = 0; other = 0; cap = 2 * size
-        for _ in range(100):
+        for _ in _trange(_iters(100)):
             a = BitArray.random(size); b = BitArray.random(size)
             cur = fscx(a, b); period = 1
             while cur != a and period < cap:
@@ -358,15 +386,16 @@ def test_orbit_period():
 
 
 def test_bit_frequency():
-    print("[4] Bit-frequency bias: 10000 FSCX outputs per size  [CLASSICAL]")
-    N = 10000
+    N = _iters(10000)
+    print(f"[4] Bit-frequency bias: {N} FSCX outputs per size  [CLASSICAL]")
     for size in SIZES:
-        counts = [0] * size
-        for _ in range(N):
+        counts = [0] * size; n_run = 0
+        for _ in _trange(N):
+            n_run += 1
             val = fscx(BitArray.random(size), BitArray.random(size)).uint
             for bit in range(size):
                 if (val >> bit) & 1: counts[bit] += 1
-        pcts  = [c / N * 100.0 for c in counts]
+        pcts  = [c / n_run * 100.0 for c in counts] if n_run > 0 else [0.0] * size
         mn = min(pcts); mx = max(pcts); mean = sum(pcts) / size
         status = "PASS" if mn > 47.0 and mx < 53.0 else "FAIL"
         print(f"    bits={size:3d}  min={mn:.2f}%  max={mx:.2f}%  mean={mean:.2f}%  [{status}]")
@@ -376,39 +405,43 @@ def test_bit_frequency():
 def test_hkex_gf_key_sensitivity():
     print("[5] HKEX-GF key sensitivity: flip 1 bit of a, measure HD of sk change  [CLASSICAL]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); total = 0.0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); total = 0.0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a  = BitArray.random(size); b  = BitArray.random(size)
             C2 = gf_pow(GF_GEN, b.uint, poly, size)
             sk1 = gf_pow(C2, a.uint,             poly, size)
             sk2 = gf_pow(C2, a.flip_bit(0).uint, poly, size)
             total += BitArray(size, sk1 ^ sk2).popcount()
-        mean = total / float(GF_TRIALS)
+        mean = total / float(n_run) if n_run > 0 else 0.0
         status = "PASS" if mean >= size // 4 else "FAIL"
         print(f"    bits={size:3d}  mean HD={mean:.2f} (expected >={size//4})  [{status}]")
     print()
 
 
 def test_hkex_gf_eve_resistance():
-    print(f"[6] HKEX-GF Eve resistance: S_op(C^C2, r) != sk for {GF_TRIALS} trials  [CLASSICAL]")
+    T = _iters(GF_TRIALS)
+    print(f"[6] HKEX-GF Eve resistance: S_op(C^C2, r) != sk for {T} trials  [CLASSICAL]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); rv = r_val(size); successes = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); rv = r_val(size); successes = 0; n_run = 0
+        for _ in _trange(T):
+            n_run += 1
             a  = BitArray.random(size); b  = BitArray.random(size)
             C  = BitArray(size, gf_pow(GF_GEN, a.uint, poly, size))
             C2 = BitArray(size, gf_pow(GF_GEN, b.uint, poly, size))
             real_sk = BitArray(size, gf_pow(C2.uint, a.uint, poly, size))
             if s_op(C ^ C2, rv) == real_sk: successes += 1
         status = "PASS" if successes == 0 else "FAIL"
-        print(f"    bits={size:3d}  {successes:5d} / {GF_TRIALS} Eve successes (expected 0)  [{status}]")
+        print(f"    bits={size:3d}  {successes:5d} / {n_run} Eve successes (expected 0)  [{status}]")
     print()
 
 
 def test_hpks_schnorr_correctness():
     print("[7] HPKS Schnorr correctness: g^s · C^e == R  [CLASSICAL]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ord_ = (1 << size) - 1; ok = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ord_ = (1 << size) - 1; ok = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a     = BitArray.random(size)
             C_int = gf_pow(GF_GEN, a.uint, poly, size)
             pt    = BitArray.random(size)
@@ -420,16 +453,17 @@ def test_hpks_schnorr_correctness():
             lhs   = gf_mul(gf_pow(GF_GEN, s,      poly, size),
                            gf_pow(C_int,  e.uint,  poly, size), poly, size)
             if lhs == R_int: ok += 1
-        status = "PASS" if ok == GF_TRIALS else "FAIL"
-        print(f"    bits={size:3d}  {ok:4d} / {GF_TRIALS} verified  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:4d} / {n_run} verified  [{status}]")
     print()
 
 
 def test_hpks_schnorr_eve_resistance():
     print("[8] HPKS Schnorr Eve resistance: random forgery attempts fail  [CLASSICAL]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); wins = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); wins = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a     = BitArray.random(size)
             C_int = gf_pow(GF_GEN, a.uint, poly, size)
             decoy = BitArray.random(size)
@@ -440,15 +474,16 @@ def test_hpks_schnorr_eve_resistance():
                            gf_pow(C_int,  e_eve.uint,  poly, size), poly, size)
             if lhs == R_eve.uint: wins += 1
         status = "PASS" if wins == 0 else "FAIL"
-        print(f"    bits={size:3d}  {wins:4d} / {GF_TRIALS} Eve wins (expected 0)  [{status}]")
+        print(f"    bits={size:3d}  {wins:4d} / {n_run} Eve wins (expected 0)  [{status}]")
     print()
 
 
 def test_hpke_roundtrip():
     print("[9] HPKE encrypt+decrypt correctness (El Gamal + fscx_revolve)  [CLASSICAL]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size); ok = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size); ok = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a   = BitArray.random(size); pt = BitArray.random(size)
             C   = gf_pow(GF_GEN, a.uint, poly, size)
             r   = BitArray.random(size)
@@ -458,8 +493,8 @@ def test_hpke_roundtrip():
             dec = BitArray(size, gf_pow(R, a.uint, poly, size))
             D   = fscx_revolve(E,   dec, rv)
             if D == pt: ok += 1
-        status = "PASS" if ok == GF_TRIALS else "FAIL"
-        print(f"    bits={size:3d}  {ok:4d} / {GF_TRIALS} decrypted  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:4d} / {n_run} decrypted  [{status}]")
     print()
 
 
@@ -474,37 +509,41 @@ def test_nl_fscx_v1_nonlinearity():
     print("[10] NL-FSCX v1 non-linearity and aperiodicity  [PQC-EXT]")
     for size in SIZES:
         zero = BitArray(size, 0)
+        N1 = _iters(1000); N2 = _iters(200)
         # Linearity violations
-        violations = 0
-        for _ in range(1000):
+        violations = 0; n1_run = 0
+        for _ in _trange(N1):
+            n1_run += 1
             A = BitArray.random(size); B = BitArray.random(size)
             lin_pred = fscx(A, zero) ^ nl_fscx_v1(zero, B)
             if nl_fscx_v1(A, B) != lin_pred:
                 violations += 1
         # Period check: no period in 4*n steps
-        cap = 4 * size; no_period = 0
-        for _ in range(200):
+        cap = 4 * size; no_period = 0; n2_run = 0
+        for _ in _trange(N2):
+            n2_run += 1
             A = BitArray.random(size); B = BitArray.random(size)
             cur = nl_fscx_v1(A, B); found = False
             for _ in range(1, cap):
                 cur = nl_fscx_v1(cur, B)
                 if cur == A: found = True; break
             if not found: no_period += 1
-        status = "PASS" if violations == 1000 and no_period >= 190 else "FAIL"
-        print(f"    bits={size:3d}  linearity violations={violations}/1000  "
-              f"no-period={no_period}/200  [{status}]")
+        status = "PASS" if violations == n1_run and no_period >= n2_run * 95 // 100 else "FAIL"
+        print(f"    bits={size:3d}  linearity violations={violations}/{n1_run}  "
+              f"no-period={no_period}/{n2_run}  [{status}]")
     print()
 
 
 def test_nl_fscx_v2_bijective_inverse():
     # NL-FSCX v2 must be bijective in A for all B (non-bijective count = 0),
-    # and the closed-form inverse must be correct for 1000 random (A,B) pairs.
+    # and the closed-form inverse must be correct for N random (A,B) pairs.
     print("[11] NL-FSCX v2 bijectivity and exact inverse  [PQC-EXT]")
     for size in SIZES:
+        N1 = _iters(500); N2 = _iters(1000); N3 = _iters(500)
         # Bijectivity: map A -> nl_fscx_v2(A, B) must be injective for fixed B
-        # (tested via collision count over random samples)
-        non_bij = 0
-        for _ in range(500):
+        non_bij = 0; n1_run = 0
+        for _ in _trange(N1):
+            n1_run += 1
             B    = BitArray.random(size)
             seen = {}
             for _ in range(min(256, 1 << min(size, 8))):
@@ -514,33 +553,35 @@ def test_nl_fscx_v2_bijective_inverse():
                     non_bij += 1; break
                 seen[out] = A.uint
         # Inverse correctness
-        inv_ok = 0
-        for _ in range(1000):
+        inv_ok = 0; n2_run = 0
+        for _ in _trange(N2):
+            n2_run += 1
             A = BitArray.random(size); B = BitArray.random(size)
             if nl_fscx_v2_inv(nl_fscx_v2(A, B), B) == A:
                 inv_ok += 1
         # Non-linearity check
         zero = BitArray(size, 0)
-        nl_ok = 0
-        for _ in range(500):
+        nl_ok = 0; n3_run = 0
+        for _ in _trange(N3):
+            n3_run += 1
             A = BitArray.random(size); B = BitArray.random(size)
             if nl_fscx_v2(A, B) != BitArray(size,
                (fscx(A, zero).uint ^ nl_fscx_v2(zero, B).uint)):
                 nl_ok += 1
-        status = "PASS" if non_bij == 0 and inv_ok == 1000 and nl_ok >= 490 else "FAIL"
-        print(f"    bits={size:3d}  collisions={non_bij}/500  inv={inv_ok}/1000  "
-              f"nonlinear={nl_ok}/500  [{status}]")
+        status = "PASS" if non_bij == 0 and inv_ok == n2_run and nl_ok >= n3_run * 98 // 100 else "FAIL"
+        print(f"    bits={size:3d}  collisions={non_bij}/{n1_run}  inv={inv_ok}/{n2_run}  "
+              f"nonlinear={nl_ok}/{n3_run}  [{status}]")
     print()
 
 
 def test_hske_nl_a1_correctness():
     # HSKE-NL-A1 counter-mode: C = P XOR keystream; D = C XOR keystream = P.
     # keystream[i] = nl_fscx_revolve_v1(K, K XOR i, n/4).
-    # Test correctness for 1000 random (K, P, counter) tuples.
     print("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
     for size in SIZES:
-        iv = i_val(size); ok = 0
-        for trial in range(1000):
+        iv = i_val(size); ok = 0; n_run = 0
+        for trial in _trange(_iters(1000)):
+            n_run += 1
             K   = BitArray.random(size)
             P   = BitArray.random(size)
             ctr = trial % (1 << min(size, 16))
@@ -549,25 +590,26 @@ def test_hske_nl_a1_correctness():
             C   = BitArray(size, P.uint ^ ks.uint)
             D   = BitArray(size, C.uint ^ ks.uint)
             if D == P: ok += 1
-        status = "PASS" if ok == 1000 else "FAIL"
-        print(f"    bits={size:3d}  {ok:4d} / 1000 correct  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:4d} / {n_run} correct  [{status}]")
     print()
 
 
 def test_hske_nl_a2_correctness():
     # HSKE-NL-A2 revolve mode: E = nl_fscx_revolve_v2(P, K, r);
     # D = nl_fscx_revolve_v2_inv(E, K, r) must equal P.
-    # Trials reduced to 50: nl_fscx_v2_inv calls M^{n/2-1} per step — O(n^2) fscx ops total.
+    # Default 50 trials: nl_fscx_v2_inv calls M^{n/2-1} per step — O(n^2) fscx ops total.
     print("[13] HSKE-NL-A2 revolve-mode correctness: D == P  [PQC-EXT]")
     for size in SIZES:
-        rv = r_val(size); ok = 0
-        for _ in range(50):
+        rv = r_val(size); ok = 0; n_run = 0
+        for _ in _trange(_iters(50)):
+            n_run += 1
             K = BitArray.random(size); P = BitArray.random(size)
             E = nl_fscx_revolve_v2(P, K, rv)
             D = nl_fscx_revolve_v2_inv(E, K, rv)
             if D == P: ok += 1
-        status = "PASS" if ok == 50 else "FAIL"
-        print(f"    bits={size:3d}  {ok:3d} /  50 correct  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:3d} / {n_run:3d} correct  [{status}]")
     print()
 
 
@@ -580,8 +622,9 @@ def test_hkex_rnl_correctness():
     print(f"     (ring sizes {RNL_SIZES}; production size is n=256)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
-        ok_raw = 0; ok_sk = 0; trials = 200
-        for _ in range(trials):
+        ok_raw = 0; ok_sk = 0; n_run = 0
+        for _ in _trange(_iters(200)):
+            n_run += 1
             a_rand  = _rnl_rand_poly(n_rnl, RNLQ)
             m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
             s_A, C_A = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
@@ -593,8 +636,8 @@ def test_hkex_rnl_correctness():
                 sk_A = nl_fscx_revolve_v1(K_A, K_A, n_rnl // 4)
                 sk_B = nl_fscx_revolve_v1(K_B, K_B, n_rnl // 4)
                 if sk_A == sk_B: ok_sk += 1
-        status = "PASS" if ok_raw >= trials * 90 // 100 else "FAIL"
-        print(f"    n={n_rnl:3d}  raw agree={ok_raw}/{trials}  sk agree={ok_sk}/{trials}  [{status}]")
+        status = "PASS" if ok_raw >= n_run * 90 // 100 else "FAIL"
+        print(f"    n={n_rnl:3d}  raw agree={ok_raw}/{n_run}  sk agree={ok_sk}/{n_run}  [{status}]")
     print()
 
 
@@ -604,8 +647,9 @@ def test_hpks_nl_correctness():
     # Verify: g^s * C^e == R
     print("[15] HPKS-NL correctness: g^s · C^e == R (NL-FSCX v1 challenge)  [PQC-EXT]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ord_ = (1 << size) - 1; ok = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ord_ = (1 << size) - 1; ok = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a     = BitArray.random(size)
             C_int = gf_pow(GF_GEN, a.uint, poly, size)
             pt    = BitArray.random(size)
@@ -617,8 +661,8 @@ def test_hpks_nl_correctness():
             lhs   = gf_mul(gf_pow(GF_GEN, s,      poly, size),
                            gf_pow(C_int,  e.uint,  poly, size), poly, size)
             if lhs == R_int: ok += 1
-        status = "PASS" if ok == GF_TRIALS else "FAIL"
-        print(f"    bits={size:3d}  {ok:4d} / {GF_TRIALS} verified  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:4d} / {n_run} verified  [{status}]")
     print()
 
 
@@ -628,8 +672,9 @@ def test_hpke_nl_correctness():
     # Alice: dec=R^a=enc; D=nl_fscx_revolve_v2_inv(E, dec, I) must equal P.
     print("[16] HPKE-NL correctness: D == P (NL-FSCX v2 encrypt/decrypt)  [PQC-EXT]")
     for size in GF_SIZES:
-        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ok = 0
-        for _ in range(GF_TRIALS):
+        poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); ok = 0; n_run = 0
+        for _ in _trange(_iters(GF_TRIALS)):
+            n_run += 1
             a   = BitArray.random(size); pt = BitArray.random(size)
             C   = gf_pow(GF_GEN, a.uint, poly, size)
             r   = BitArray.random(size)
@@ -639,8 +684,8 @@ def test_hpke_nl_correctness():
             dec = BitArray(size, gf_pow(R, a.uint, poly, size))
             D   = nl_fscx_revolve_v2_inv(E, dec, iv)
             if D == pt: ok += 1
-        status = "PASS" if ok == GF_TRIALS else "FAIL"
-        print(f"    bits={size:3d}  {ok:3d} / {GF_TRIALS} decrypted  [{status}]")
+        status = "PASS" if ok == n_run else "FAIL"
+        print(f"    bits={size:3d}  {ok:3d} / {n_run} decrypted  [{status}]")
     print()
 
 
@@ -656,7 +701,7 @@ def _bench(label: str, fn):
         for _ in range(100): fn()
         ops += 100
         elapsed = time.perf_counter() - t0
-        if elapsed >= TARGET_SEC: break
+        if elapsed >= g_bench_sec: break
     rate = ops / elapsed
     if rate >= 1e6:    rate_str = f"{rate/1e6:.2f} M ops/sec"
     elif rate >= 1e3:  rate_str = f"{rate/1e3:.2f} K ops/sec"
@@ -791,7 +836,43 @@ def bench_hkex_rnl_handshake():
 # ---------------------------------------------------------------------------
 
 if __name__ == '__main__':
-    print("=== Herradura KEx \u2014 Security & Performance Tests (Python) ===\n")
+    # --- Arg parsing (CLI overrides env vars) ---
+    parser = argparse.ArgumentParser(
+        description="Herradura KEx v1.5.1 — Security & Performance Tests (Python)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
+    parser.add_argument('-r', '--rounds', type=int, default=0,
+                        metavar='N', help='max iterations per security test (default: test-specific)')
+    parser.add_argument('-t', '--time', type=float, default=0.0,
+                        metavar='T', dest='time_limit',
+                        help='benchmark duration and per-test time cap in seconds')
+    args = parser.parse_args()
+
+    # env var fallbacks (only if CLI not set)
+    _env_r = os.environ.get('HTEST_ROUNDS', '')
+    _env_t = os.environ.get('HTEST_TIME', '')
+    if args.rounds == 0 and _env_r.isdigit() and int(_env_r) > 0:
+        args.rounds = int(_env_r)
+    if args.time_limit == 0.0 and _env_t:
+        try:
+            args.time_limit = float(_env_t)
+        except ValueError:
+            pass
+
+    # apply to module-level globals (module-level code; no 'global' keyword needed)
+    if args.rounds > 0:
+        g_rounds = args.rounds
+    if args.time_limit > 0:
+        g_bench_sec  = args.time_limit
+        g_time_limit = args.time_limit
+
+    print("=== Herradura KEx v1.5.1 \u2014 Security & Performance Tests (Python) ===")
+    if g_rounds > 0 or g_time_limit > 0:
+        parts = []
+        if g_rounds > 0:     parts.append(f"rounds={g_rounds}")
+        if g_time_limit > 0: parts.append(f"time_limit={g_time_limit:.2f}s")
+        print(f"    Config: {', '.join(parts)}")
+    print()
 
     print("--- Security Tests: Classical Protocols ---\n")
     test_hkex_gf_correctness()

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ $$\text{FSCX}(A, B) = M \cdot (A \oplus B)$$
 
 **FSCX_REVOLVE(A, B, n)** iterates FSCX $n$ times with $B$ held constant:
 
-$$\text{FSCX\_REVOLVE}(A, B, n) = \text{FSCX}^{\circ n}(A, B)$$
+$$\text{FSCX}\_\text{REVOLVE}(A, B, n) = \text{FSCX}^{\circ n}(A, B)$$
 
-For bitstrings of size $P = 2^k$, the orbit period is always $P$ or $P/2$, so $\text{FSCX\_REVOLVE}(A, B, P) = A$ for all $A$, $B$.
+For bitstrings of size $P = 2^k$, the orbit period is always $P$ or $P/2$, so $\text{FSCX}\_\text{REVOLVE}(A, B, P) = A$ for all $A$, $B$.
 
 ---
 
@@ -51,9 +51,9 @@ The suite builds protocols on top of HKEX-GF, FSCX_REVOLVE, and the v1.5.0 NL-FS
 **Classical (v1.4.0):**
 
 1. **HKEX-GF** — key exchange (DH over $\mathbb{GF}(2^n)^*$, as above)
-2. **HSKE** — symmetric encryption: $E = \text{FSCX\_REVOLVE}(P, \mathit{key}, i)$; decrypt with $D = \text{FSCX\_REVOLVE}(E, \mathit{key}, r)$
-3. **HPKS** — Schnorr-style public key signature: $R = g^k$; $e = \text{FSCX\_REVOLVE}(R, P, i)$; $s = (k - a \cdot e) \bmod (2^n - 1)$; verify $g^s \cdot C^e = R$
-4. **HPKE** — El Gamal public key encryption: $R = g^r$; $\mathit{enc\_key} = C^r$; $E = \text{FSCX\_REVOLVE}(P, \mathit{enc\_key}, i)$; Alice decrypts with $\mathit{dec\_key} = R^a$
+2. **HSKE** — symmetric encryption: $E = \text{FSCX}\_\text{REVOLVE}(P, \mathit{key}, i)$; decrypt with $D = \text{FSCX}\_\text{REVOLVE}(E, \mathit{key}, r)$
+3. **HPKS** — Schnorr-style public key signature: $R = g^k$; $e = \text{FSCX}\_\text{REVOLVE}(R, P, i)$; $s = (k - a \cdot e) \bmod (2^n - 1)$; verify $g^s \cdot C^e = R$
+4. **HPKE** — El Gamal public key encryption: $R = g^r$; $\mathit{enc}\_\mathit{key} = C^r$; $E = \text{FSCX}\_\text{REVOLVE}(P, \mathit{enc}\_\mathit{key}, i)$; Alice decrypts with $\mathit{dec}\_\mathit{key} = R^a$
 
 **Post-quantum / NL-hardened (v1.5.0):**
 
@@ -61,7 +61,7 @@ The suite builds protocols on top of HKEX-GF, FSCX_REVOLVE, and the v1.5.0 NL-FS
 6. **HSKE-NL-A2** — revolve-mode with NL-FSCX v2: $E = \text{NL-FSCX-revolve-v2}(P, K, r)$; $D = \text{NL-FSCX-revolve-v2-inv}(E, K, r)$
 7. **HKEX-RNL** — Ring-LWR key exchange (conjectured quantum-resistant): shared $m_\text{blind}$ in $\mathbb{Z}_q[x]/(x^n+1)$; parties derive $C = \text{round}_p(m_\text{blind} \cdot s)$; agreement $K = \text{round}_{pp}(s \cdot \text{lift}(C_\text{other}))$
 8. **HPKS-NL** — NL-hardened Schnorr: $e = \text{NL-FSCX-revolve-v1}(R, P, i)$
-9. **HPKE-NL** — NL-hardened El Gamal: $E = \text{NL-FSCX-revolve-v2}(P, \mathit{enc\_key}, i)$; $D = \text{NL-FSCX-revolve-v2-inv}(E, \mathit{dec\_key}, i)$
+9. **HPKE-NL** — NL-hardened El Gamal: $E = \text{NL-FSCX-revolve-v2}(P, \mathit{enc}\_\mathit{key}, i)$; $D = \text{NL-FSCX-revolve-v2-inv}(E, \mathit{dec}\_\mathit{key}, i)$
 
 Implementations are provided in C, Go, Python, ARM Thumb-2 assembly, NASM i386 assembly, and Arduino.
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -96,7 +96,7 @@ $\blacksquare$
 
 **Definition:**
 
-$$\text{FSCX\_REVOLVE}(A, B, k) = f_B^k(A)$$
+$$\text{FSCX}\_\text{REVOLVE}(A, B, k) = f_B^k(A)$$
 
 where $f_B(X) = \text{FSCX}(X, B) = M \cdot X \oplus M \cdot B$ is an affine map over $\mathbb{GF}(2)^n$.
 
@@ -141,7 +141,7 @@ $$= I + M + M^2 + \cdots + M^{n-1} = S_n = 0 \quad \blacksquare$$
 
 **Definition (v1.1):**
 
-$$\text{FSCX\_REVOLVE\_N}(A, B, N, k) :
+$$\text{FSCX}\_\text{REVOLVE}\_\text{N}(A, B, N, k) :
 \begin{cases}
 X_0 = A \\
 X_{j+1} = \text{FSCX}(X_j, B) \oplus N = M \cdot X_j \oplus M \cdot B \oplus N
@@ -149,7 +149,7 @@ X_{j+1} = \text{FSCX}(X_j, B) \oplus N = M \cdot X_j \oplus M \cdot B \oplus N
 
 This is the affine map $g_{B,N}(X) = M \cdot X + (M \cdot B \oplus N)$ with translation $c = M \cdot B \oplus N$. The closed-form iteration formula is:
 
-$$\text{FSCX\_REVOLVE\_N}(A, B, N, k) = M^k \cdot A + M \cdot S_k \cdot B \oplus S_k \cdot N$$
+$$\text{FSCX}\_\text{REVOLVE}\_\text{N}(A, B, N, k) = M^k \cdot A + M \cdot S_k \cdot B \oplus S_k \cdot N$$
 
 **Theorem 5 — Period still divides $n$:**
 
@@ -157,7 +157,7 @@ $$g^n_{B,N}(A) = M^n \cdot A + S_n \cdot (M \cdot B \oplus N) = A + 0 = A$$
 
 The nonce $N$ does not affect the period, and decryption is the complementary revolve.
 
-**Nonce propagation linearity:** If $N$ changes by $\delta N$, the change in $\text{FSCX\_REVOLVE\_N}(\cdot, B, N, k)$ at step $k$ is:
+**Nonce propagation linearity:** If $N$ changes by $\delta N$, the change in $\text{FSCX}\_\text{REVOLVE}\_\text{N}(\cdot, B, N, k)$ at step $k$ is:
 
 $$\delta\text{Output} = S_k \cdot \delta N = (I + M + M^2 + \cdots + M^{k-1}) \cdot \delta N$$
 
@@ -172,15 +172,15 @@ For $k = n$ this is $S_n \cdot \delta N = 0$, so nonce changes are fully absorbe
 **Protocol:**
 
 $$\begin{aligned}
-&\textbf{Alice:}\quad A, B \leftarrow \text{random};\quad C = \text{FSCX\_REVOLVE}(A, B, i) \\
-&\textbf{Bob:}\quad A_2, B_2 \leftarrow \text{random};\quad C_2 = \text{FSCX\_REVOLVE}(A_2, B_2, i)
+&\textbf{Alice:}\quad A, B \leftarrow \text{random};\quad C = \text{FSCX}\_\text{REVOLVE}(A, B, i) \\
+&\textbf{Bob:}\quad A_2, B_2 \leftarrow \text{random};\quad C_2 = \text{FSCX}\_\text{REVOLVE}(A_2, B_2, i)
 \end{aligned}$$
 
 $$\text{Alice} \xrightarrow{C} \text{Bob} \qquad \text{Bob} \xrightarrow{C_2} \text{Alice}$$
 
 $$\begin{aligned}
-&\textbf{Alice:}\quad sk_A = \text{FSCX\_REVOLVE\_N}(C_2, B, N, r) \oplus A \\
-&\textbf{Bob:}\quad sk_B = \text{FSCX\_REVOLVE\_N}(C, B_2, N, r) \oplus A_2 \\
+&\textbf{Alice:}\quad sk_A = \text{FSCX}\_\text{REVOLVE}\_\text{N}(C_2, B, N, r) \oplus A \\
+&\textbf{Bob:}\quad sk_B = \text{FSCX}\_\text{REVOLVE}\_\text{N}(C, B_2, N, r) \oplus A_2 \\
 &\text{where}\quad N = C \oplus C_2
 \end{aligned}$$
 
@@ -213,8 +213,8 @@ This formula depends only on the public wire values $C$ and $C_2$. The private p
 
 **Protocol:**
 
-$$\text{Encrypt:}\quad E = \text{FSCX\_REVOLVE\_N}(P, K, K, i)$$
-$$\text{Decrypt:}\quad D = \text{FSCX\_REVOLVE\_N}(E, K, K, r)$$
+$$\text{Encrypt:}\quad E = \text{FSCX}\_\text{REVOLVE}\_\text{N}(P, K, K, i)$$
+$$\text{Decrypt:}\quad D = \text{FSCX}\_\text{REVOLVE}\_\text{N}(E, K, K, r)$$
 
 Applying the affine formula with $B = N = K$:
 
@@ -250,8 +250,8 @@ $$\begin{aligned}
 The original scheme used $S = sk_A \oplus P$ (a direct XOR mask), which trivially leaks $sk_A$ (see W3). The corrected scheme **HPKS₂** replaces the XOR with HSKE encryption of $P$ under $sk_A$:
 
 $$\begin{aligned}
-&\textbf{Alice:}\quad S = \text{FSCX\_REVOLVE\_N}(P,\; sk_A,\; sk_A,\; i) \quad [\text{HSKE-encrypt } P \text{ under } sk_A] \\
-&\textbf{Bob:}\quad V = \text{FSCX\_REVOLVE\_N}(S,\; sk_B,\; sk_B,\; r) \quad [\text{HSKE-decrypt } S \text{ under } sk_B] \\
+&\textbf{Alice:}\quad S = \text{FSCX}\_\text{REVOLVE}\_\text{N}(P,\; sk_A,\; sk_A,\; i) \quad [\text{HSKE-encrypt } P \text{ under } sk_A] \\
+&\textbf{Bob:}\quad V = \text{FSCX}\_\text{REVOLVE}\_\text{N}(S,\; sk_B,\; sk_B,\; r) \quad [\text{HSKE-decrypt } S \text{ under } sk_B] \\
 &\qquad\text{Check: } V = P
 \end{aligned}$$
 
@@ -272,8 +272,8 @@ $$\begin{aligned}
 \end{aligned}$$
 
 $$\begin{aligned}
-&\textbf{Bob:}\quad E = \text{FSCX\_REVOLVE\_N}(C, B_2, N, r) \oplus A_2 \oplus P \\
-&\textbf{Alice:}\quad D = \text{FSCX\_REVOLVE\_N}(C_2, B, N, r) \oplus A \oplus E
+&\textbf{Bob:}\quad E = \text{FSCX}\_\text{REVOLVE}\_\text{N}(C, B_2, N, r) \oplus A_2 \oplus P \\
+&\textbf{Alice:}\quad D = \text{FSCX}\_\text{REVOLVE}\_\text{N}(C_2, B, N, r) \oplus A \oplus E
 \end{aligned}$$
 
 **Correctness:**
@@ -311,7 +311,7 @@ Since $sk_B = S_{r+1} \cdot (C \oplus C_2)$ is a linear function of public value
 
 ### 3.2 Single Nonce Injection Cannot Fix HKEX
 
-**The proposal:** Replace the public-key computation $C = \text{FSCX\_REVOLVE}(A, B, i)$ with the nonce-augmented variant $C = \text{FSCX\_REVOLVE\_N}(A, B, \Phi, i)$:
+**The proposal:** Replace the public-key computation $C = \text{FSCX}\_\text{REVOLVE}(A, B, i)$ with the nonce-augmented variant $C = \text{FSCX}\_\text{REVOLVE}\_\text{N}(A, B, \Phi, i)$:
 
 $$C = M^i \cdot A + S_i \cdot (M \cdot B \oplus \Phi)$$
 
@@ -352,7 +352,7 @@ $$sk_A \oplus sk_B = M^r \cdot S_i \cdot (B \oplus B_2) \neq 0 \quad \text{for i
 >
 > If $sk_A = sk_B$ for **all** independently generated key pairs $(A,B)$ and $(A_2,B_2)$, then $sk$ is a $\mathbb{GF}(2)$-affine function of $(C, C_2)$ alone.
 
-*Proof.* Applying the affine iteration formula for $\text{FSCX\_REVOLVE\_N}$ and substituting $A = M^r \cdot C \oplus M^{r+1} \cdot S_i \cdot B$:
+*Proof.* Applying the affine iteration formula for $\text{FSCX}\_\text{REVOLVE}\_\text{N}$ and substituting $A = M^r \cdot C \oplus M^{r+1} \cdot S_i \cdot B$:
 
 $$sk_A = M^r \cdot C_2 + S_r \cdot (M \cdot B \oplus n_A) \oplus A$$
 $$= M^r \cdot (C \oplus C_2) \oplus \underbrace{(S_r \cdot M + M^{r+1} \cdot S_i)}_{S_n = 0} \cdot B \oplus S_r \cdot n_A$$
@@ -618,9 +618,9 @@ $$M \cdot S_r + M^{r+1} \cdot S_i = S_n = 0$$
 
 Together, these imply that for any $A, B, A_2, B_2 \in \mathbb{GF}(2)^n$ and any nonce $N$:
 
-$$\text{FSCX\_REVOLVE\_N}\!\left(\text{FSCX\_REVOLVE}(A_2, B_2, i),\; B,\; N,\; r\right) \oplus A$$
+$$\text{FSCX}\_\text{REVOLVE}\_\text{N}\!\left(\text{FSCX}\_\text{REVOLVE}(A_2, B_2, i),\; B,\; N,\; r\right) \oplus A$$
 $$=$$
-$$\text{FSCX\_REVOLVE\_N}\!\left(\text{FSCX\_REVOLVE}(A, B, i),\; B_2,\; N,\; r\right) \oplus A_2$$
+$$\text{FSCX}\_\text{REVOLVE}\_\text{N}\!\left(\text{FSCX}\_\text{REVOLVE}(A, B, i),\; B_2,\; N,\; r\right) \oplus A_2$$
 
 This identity is the mathematical core from which all four protocols derive their correctness. All protocols are **correct**. However, the same identity that enables correctness also ensures that the shared secret $sk = S_{r+1} \cdot (C \oplus C_2)$ contains no private information — breaking the key exchange.
 
@@ -854,7 +854,7 @@ Version 1.4.0 replaces the broken HKEX key exchange with HKEX-GF across all impl
 
 Theorem 10 (proved in §4.5 / SecurityProofsCode) shows that any nonce $N$ injected during FSCX iteration satisfies:
 
-$$\text{FSCX\_REVOLVE\_N}(A, B, N, k) = M^k \cdot A \oplus M \cdot S_k \cdot B \oplus S_k \cdot N$$
+$$\text{FSCX}\_\text{REVOLVE}\_\text{N}(A, B, N, k) = M^k \cdot A \oplus M \cdot S_k \cdot B \oplus S_k \cdot N$$
 
 The nonce contribution $S_k \cdot N$ is the same on both sides of the key exchange equation, so it cancels identically — providing no protection against the classical break. With HKEX-GF, the nonce was derived as $N = C \oplus C_2$ (a public value), making its use circular and pointless. `fscx_revolve_n` is therefore removed rather than kept as dead code.
 
@@ -881,7 +881,7 @@ All results from `Herradura_tests.py`, `Herradura_tests.go`, `Herradura_tests.c`
 | Key sensitivity (flip 1 bit of $a$ → HD in $sk$) | mean $\approx n/2$ (avalanche) |
 | FSCX orbit period (unchanged) | $n$ or $n/2$, 0 exceptions |
 | FSCX bit-frequency bias | 49.5–50.5% per bit |
-| HSKE round-trip $\text{fscx\_revolve}^2(P, K, i, r) = P$ | 5 000/5 000 |
+| HSKE round-trip $\text{fscx}\_\text{revolve}^2(P, K, i, r) = P$ | 5 000/5 000 |
 
 ### 10.5 Security Status After Migration
 
@@ -917,14 +917,14 @@ All claims in this section are supported by `SecurityProofsCode/hkex_nl_verifica
 
 For fixed $B$:
 
-$$\text{FSCX\_REVOLVE}(X, B, r) = R \cdot X \oplus K \cdot B$$
+$$\text{FSCX}\_\text{REVOLVE}(X, B, r) = R \cdot X \oplus K \cdot B$$
 
 where $R = M^r$ and $K = M + M^2 + \cdots + M^r \in \mathbb{GF}(2)^{n \times n}$.
 
 *Proof:* By induction.  Base case: $\text{FSCX}(X, B) = M(X \oplus B) = M \cdot X \oplus M \cdot B$.
 For step $k+1$: $\text{FSCX}(M^k X \oplus S_k B, B) = M(M^k X \oplus S_k B \oplus B) = M^{k+1} X \oplus M(S_k + I) B = R \cdot X \oplus K \cdot B$. $\blacksquare$
 
-**Consequence.** Eve holding $(X, \text{FSCX\_REVOLVE}(X, B, r))$ for a single plaintext–ciphertext pair
+**Consequence.** Eve holding $(X, \text{FSCX}\_\text{REVOLVE}(X, B, r))$ for a single plaintext–ciphertext pair
 can solve $K \cdot B = C \oplus R \cdot X$ for $B$ by Gaussian elimination over $\mathbb{GF}(2)$ in $O(n^3)$ time,
 provided $K$ has full rank over $\mathbb{GF}(2)$.  Even when $K$ is rank-deficient, the null-space dimension
 is at most $n - \text{rank}(K)$, bounding the residual key entropy.
@@ -959,7 +959,7 @@ relative to the FSCX XOR structure ($M^{n/2} = I$), maximising cross-mixing betw
 the carry channel and the XOR channel per round.
 
 **Consequence for HSKE.** The non-existence of a consistent period means the standard
-revolve-based decryption identity $\text{FSCX\_REVOLVE}(E, K, n/2 - r) = P$ cannot be ported to
+revolve-based decryption identity $\text{FSCX}\_\text{REVOLVE}(E, K, n/2 - r) = P$ cannot be ported to
 NL-FSCX v1.  Counter mode (§11.3.1) is the only applicable HSKE construction.
 
 #### 11.2.2 NL-FSCX v2 (B-only offset, explicit inverse)
@@ -1229,11 +1229,11 @@ determined.  **HSKE provides no security under known-plaintext attack at any $n$
 #### 12.2.2 HPKS — Classical Forgery Resistance
 
 Forgery requires finding $(R^*, s^*)$ satisfying $g^{s^*} \cdot C^{e^*} = R^*$ where
-$e^* = \text{fscx\_revolve}(R^*_\text{bits}, P^*, i)$, without knowing the private key $a$.
+$e^* = \text{fscx}\_\text{revolve}(R^*_\text{bits}, P^*, i)$, without knowing the private key $a$.
 
 - If Eve fixes $R^*$ first: she needs $s^* = \log_g(R^* \cdot C^{-e^*})$ — a DLP instance.
 - If Eve fixes $s^*$ first: she can compute $g^{s^*} \cdot C^{e^*}$ for any $e^*$, but the
-  constraint $e^* = \text{fscx\_revolve}(R^*_\text{bits}, P^*, i)$ ties $R^*$ and $e^*$
+  constraint $e^* = \text{fscx}\_\text{revolve}(R^*_\text{bits}, P^*, i)$ ties $R^*$ and $e^*$
   together.  Since fscx\_revolve is an affine bijection in its first argument (see §12.3),
   solving both simultaneously reduces to DLP hardness.
 
@@ -1242,7 +1242,7 @@ quasi-polynomial attack in §12.1 and the challenge-function caveat in §12.3.
 
 #### 12.2.3 HPKE — Classical Attack
 
-Ciphertext is $(R, E) = (g^r,\, \text{fscx\_revolve}(P,\, g^{ar},\, i))$.  Recovering the
+Ciphertext is $(R, E) = (g^r,\, \text{fscx}\_\text{revolve}(P,\, g^{ar},\, i))$.  Recovering the
 plaintext requires $g^{ar}$, which is the CDH problem given $(g^a, g^r)$.
 Since CDH $\leq$ DLP, all classical DLP attacks in §12.1 apply directly.
 
@@ -1255,7 +1255,7 @@ DLP on $\mathit{ek} = C^r$ or $\mathit{ek} = R^a$ may then recover $a$ or $r$.
 ### 12.3 HPKS Challenge Function — Algebraic Properties
 
 The challenge in HPKS uses fscx\_revolve in place of a hash function:
-$e = \text{fscx\_revolve}(R_\text{bits}, P, i)$.  Two algebraic properties affect
+$e = \text{fscx}\_\text{revolve}(R_\text{bits}, P, i)$.  Two algebraic properties affect
 provable security.
 
 **Property 1 — Affine bijection in $R$.**
@@ -1270,7 +1270,7 @@ so no two distinct $R$ values produce the same challenge $e$.
 
 By the difference identity (Theorem 11 linearity):
 
-$$e(R_2) \oplus e(R_1) = \text{fscx\_revolve}(R_1 \oplus R_2,\; 0,\; i) = M^i \cdot (R_1 \oplus R_2)$$
+$$e(R_2) \oplus e(R_1) = \text{fscx}\_\text{revolve}(R_1 \oplus R_2,\; 0,\; i) = M^i \cdot (R_1 \oplus R_2)$$
 
 Given any one valid challenge $e(R_1)$, the challenge for any $R_2 = R_1 \oplus \delta$ is
 $e(R_2) = e(R_1) \oplus M^i \cdot \delta$ — **publicly computable without oracle access**.


### PR DESCRIPTION
## Summary

- **KaTeX fix** — Resolved `'_' allowed only in math mode` errors on GitHub by moving `\_` out of `\text{}` blocks (text mode) into math mode. The working pattern is `\text{FSCX}\_\text{REVOLVE}` instead of `\text{FSCX\_REVOLVE}`. Applied to 42 occurrences across `README.md` and `SecurityProofs.md`; also fixed `\mathit{enc\_key}` → `\mathit{enc}\_\mathit{key}` (4 occurrences in `README.md`).
- **Test execution limits** (C, Python, Go) — `--rounds`/`-r` and `--time`/`-t` CLI flags with `HTEST_ROUNDS`/`HTEST_TIME` env var fallbacks; wall-clock timeout in all 16 security tests; pass thresholds scale to actual iterations completed.
- **CHANGELOG** — Added `[1.5.1]` entry covering both changes above.

## Test plan

- [ ] Browse `README.md` and `SecurityProofs.md` on GitHub after merge — confirm no KaTeX parse errors in any math block
- [ ] Run `CryptosuiteTests/Herradura_tests` (C/Go/Python) with `-r 10` and `-t 2` to verify execution limits work
- [ ] Run tests without flags to confirm default behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)