### PR TITLE
v1.5.1: fix KaTeX 'Missing close brace' in SecurityProofs.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Final correct pattern (58 occurrences across both files):
 `README.md`: also `\mathit{enc}\textunderscore\mathit{key}` and
 `\mathit{dec}\textunderscore\mathit{key}`.
 
+- **`Missing close brace`** (`SecurityProofs.md` line 702) — `\xleftarrow{\$}`
+  inside `$...$` inline math: GitHub's markdown parser treats `\$` as closing
+  the math span, leaving `\xleftarrow{` with no matching `}`.  Fix: replace
+  `\$` with `\textdollar` (KaTeX's dollar-sign command, contains no literal
+  `$` character).
+
 ---
 
 ## [1.5.0] - 2026-04-11

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -699,7 +699,7 @@ Pre-agreed public parameters: field size $n$, irreducible polynomial $p(x)$, gen
 
 | Step | Alice | Bob |
 |------|-------|-----|
-| Private | $a \xleftarrow{\$} \{1,\ldots,2^n{-}1\}$ | $b \xleftarrow{\$} \{1,\ldots,2^n{-}1\}$ |
+| Private | $a \xleftarrow{\textdollar} \{1,\ldots,2^n{-}1\}$ | $b \xleftarrow{\textdollar} \{1,\ldots,2^n{-}1\}$ |
 | Public | $C = g^a \in \mathbb{GF}(2^n)^*$ | $C_2 = g^b \in \mathbb{GF}(2^n)^*$ |
 | Shared | $sk = C_2^{\,a} = g^{ab}$ | $sk = C^{\,b} = g^{ab}$ |
 


### PR DESCRIPTION
## Summary

- `\xleftarrow{\$}` on line 702 — GitHub's markdown parser treats `\$` inside `$...$` as closing the math span early, leaving `\xleftarrow{` with no matching `}` and causing KaTeX to report "Missing close brace". Fix: replace `\$` with `\textdollar`, a KaTeX-native command for the dollar-sign glyph that contains no literal `$` character.
- **CHANGELOG** — `[1.5.1]` entry extended with this third KaTeX fix.

## Test plan

- [x] Browse `SecurityProofs.md` §9.2.2 protocol table on GitHub — confirm `a ←$ {1,…,2ⁿ−1}` renders without KaTeX errors
- [ ] Confirm no other KaTeX warnings remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)