### PR TITLE
v1.5.2: document proposed multi-size key-length tests for Herradura_tests.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.2] - 2026-04-16
+
+### Proposed — multi-size key-length tests for `Herradura_tests.c`
+
+Analysis of the gap between the Python and C test suites: `Herradura_tests.py`
+loops each test over `SIZES = [64, 128, 256]` (FSCX tests) and `GF_SIZES = [32, 64]`
+(GF protocol tests), while `Herradura_tests.c` runs each test at a single hardcoded
+size (256-bit for tests [1]–[6], 32-bit for tests [7]–[16]).
+
+Three structural changes proposed for a follow-up implementation commit:
+
+1. **Generalize `BitArray`** — add `int nbits; int nbytes;` fields (max buffer stays
+   32 bytes); thread `nbits` through all `ba_*` and `ba_fscx*` functions; add `ba_add`
+   (mod 2^n addition) required by NL-FSCX v1/v2 at non-32-bit widths.
+
+2. **Add 64-bit GF layer** — `gf_mul_64` / `gf_pow_64` (poly `0x1BULL`,
+   GF(2^64)); `fscx64` / `fscx_revolve64`; `nl_fscx_v1_64` / `nl_fscx_v2_64` and
+   their inverses, mirroring the existing `_32` helpers.
+
+3. **Loop tests over multiple sizes**:
+   ```c
+   static const int SIZES[]    = {64, 128, 256}; /* tests 2,3,4,10,11,12,13 */
+   static const int GF_SIZES[] = {32, 64};        /* tests 1,5,6,7,8,9,15,16 */
+   ```
+
+Version strings bumped to v1.5.2 in `Herradura_tests.c`, `Herradura_tests.py`,
+and `Herradura_tests.go`.
+
+---
+
 ## [1.5.1] - 2026-04-16
 
 ### Fixed / Added

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, 256-bit BitArray + 32-bit GF)
+    v1.5.2: proposed multi-size key-length loops for all tests (matching Python/Go).
     v1.5.0: HKEX-GF; Schnorr HPKS; El Gamal HPKE; NL-FSCX non-linear extension; PQC.
       Tests [1]-[6]: 256-bit HKEX-GF and FSCX primitives (unchanged).
       [7] HPKS Schnorr correctness: g^s * C^e == R  (32-bit GF).
@@ -1186,7 +1187,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.1 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.5.2 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.2: proposed multi-size key-length tests for Herradura_tests.c (matching Python).
     v1.5.1: added -rounds and -time CLI flags (also HTEST_ROUNDS / HTEST_TIME env vars).
     v1.5.0: added PQC extension tests [10-16] (NL-FSCX, HKEX-RNL, HPKS-NL, HPKE-NL);
             benchmarks renumbered [17-21] (were [10-14] in v1.4.0);
@@ -1174,7 +1175,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.1 \u2014 Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.2 \u2014 Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.2: proposed multi-size key-length tests for Herradura_tests.c (matching Python).
     v1.5.1: added --rounds/-r and --time/-t CLI options (also HTEST_ROUNDS / HTEST_TIME env).
     v1.5.0: added PQC extension tests [10-16] and benchmarks [22-25].
             benchmarks renumbered [17-21] (were [10-14] in v1.4.0).
@@ -842,7 +843,7 @@ def bench_hkex_rnl_handshake():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.1 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.5.2 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -870,7 +871,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.1 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.2 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")


### PR DESCRIPTION
## Summary

- Adds `[1.5.2]` entry to `CHANGELOG.md` documenting the three structural changes needed to bring `Herradura_tests.c` to feature-parity with the Python test suite (per-test loops over `SIZES = [64, 128, 256]` and `GF_SIZES = [32, 64]`).
- Bumps version strings to `v1.5.2` in `Herradura_tests.c`, `Herradura_tests.py`, and `Herradura_tests.go`.
- No code logic changes in this PR; implementation of the multi-size loops is tracked in the changelog as a follow-up.

## Test plan

- [ ] `python3 CryptosuiteTests/Herradura_tests.py` — header line reads `v1.5.2`
- [ ] `cd CryptosuiteTests && go run Herradura_tests.go` — header line reads `v1.5.2`
- [ ] `gcc -O2 -o CryptosuiteTests/Herradura_tests CryptosuiteTests/Herradura_tests.c && ./CryptosuiteTests/Herradura_tests` — header line reads `v1.5.2`
- [ ] `CHANGELOG.md` top entry is `[1.5.2] - 2026-04-16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)