### PR TITLE
v1.5.2: fix KaTeX cross-span emphasis collision in SecurityProofs.md §11.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ### Fixed — KaTeX rendering in `SecurityProofs.md` (cross-span emphasis collision)
 
-Three formulas in `SecurityProofs.md` rendered as raw source code on GitHub due to
+Six formulas in `SecurityProofs.md` rendered as raw source code on GitHub due to
 cmark-gfm processing emphasis `_` delimiters before detecting `$...$` inline math spans.
 
 Root cause: `_` preceded by `}` (a CommonMark punctuation character) satisfies the
 left-flanking delimiter rule and can open an emphasis run.  When a matching
-right-flanking `_` appears in a later math span on the same line, GitHub's parser
-consumes both underscores as emphasis, destroying the enclosing `$` math spans.
+right-flanking `_` appears in a later math span on the same line or paragraph,
+GitHub's parser consumes both underscores as emphasis, destroying the enclosing
+`$` math spans.
 
 Fixes applied:
 
@@ -24,6 +25,12 @@ Fixes applied:
 - **Line 1171** (`\text{NL-FSCX-REVOLVE}_{v1}`) — `}_{v1}` still has `_` preceded by
   `}`, so the entire subscripted name is rewritten using `\textunderscore` separators:
   `\text{NL-FSCX}\textunderscore\text{REVOLVE}\textunderscore\text{v1}`.
+- **Lines 1057–1059** (§11.4.2 shared polynomial setup) — same `\mathcal{R}_q` →
+  `\mathcal R_q` fix; opener `_q` on line 1057 was pairing with `m_\text{blind}`
+  closer on line 1059 across the paragraph boundary of two `$...$` spans.
+- **Line 1071** (§11.4.2 commutativity sentence) — `\mathcal{R}_q` opener at start
+  of line paired with `m_\text{blind}` closer in the adjacent span on the same line;
+  fixed with `\mathcal R_q`.
 
 ---
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1054,9 +1054,9 @@ The centered $\ell_1$-norm of $m^{-1}(x)$ scales as $\|m^{-1}\|_1 \approx n \cdo
 **Setup.** Parties agree on public parameters $(n, q, p, g)$ with $p < q$ both prime.
 
 **Shared polynomial setup (one-shot, per session):**
-- One party (e.g. Alice) draws $a_\text{rand} \leftarrow \mathcal{R}_q$ uniformly and
+- One party (e.g. Alice) draws $a_\text{rand} \leftarrow \mathcal R_q$ uniformly and
   transmits it in the clear.  Both parties compute the **shared** blinded polynomial:
-  $m_\text{blind} = m(x) + a_\text{rand} \in \mathcal{R}_q$.
+  $m_\text{blind} = m(x) + a_\text{rand} \in \mathcal R_q$.
 
 **Key generation (Alice and Bob, independently):**
 - Alice: private $s_A \leftarrow \mathcal R_q$; public key $C_A = \lfloor m_\text{blind} \cdot s_A \rceil_p \in \mathcal R_p$.
@@ -1068,7 +1068,7 @@ Both use the **same** $m_\text{blind}$.  ($\lfloor \cdot \rceil_p$ denotes round
 $$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind} \cdot s_B \in \mathcal{R}_q$$
 $$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind} \cdot s_A \in \mathcal{R}_q$$
 
-Commutativity of $\mathcal{R}_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
+Commutativity of $\mathcal R_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
 
 **KDF post-processing.**  The reconciled raw key $K$ is passed through NL-FSCX v1 for final extraction:
 


### PR DESCRIPTION
## Summary

- Fixed 3 formulas in `SecurityProofs.md §11.4.2` that rendered as raw source on GitHub (follow-up to PR #28)
- Same root cause: `_` preceded by `}` is left-flanking per CommonMark rules, opening emphasis across adjacent `$...$` spans
- Lines 1057/1059: `\mathcal{R}_q` opener paired with `m_\text{blind}` closer across two spans in the same paragraph
- Line 1071: same opener+closer pair on a single line
- Fix: `\mathcal{R}_q` → `\mathcal R_q` (no braces needed around single-char `\mathcal` argument)

## Test plan

- [x] View `SecurityProofs.md §11.4.2` on GitHub and confirm lines 1057, 1059, and 1071 render as math
- [ ] Confirm display-math `$$...$$` blocks on lines 1068–1069 are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)