### PR TITLE
v1.5.1: documentation/proof consistency fixes and PQC test improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
-## [1.5.1] - 2026-04-11
+## [1.5.1] - 2026-04-16
 
 ### Fixed / Added
 
@@ -43,6 +43,58 @@ Final correct pattern (58 occurrences across both files):
   the math span, leaving `\xleftarrow{` with no matching `}`.  Fix: replace
   `\$` with `\textdollar` (KaTeX's dollar-sign command, contains no literal
   `$` character).
+
+#### Documentation and code inconsistency review
+
+Cross-file audit of documentation vs. implementation; all inconsistencies resolved.
+
+**CLAUDE.md:**
+- Test count corrected: `9 security tests` → `16 security tests` (reflects v1.5.0 tests [1]–[16]).
+- Repository structure: removed `SecurityProofs2.md` (never existed) and `PQCanalysis.md`
+  (removed in v1.4.1, merged into `SecurityProofs.md §12`).
+- Protocol stack section updated from v1.4.0 to v1.5.0; added five NL/PQC protocol entries
+  (HSKE-NL-A1, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL).
+
+**README.md:**
+- Version in title updated to v1.5.1.
+
+**`CryptosuiteTests/Herradura_tests.c`:**
+- Stale block comments on benchmark functions corrected: `[11]`–`[14]` → `[18]`–`[21]`
+  (printf statements already printed the correct numbers; only the block comments lagged).
+
+#### PQC proofs and tests review
+
+**`SecurityProofs.md`:**
+- §11 section header: `(v1.4.0)` → `(v1.5.0)`; opening sentence updated to "documents
+  the verified fixes implemented in v1.5.0" (was "proposes verified fixes").
+- §11.4.2 HKEX-RNL protocol: clarified that `m_blind = m(x) + a_rand` is a **shared**
+  public polynomial (one party generates `a_rand` and transmits it; both use the same
+  `m_blind`).  Previous wording "Bob generates analogously" implied independent polynomials,
+  which breaks key agreement by commutativity.
+- §11.4.3 attack table: added `(q=769, n=16, 200 trials…)` attribution — the q value
+  used for the table was previously unstated.
+- §11.5 Q1 table: first row description `B=0` corrected to `random B` (the verification
+  script generates random B per trial, not a fixed B=0).
+- §11.5 Q2 table: replaced two "not yet verified" rows with confirmed results for the
+  deployed parameters `(q=65537, n=32)` and `(q=65537, n=256)`.
+- §11.6: updated recommended parameters from `q=3329/p=1024/p'=32` to the deployed
+  `q=65537/p=4096/pp=2`; replaced stale "code migration planned" status note with
+  v1.5.0 implementation status and noise-amplification verification summary.
+- §12.5 protocol summary table: added six new rows covering the v1.5.0 NL protocols
+  (HSKE-NL-A1, HSKE-NL-A2 — both key-only and known-plaintext cases; HPKS-NL; HPKE-NL;
+  HKEX-RNL).
+
+**`SecurityProofsCode/hkex_nl_verification.py`:**
+- §2.1 extended to verify `m(x)` invertibility for deployed parameters `(q=65537, n=32)`
+  and `(q=65537, n=256)` — both confirmed invertible with `m·m⁻¹ = 1`.
+- §2.3 extended to compute noise amplification `‖m⁻¹‖₁ · q/(2p)` for deployed
+  `q=65537, n=32, p=4096` (result: ≈4.3×10⁶ ≫ q — structural protection confirmed).
+
+**`CryptosuiteTests/Herradura_tests.{c,go,py}` — test [14] HKEX-RNL:**
+- All three implementations now report both raw agreement (`K_A == K_B`) and
+  KDF-processed agreement (`sk_A == sk_B`) — previously only the Go file checked both.
+- Added explanatory comment describing the shared-polynomial protocol structure.
+- Go benchmark [25]: same structural consistency (was already correct; comment added).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,7 @@ CryptosuiteTests/
   Herradura_tests.{c,go,py,s,asm,ino}              — security tests & benchmarks
   go.mod
 SecurityProofsCode/                                 — formal break proofs (Python scripts)
-SecurityProofs.md / SecurityProofs2.md              — algebraic analysis
-PQCanalysis.md                                      — classical & post-quantum analysis
+SecurityProofs.md                                   — algebraic analysis (incl. §11 NL/PQC, §12 quantum analysis)
 ```
 
 ## Build Commands
@@ -63,7 +62,7 @@ qemu-i386 "./Herradura cryptographic suite_i386"
 No automated test framework. Tests are manual: run each program and verify console output.
 
 ```bash
-./CryptosuiteTests/Herradura_tests          # C — 9 security tests + 5 benchmarks
+./CryptosuiteTests/Herradura_tests          # C — 16 security tests + 5 benchmarks
 cd CryptosuiteTests && go run Herradura_tests.go
 python3 CryptosuiteTests/Herradura_tests.py
 ```
@@ -84,8 +83,9 @@ Linear map M = I ⊕ ROL ⊕ ROR; order of M is n/2. Iterating FSCX creates peri
 
 **GF(2^n) arithmetic:** `gf_mul` (carryless multiply mod irreducible polynomial), `gf_pow` (square-and-multiply). Generator g = 3.
 
-### Protocol Stack (v1.4.0)
+### Protocol Stack (v1.5.0)
 
+**Classical (v1.4.0):**
 ```
 FSCX_REVOLVE + GF(2^n)* arithmetic
 ├── HKEX-GF  — C = g^a; C2 = g^b; sk = C2^a = C^b = g^{ab}
@@ -98,7 +98,47 @@ FSCX_REVOLVE + GF(2^n)* arithmetic
                D = fscx_revolve(E, dec_key, r) = P
 ```
 
+**NL/PQC (v1.5.0):**
+```
+NL-FSCX primitives + Ring-LWR
+├── HSKE-NL-A1 — counter-mode: ks = nl_fscx_revolve_v1(K, K⊕ctr, i); E = P ⊕ ks
+├── HSKE-NL-A2 — revolve-mode: E = nl_fscx_revolve_v2(P, K, r); D = inverse
+├── HKEX-RNL   — Ring-LWR key exchange (conjectured quantum-resistant)
+├── HPKS-NL    — Schnorr with NL-FSCX v1 challenge: e = nl_fscx_revolve_v1(R, msg, i)
+└── HPKE-NL    — El Gamal with NL-FSCX v2: E = nl_fscx_revolve_v2(P, enc_key, i)
+```
+
 Parameters: i = n/4, r = 3n/4. GF arithmetic uses 32-bit operands in assembly/Arduino; 256-bit in C/Go/Python suite. HSKE and FSCX tests always use 256-bit.
+
+## KaTeX Rendering Rules for Markdown Files
+
+GitHub renders math in `README.md`, `SecurityProofs.md`, and similar files via KaTeX. Three classes of errors have been fixed and **must not be reintroduced**:
+
+### 1. `'_' allowed only in math mode`
+**Cause:** `\_` inside a `\text{}` block — KaTeX rejects `\_` in text mode.
+**Wrong:** `\text{FSCX\_REVOLVE}`, `\mathit{enc\_key}`
+**Correct:** use `\textunderscore` to produce a literal underscore glyph in math mode:
+- `\text{FSCX}\textunderscore\text{REVOLVE}\textunderscore\text{N}`
+- `\mathit{enc}\textunderscore\mathit{key}`
+
+### 2. `Double subscripts: use braces to clarify`
+**Cause:** using `\_` as the subscript operator between `\text{}` groups creates two subscripts on the same base.
+**Wrong:** `\text{FSCX}\_\text{REVOLVE}\_\text{N}` (the intermediate "fix" for error 1)
+**Correct:** same as above — `\textunderscore` is not a subscript operator, so it is safe for multi-segment names.
+
+### 3. `Missing close brace`
+**Cause:** `\xleftarrow{\$}` — GitHub's markdown parser treats `\$` as closing the inline math span `$...$`, so KaTeX receives an unclosed brace.
+**Wrong:** `\xleftarrow{\$}`
+**Correct:** `\xleftarrow{\textdollar}` — `\textdollar` is the KaTeX dollar-sign glyph command with no literal `$`.
+
+### Summary table
+
+| Pattern to avoid | Correct replacement | Error prevented |
+|---|---|---|
+| `\text{FOO\_BAR}` | `\text{FOO}\textunderscore\text{BAR}` | `'_' allowed only in math mode` |
+| `\mathit{foo\_bar}` | `\mathit{foo}\textunderscore\mathit{bar}` | `'_' allowed only in math mode` |
+| `\text{A}\_\text{B}\_\text{C}` | `\text{A}\textunderscore\text{B}\textunderscore\text{C}` | `Double subscripts` |
+| `\xleftarrow{\$}` | `\xleftarrow{\textdollar}` | `Missing close brace` |
 
 ## License
 

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -910,14 +910,18 @@ static void test_hske_nl_a2_correctness(void)
     putchar('\n');
 }
 
-/* [14] HKEX-RNL key agreement: K_A == K_B  (n=32, Ring-LWR) */
+/* [14] HKEX-RNL key agreement: K_A == K_B and sk_A == sk_B  (n=32, Ring-LWR)
+   Protocol: one party generates a_rand and transmits it in the clear; both derive
+   the shared m_blind = m_base + a_rand and compute their individual public keys
+   C = round_p(m_blind · s).  Agreement holds because the ring is commutative:
+   s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs.md. */
 static void test_hkex_rnl_correctness(void)
 {
-    int i, ok_raw = 0;
+    int i, ok_raw = 0, ok_sk = 0;
     int N = TEST_ROUNDS(200);
     struct timespec t0;
     rnl32_poly_t m_base, a_rand, m_blind;
-    printf("[14] HKEX-RNL key agreement: K_A == K_B  (n=%d, Ring-LWR)\n", RNL_N32);
+    printf("[14] HKEX-RNL key agreement: K_A == K_B / sk_A == sk_B  (n=%d, Ring-LWR)\n", RNL_N32);
     rnl32_m_poly(m_base);
     clock_gettime(CLOCK_MONOTONIC, &t0);
     for (i = 0; i < N; i++) {
@@ -925,16 +929,20 @@ static void test_hkex_rnl_correctness(void)
         int32_t s_B[RNL_N32], c_B[RNL_N32];
         uint32_t K_A, K_B;
         rnl32_rand_poly(a_rand);
-        rnl32_poly_add(m_blind, m_base, a_rand);
+        rnl32_poly_add(m_blind, m_base, a_rand);   /* shared public polynomial */
         rnl32_keygen(s_A, c_A, m_blind);
         rnl32_keygen(s_B, c_B, m_blind);
         K_A = rnl32_agree(s_A, c_B);
         K_B = rnl32_agree(s_B, c_A);
         if (K_A == K_B) ok_raw++;
+        /* KDF post-processing: sk = nl_fscx_revolve_v1(K, K, n/4) */
+        if (nl_fscx_revolve_v1_32(K_A, K_A, NL_I32) ==
+            nl_fscx_revolve_v1_32(K_B, K_B, NL_I32)) ok_sk++;
         if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
     }
-    printf("    n=%d  raw agree=%d/%d  [%s]\n",
-           RNL_N32, ok_raw, N, ok_raw >= N * 9 / 10 ? "PASS" : "FAIL");
+    printf("    n=%d  raw agree=%d/%d  sk agree=%d/%d  [%s]\n",
+           RNL_N32, ok_raw, N, ok_sk, N,
+           ok_raw >= N * 9 / 10 ? "PASS" : "FAIL");
     putchar('\n');
 }
 
@@ -1018,7 +1026,7 @@ static void bench_fscx_throughput(void)
     putchar('\n');
 }
 
-/* [11] HKEX-GF gf_pow throughput (32-bit) */
+/* [18] HKEX-GF gf_pow throughput (32-bit) */
 static void bench_gf_pow32_throughput(void)
 {
     uint32_t base, exp, tmp;
@@ -1040,7 +1048,7 @@ static void bench_gf_pow32_throughput(void)
     putchar('\n');
 }
 
-/* [12] HKEX-GF full handshake (32-bit: 4 gf_pow_32 calls) */
+/* [19] HKEX-GF full handshake (32-bit: 4 gf_pow_32 calls) */
 static void bench_hkex_gf32_handshake(void)
 {
     struct timespec t0, t1;
@@ -1073,7 +1081,7 @@ static void bench_hkex_gf32_handshake(void)
     putchar('\n');
 }
 
-/* [13] HSKE round-trip: encrypt+decrypt (256-bit) */
+/* [20] HSKE round-trip: encrypt+decrypt (256-bit) */
 static void bench_hske_roundtrip(void)
 {
     struct timespec t0, t1;
@@ -1101,7 +1109,7 @@ static void bench_hske_roundtrip(void)
     putchar('\n');
 }
 
-/* [14] HPKE El Gamal encrypt+decrypt round-trip (32-bit) */
+/* [21] HPKE El Gamal encrypt+decrypt round-trip (32-bit) */
 static void bench_hpke_el_gamal_roundtrip(void)
 {
     struct timespec t0, t1;

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -863,7 +863,11 @@ func testHskeNlA2Correctness() {
 }
 
 func testHkexRnlCorrectness() {
-	fmt.Println("[14] HKEX-RNL key agreement: K_raw_A == K_raw_B  [PQC-EXT]")
+	// Protocol: one party generates aRand and transmits it in the clear; both
+	// derive the shared mBlind = mBase + aRand and compute individual public keys
+	// C = round_p(mBlind · s).  Agreement holds by ring commutativity:
+	// sA·(mBlind·sB) = sB·(mBlind·sA).  See §11.4.2 of SecurityProofs.md.
+	fmt.Println("[14] HKEX-RNL key agreement: K_raw_A == K_raw_B / sk_A == sk_B  [PQC-EXT]")
 	fmt.Printf("     (ring sizes %v; production size is n=256)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := rnlMPoly(nRnl)
@@ -872,17 +876,15 @@ func testHkexRnlCorrectness() {
 		t0 := time.Now()
 		for i := 0; i < trials; i++ {
 			aRand := rnlRandPoly(nRnl, rnlQ)
-			mBlind := rnlPolyAdd(mBase, aRand, rnlQ)
+			mBlind := rnlPolyAdd(mBase, aRand, rnlQ) // shared public polynomial
 			sA, CA := rnlKeygen(mBlind, nRnl, rnlQ, rnlP, rnlB)
 			sB, CB := rnlKeygen(mBlind, nRnl, rnlQ, rnlP, rnlB)
 			KA := rnlAgree(sA, CB, rnlQ, rnlP, rnlPP, nRnl, nRnl)
 			KB := rnlAgree(sB, CA, rnlQ, rnlP, rnlPP, nRnl, nRnl)
-			if KA.Equal(KB) {
-				okRaw++
-				skA := NlFscxRevolveV1(KA, KA, nRnl/4)
-				skB := NlFscxRevolveV1(KB, KB, nRnl/4)
-				if skA.Equal(skB) { okSk++ }
-			}
+			if KA.Equal(KB) { okRaw++ }
+			skA := NlFscxRevolveV1(KA, KA, nRnl/4)
+			skB := NlFscxRevolveV1(KB, KB, nRnl/4)
+			if skA.Equal(skB) { okSk++ }
 			if i&15 == 15 && timeExceeded(t0) { trials = i + 1; break }
 		}
 		status := "PASS"

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -618,7 +618,12 @@ def test_hkex_rnl_correctness():
     # at the chosen parameters) and equal final sk after NL-FSCX KDF.
     # Uses RNL_SIZES (smaller than KEYBITS) for performance.
     # Production size is n=256; error probability is negligible at n>=64, b=1.
-    print("[14] HKEX-RNL key agreement: K_raw_A == K_raw_B  [PQC-EXT]")
+    #
+    # Protocol: one party generates a_rand and transmits it in the clear; both
+    # derive the shared m_blind = m_base + a_rand and compute individual public keys
+    # C = round_p(m_blind · s).  Agreement holds by ring commutativity:
+    # s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs.md.
+    print("[14] HKEX-RNL key agreement: K_raw_A == K_raw_B / sk_A == sk_B  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; production size is n=256)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
@@ -626,16 +631,15 @@ def test_hkex_rnl_correctness():
         for _ in _trange(_iters(200)):
             n_run += 1
             a_rand  = _rnl_rand_poly(n_rnl, RNLQ)
-            m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
+            m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)   # shared public polynomial
             s_A, C_A = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
             s_B, C_B = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
             K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
             K_B = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
-            if K_A == K_B:
-                ok_raw += 1
-                sk_A = nl_fscx_revolve_v1(K_A, K_A, n_rnl // 4)
-                sk_B = nl_fscx_revolve_v1(K_B, K_B, n_rnl // 4)
-                if sk_A == sk_B: ok_sk += 1
+            if K_A == K_B: ok_raw += 1
+            sk_A = nl_fscx_revolve_v1(K_A, K_A, n_rnl // 4)
+            sk_B = nl_fscx_revolve_v1(K_B, K_B, n_rnl // 4)
+            if sk_A == sk_B: ok_sk += 1
         status = "PASS" if ok_raw >= n_run * 90 // 100 else "FAIL"
         print(f"    n={n_rnl:3d}  raw agree={ok_raw}/{n_run}  sk agree={ok_sk}/{n_run}  [{status}]")
     print()
@@ -825,8 +829,8 @@ def bench_hkex_rnl_handshake():
             m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
             s_A, C_A = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
             s_B, C_B = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
-            K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
-            K_B = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
+            _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
+            _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
         _bench(f"n={n_rnl:3d}  full exchange", fn)
     print()
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.5.0)
+# Herradura Cryptographic Suite (v1.5.1)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1,7 +1,7 @@
 # Formal Cryptographic Analysis of the Herradura Cryptographic Suite
 
-**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions proposed and verified in v1.4.0 (§11).  Full quantum algorithm analysis in §12 (merged from PQCanalysis.md, v1.4.1).  
-**Last updated:** 2026-04-08
+**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §12 (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §12.5 NL-protocol rows added in v1.5.1.
+**Last updated:** 2026-04-16
 
 ---
 
@@ -899,10 +899,10 @@ The key exchange is now provably secure under CDH in $\mathbb{GF}(2^n)^*$. Remai
 
 ---
 
-## 11. Non-linearity and Post-quantum Extensions (v1.4.0)
+## 11. Non-linearity and Post-quantum Extensions (v1.5.0)
 
 This section analyses the two remaining structural weaknesses of the v1.4.0 suite and
-proposes verified fixes:
+documents the verified fixes implemented in v1.5.0:
 
 1. **GF(2)-linearity** of FSCX — allows linear-algebraic attacks on symmetric protocols.
 2. **Quantum vulnerability** of HKEX-GF — GF(2^n)^* DLP is broken by Shor's algorithm.
@@ -1053,19 +1053,22 @@ The centered $\ell_1$-norm of $m^{-1}(x)$ scales as $\|m^{-1}\|_1 \approx n \cdo
 
 **Setup.** Parties agree on public parameters $(n, q, p, g)$ with $p < q$ both prime.
 
-**Key generation (Alice):**
-- Private: $s_A \leftarrow \mathcal{R}_q$ uniformly at random.
-- Session random: $a_\text{rand} \leftarrow \mathcal{R}_q$ uniformly (transmitted in the clear).
-- Blinded polynomial: $m_\text{blind} = m(x) + a_\text{rand} \in \mathcal{R}_q$.
-- Public key: $C_A = \lfloor m_\text{blind} \cdot s_A \rceil_p \in \mathcal{R}_p$, where $\lfloor \cdot \rceil_p$ denotes rounding from $\mathbb{Z}/q\mathbb{Z}$ to $\mathbb{Z}/p\mathbb{Z}$.
+**Shared polynomial setup (one-shot, per session):**
+- One party (e.g. Alice) draws $a_\text{rand} \leftarrow \mathcal{R}_q$ uniformly and
+  transmits it in the clear.  Both parties compute the **shared** blinded polynomial:
+  $m_\text{blind} = m(x) + a_\text{rand} \in \mathcal{R}_q$.
 
-Bob generates $(s_B, a_\text{rand,B}, m_\text{blind,B}, C_B)$ analogously.
+**Key generation (Alice and Bob, independently):**
+- Alice: private $s_A \leftarrow \mathcal{R}_q$; public key $C_A = \lfloor m_\text{blind} \cdot s_A \rceil_p \in \mathcal{R}_p$.
+- Bob:   private $s_B \leftarrow \mathcal{R}_q$; public key $C_B = \lfloor m_\text{blind} \cdot s_B \rceil_p \in \mathcal{R}_p$.
+
+Both use the **same** $m_\text{blind}$.  ($\lfloor \cdot \rceil_p$ denotes rounding from $\mathbb{Z}/q\mathbb{Z}$ to $\mathbb{Z}/p\mathbb{Z}$.)
 
 **Key agreement:**
-$$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind,B} \cdot s_B \in \mathcal{R}_q$$
-$$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind,A} \cdot s_A \in \mathcal{R}_q$$
+$$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind} \cdot s_B \in \mathcal{R}_q$$
+$$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind} \cdot s_A \in \mathcal{R}_q$$
 
-Commutativity of $\mathcal{R}_q$ gives $K_A \approx K_B$; reconciliation extracts a shared bit-string.
+Commutativity of $\mathcal{R}_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
 
 **KDF post-processing.**  The reconciled raw key $K$ is passed through NL-FSCX v1 for final extraction:
 
@@ -1082,7 +1085,8 @@ This is believed post-quantum hard; no polynomial-time quantum algorithm is know
 **Naive algebraic attack analysis.**  Without blinding ($m_\text{blind} = m$), Eve computes
 $m^{-1} \cdot (C \cdot q/p) \bmod q$ attempting to recover $s$.  The attack fails because
 rounding noise $\delta$ (bounded by $q/(2p)$ per coefficient) is amplified by $\|m^{-1}\|_1 \gg q$
-before any wrap-around threshold is crossed:
+before any wrap-around threshold is crossed.  (Verified with $q = 769$, $n = 16$, 200 trials per
+$p$ — see `SecurityProofsCode/hkex_nl_verification.py` §2.2.)
 
 | $p$ | $q/p$ | $\|m^{-1}\|_1 \cdot q/(2p)$ | Wraps mod $q$? | Attack success |
 |-----|-------|------------------------------|----------------|----------------|
@@ -1110,17 +1114,23 @@ All results are from `SecurityProofsCode/hkex_nl_verification.py` (n=32 unless n
 
 | Test | Result | Conclusion |
 |------|--------|------------|
-| Standard FSCX period $M^{n/2} = I$ (n=32, B=0) | 133/500 pairs satisfy period = n/2 | ~25% of random B values lie in null$(K_{n/2})$; confirms prior PL-1 analysis |
+| Standard FSCX period $M^{n/2} = I$ (n=32, random B) | 133/500 pairs satisfy period = n/2 | ~25% of random (X,B) pairs have orbit period exactly n/2; confirms prior PL-1 analysis |
 | NL-FSCX v1 orbit lengths (n=8, 1024 samples) | 938/1024 find no period in 256 steps; remainder have variable lengths | No consistent period |
 | NL-FSCX v1 period (n=32, 500 samples) | 500/500 find no period in 256 steps | Period property completely destroyed |
 | HSKE-A1 counter mode encrypt→decrypt | 200/200 correct | Counter mode is viable |
 
 #### Q2 — FSCX-LWR algebraic attack
 
+All rows below use $n = 16$ unless noted.  The deployed implementation uses $q = 65537$,
+$n \in \{32, 256\}$; those parameter pairs are marked ⚠ pending verification.
+
 | Test | Result | Conclusion |
 |------|--------|------------|
-| $m(x)$ invertible in $\mathcal{R}_q$, q ∈ {257…12289} | Yes, all 5 values; $m \cdot m^{-1} = 1$ verified | Algebraic inverse exists |
-| Naive attack: exact $s$ recovery (fixed $m$, p ∈ {4…256}) | 0/200 for every $p$ value | Rounding noise too large for naive inversion |
+| $m(x)$ invertible in $\mathcal{R}_q$, $q \in \{257, 769, 3329, 7681, 12289\}$, $n=16$ | Yes, all 5 values; $m \cdot m^{-1} = 1$ verified | Algebraic inverse exists for these $(n,q)$ |
+| $m(x)$ invertible, $q = 65537$, $n = 32$ | Yes; $\|m^{-1}\|_\infty = 31\,833$, $\|m^{-1}\|_1 = 536\,649$ | Verified in `hkex_nl_verification.py` §2.1 |
+| $m(x)$ invertible, $q = 65537$, $n = 256$ | Yes; $\|m^{-1}\|_\infty = 32\,640$, $\|m^{-1}\|_1 = 4\,286\,173$ | Verified in `hkex_nl_verification.py` §2.1 |
+| Noise amplification $\|m^{-1}\|_1 \cdot q/(2p)$ for deployed params ($q=65537$, $n=32$, $p=4096$) | $\approx 4\,293\,192 \gg q$ | Wraps mod $q$ — structural protection holds |
+| Naive attack: exact $s$ recovery (fixed $m$, $q=769$, $n=16$, $p \in \{4…256\}$) | 0/200 for every $p$ value | Rounding noise too large for naive inversion |
 | Noise amplification $\|m^{-1}\|_1 \cdot q/(2p)$ vs. $q$ | Exceeds $q$ for all tested $(q,p)$ | Structural protection against naive inversion |
 | Blinded $m$ vs. fixed $m$ (naive attack) | Both 0/200 | Blinding adds standard Ring-LWR hardness beyond structural noise protection |
 
@@ -1151,14 +1161,22 @@ The C3 hybrid assigns each primitive to the role that matches its properties:
 | HPKS commitment hash | **NL-FSCX v1** revolve | One-way; hardened against linear preimage |
 | HPKE encryption | **NL-FSCX v2** revolve | Invertible; bijective |
 
-**Parameters for HKEX-RNL** (suggested, requires further analysis before deployment):
-- $n = 256$, $q = 3329$ (Kyber-aligned), $p = 1024$, $p' = 32$
-- $a_\text{rand}$: 256-coefficient polynomial, coefficients uniform in $\mathbb{Z}/q\mathbb{Z}$, transmitted per session
+**Parameters for HKEX-RNL** (deployed in v1.5.0; requires further analysis before production use):
+- $n = 256$ (suite C/Go/Python), $n = 32$ (assembly, Arduino, C/Go/Python tests)
+- $q = 65537$ ($= 2^{16}+1$, Fermat prime); chosen over $q = 3329$ (Kyber) for lower
+  noise-to-margin ratio at small $n$, ensuring reliable single-block agreement without
+  reconciliation hints
+- $p = 4096$, $p' = 2$ (1 bit extracted per ring coefficient)
+- $a_\text{rand}$: $n$-coefficient polynomial, coefficients uniform in $\mathbb{Z}/q\mathbb{Z}$, transmitted per session
 - KDF: $sk = \text{NL-FSCX-REVOLVE}_{v1}(K_\text{raw}, K_\text{raw}, n/4)$
 
-**Status.** The cryptosuite code (`.c`, `.go`, `.py`, `.s`, `.asm`, `.ino`) continues to use
-standard FSCX in v1.4.0.  The NL-FSCX primitives and HKEX-RNL are documented here as
-verified proposals; code migration is planned for a future version.
+*Verification.* The invertibility of $m(x)$ in $\mathbb{Z}_q[x]/(x^n+1)$ is confirmed for
+the deployed parameters $(q=65537, n=32)$ and $(q=65537, n=256)$ by `hkex_nl_verification.py` §2.1.
+Noise amplification at $p=4096$ gives $\|m^{-1}\|_1 \cdot q/(2p) \approx 4.3\times10^6 \gg q$,
+confirming structural protection against naive inversion (§11.4.3, §11.5 Q2).
+
+**Status.** The NL-FSCX primitives and HKEX-RNL were implemented across all languages in v1.5.0.
+The C3 hybrid assignment (table above) governs the current implementation.
 
 ---
 
@@ -1381,7 +1399,13 @@ without solving a linear system at all (direct XOR), HHL is irrelevant.
 | **HSKE** (known-plaintext) | — | 1 KPT pair → full $c_K$, $O(n^2)$ | BV: 1 query | **None** |
 | **HPKS** | DLP in $\mathbb{GF}(2^n)^*$ + non-ROM challenge | Quasi-polynomial DLP | Shor's DLP | **None** |
 | **HPKE** | CDH in $\mathbb{GF}(2^n)^*$ | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
-| **HKEX-RNL** (proposed, §11.4) | Ring-LWR with blinded $m$ | No known sub-exponential attack | No known polynomial-time quantum attack | Conjectured — pending proof |
+| **HSKE-NL-A1** (§11.3.1, key-only) | NL-FSCX v1 PRF | Brute force $2^n$ (linear recovery blocked) | Grover $2^{n/2}$ | $n/2$ bits |
+| **HSKE-NL-A1** (known-plaintext) | — | Linear recovery blocked; 1-pair attack still recovers keystream | BV inapplicable (non-affine) | **None** (keystream recoverable) |
+| **HSKE-NL-A2** (§11.3.2, key-only) | NL-FSCX v2 bijection | Brute force $2^n$ (linear recovery blocked) | Grover $2^{n/2}$ | $n/2$ bits |
+| **HSKE-NL-A2** (known-plaintext) | — | Linear recovery blocked; 1-pair attack still recovers keystream | BV inapplicable (non-affine) | **None** (keystream recoverable) |
+| **HPKS-NL** (§11.2.1) | DLP in $\mathbb{GF}(2^n)^*$ + NL challenge | Quasi-polynomial DLP; challenge non-predictable | Shor's DLP | **None** |
+| **HPKE-NL** (§11.2.2) | CDH in $\mathbb{GF}(2^n)^*$ + NL-FSCX v2 | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
+| **HKEX-RNL** (§11.4) | Ring-LWR with blinded $m$ | No known sub-exponential attack | No known polynomial-time quantum attack | Conjectured — pending proof |
 
 **HSKE key-only** provides $n/2$ bits of post-quantum security only when no plaintext
 is ever observed.  In any realistic deployment, plaintexts are available and this bound

--- a/SecurityProofsCode/hkex_nl_verification.py
+++ b/SecurityProofsCode/hkex_nl_verification.py
@@ -280,24 +280,35 @@ print(f"\n[2.1]  Invertibility of m(x) in Z_q[x]/(x^n+1) for various (n, q)")
 n_lwr   = 16
 q_vals  = [257, 769, 3329, 7681, 12289]
 
-m16 = m_poly(n_lwr)
-print(f"  n={n_lwr}, m(x) = {m16}")
-print(f"\n  {'q':>6}  {'inv?':>5}  {'‖m⁻¹‖_∞':>9}  {'‖m⁻¹‖_1':>9}  {'verify':>7}")
+def check_inv_table(n_check, q_list, label=""):
+    mn = m_poly(n_check)
+    if label:
+        print(f"\n  {label}")
+    print(f"  n={n_check}")
+    print(f"  {'q':>7}  {'inv?':>5}  {'‖m⁻¹‖_∞':>11}  {'‖m⁻¹‖_1':>11}  {'verify':>7}")
+    results = {}
+    for q in q_list:
+        mi = poly_inv_mod(mn, q, n_check)
+        if mi is None:
+            print(f"  {q:7d}  {'NO':>5}")
+            results[q] = None
+        else:
+            chk  = poly_mul_neg(mn, mi, q, n_check)
+            ok   = chk[0] == 1 and all(c == 0 for c in chk[1:])
+            cinf = max(abs(centered_coeff(c, q)) for c in mi)
+            c1   = sum(abs(centered_coeff(c, q)) for c in mi)
+            print(f"  {q:7d}  {'YES':>5}  {cinf:11d}  {c1:11d}  {'✓' if ok else '✗':>7}")
+            results[q] = mi
+    return results
 
-inv_results = {}
-for q in q_vals:
-    mi = poly_inv_mod(m16, q, n_lwr)
-    if mi is None:
-        print(f"  {q:6d}  {'NO':>5}")
-        inv_results[q] = None
-    else:
-        # Verify
-        chk   = poly_mul_neg(m16, mi, q, n_lwr)
-        ok    = chk[0] == 1 and all(c == 0 for c in chk[1:])
-        cinf  = max(abs(centered_coeff(c, q)) for c in mi)
-        c1    = sum(abs(centered_coeff(c, q)) for c in mi)
-        print(f"  {q:6d}  {'YES':>5}  {cinf:9d}  {c1:9d}  {'✓' if ok else '✗':>7}")
-        inv_results[q] = mi
+inv_results = check_inv_table(n_lwr, q_vals, "Prior verification (n=16, q ∈ {257…12289})")
+
+# Deployed code uses q=65537 at n=32 (assembly / C tests) and n=256 (suite C/Go/Python).
+# Verify these parameter pairs explicitly.
+print()
+inv_results_32  = check_inv_table(32,  [65537], "Deployed params — n=32,  q=65537")
+print()
+inv_results_256 = check_inv_table(256, [65537], "Deployed params — n=256, q=65537  (slow — negacyclic 256×256 GJ)")
 
 # ── 2.2  Algebraic attack: recover s from C = round_p(m·s mod q) ─────────────
 print(f"\n[2.2]  Algebraic attack: Eve computes s_rec = m⁻¹ · (C · q/p) mod q")
@@ -347,12 +358,25 @@ for q in [769, 3329]:
     if mi is None: continue
     c1   = sum(abs(centered_coeff(c, q)) for c in mi)
     cinf = max(abs(centered_coeff(c, q)) for c in mi)
-    print(f"\n  q={q}:")
+    print(f"\n  q={q}, n={n_lwr}:")
     print(f"    ‖m⁻¹‖_1 = {c1}  →  output noise ≤ {c1} · q/(2p)")
     for p in [16, 32, 64]:
         max_out_noise = c1 * (q // (2 * p))
         recoverable   = max_out_noise >= q // 2
         print(f"    p={p:3d}: max output noise ≈ {max_out_noise:6d}  "
+              f"({'wraps mod q → s unrecoverable' if recoverable else 'small → s likely recoverable'})")
+
+# Deployed parameters: q=65537, n=32, p=4096
+mi32 = inv_results_32.get(65537)
+if mi32 is not None:
+    q_dep, n_dep, p_dep = 65537, 32, 4096
+    c1   = sum(abs(centered_coeff(c, q_dep)) for c in mi32)
+    print(f"\n  q={q_dep}, n={n_dep} (deployed):")
+    print(f"    ‖m⁻¹‖_1 = {c1}  →  output noise ≤ {c1} · q/(2p)")
+    for p in [p_dep, 256, 64]:
+        max_out_noise = c1 * (q_dep // (2 * p))
+        recoverable   = max_out_noise >= q_dep // 2
+        print(f"    p={p:4d}: max output noise ≈ {max_out_noise:12d}  "
               f"({'wraps mod q → s unrecoverable' if recoverable else 'small → s likely recoverable'})")
 
 # ── 2.4  Random blinding: m_blind = m + a_rand ───────────────────────────────


### PR DESCRIPTION
## Summary

- **CLAUDE.md / README.md** — corrected stale version label, wrong test count (9→16), removed non-existent files from repo structure, added v1.5.0 NL/PQC protocol entries to protocol-stack section
- **`Herradura_tests.c`** — fixed four benchmark block comments that still showed old numbers `[11]`–`[14]` instead of `[18]`–`[21]`
- **`SecurityProofs.md`** — seven proof-level fixes: §11 version label, §11.4.2 shared-polynomial clarification, §11.4.3 missing `q` attribution, §11.5 Q1 wrong `B=0` description, §11.5 Q2 deployed-parameter verification rows, §11.6 stale status/parameter mismatch, §12.5 missing NL-protocol rows
- **`hkex_nl_verification.py`** — extended §2.1 and §2.3 to verify and characterise `m(x)` invertibility and noise amplification for the deployed parameters `(q=65537, n=32)` and `(q=65537, n=256)`
- **`Herradura_tests.{c,go,py}` test [14]** — all three now check both raw agreement (`K_A == K_B`) and KDF-processed agreement (`sk_A == sk_B`); previously only Go did both; added protocol comments

## Test plan

- [x] C: `gcc -O2` compiles cleanly; `./Herradura_tests -t 2` — all 16 tests PASS
- [x] Python: `python3 -c "import ast; ast.parse(open('CryptosuiteTests/Herradura_tests.py').read())"` — syntax OK
- [x] Go: `go vet` — no semantic errors (only pre-existing redundant-newline lint warnings)
- [x] Verification script: `python3 SecurityProofsCode/hkex_nl_verification.py` runs to completion; `(q=65537, n=32)` and `(q=65537, n=256)` both show `YES ✓`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)