### PR TITLE
v1.5.2: fix KaTeX ^* and \mathcal{R}_q cross-span emphasis in SecurityProofs.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
-## [1.5.2] - 2026-04-17
+## [1.5.2] - 2026-04-18
+
+### Fixed — KaTeX rendering in `SecurityProofs.md` (`^*` and `\mathcal{R}_q` cross-span emphasis)
+
+Additional cross-span emphasis collisions in `SecurityProofs.md` fixed:
+
+- **`^*` in inline math spans** — `*` between `^` and `$`/`,`/`}` (all CommonMark
+  punctuation) is both-flanking: it can open AND close `*`-emphasis.  When two or more
+  `$...\mathbb{GF}(2^n)^*...$` spans appear in the same paragraph (lines 726, 1202–1206)
+  or the forgery section contains many `$R^*$`, `$s^*$`, `$e^*$`, `$P^*$` spans
+  (lines 1249–1254), opener/closer pairs form across span boundaries, destroying both
+  math spans and garbling the surrounding text.
+  Fix: `^*` → `^{\ast}` throughout all inline math (`\ast` renders identically as ∗
+  but contains no literal `*` character, preventing emphasis matching).
+  Applies to `\mathbb{GF}(2^n)^{\ast}`, `\mathbb{GF}(2^{32})^{\ast}`,
+  `\mathbb{Z}_p^{\ast}`, and all starred variables in §12.2.2.
+- **Lines 1068–1069** (`$$K_A/K_B$$` display math) — `\mathcal{R}_q` (where `}`
+  precedes `_q`) across the two consecutive display-math blocks creates a cross-block
+  emphasis pair.  Fixed with `\mathcal R_q` (no braces around single-char argument).
 
 ### Fixed — KaTeX rendering in `SecurityProofs.md` (cross-span emphasis collision)
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -581,7 +581,7 @@ None of HSKE, HPKE, or HPKS provides joint confidentiality + integrity + authent
 | $k$ exchanged public values do not help (any $k$) | **Proved** | Each term linear; $k = 1, 2, 4$ tested |
 | Root cause: GF(2)-linearity/correctness–security incompatibility | **Proved** (Thm. 10) | Algebraic; no counterexample exists |
 | Quantum attacks: classical break makes them moot | **Proved** | See §6 |
-| **HKEX-GF correctness:** $g^{ab} = g^{ba}$ in $\mathbb{GF}(2^n)^*$ | **Proved** (field commutativity) | Algebraic + 5K/1K trials (Python/C) |
+| **HKEX-GF correctness:** $g^{ab} = g^{ba}$ in $\mathbb{GF}(2^n)^{\ast}$ | **Proved** (field commutativity) | Algebraic + 5K/1K trials (Python/C) |
 | **HKEX-GF Eve resistance:** $S_{r+1}(C \oplus C_2) \neq sk$ | **Proved** | 10K trials — 0 successes |
 | **FSCX-CY non-linearity** | **Proved** | 4998/5000 affine-test failures |
 | **FSCX-CY HKEX failure** | **Proved** | 0/2000 correctness trials |
@@ -665,7 +665,7 @@ The two proposals below attack this from different angles:
 
 ---
 
-### 9.2 HKEX-GF — Diffie-Hellman over $\mathbb{GF}(2^n)^*$
+### 9.2 HKEX-GF — Diffie-Hellman over $\mathbb{GF}(2^n)^{\ast}$
 
 #### 9.2.1 Algebraic structure
 
@@ -695,19 +695,19 @@ This contrasts with the FSCX map $A \mapsto M^i \cdot A + M \cdot S_i \cdot B$, 
 
 #### 9.2.2 Protocol
 
-Pre-agreed public parameters: field size $n$, irreducible polynomial $p(x)$, generator $g \in \mathbb{GF}(2^n)^*$.
+Pre-agreed public parameters: field size $n$, irreducible polynomial $p(x)$, generator $g \in \mathbb{GF}(2^n)^{\ast}$.
 
 | Step | Alice | Bob |
 |------|-------|-----|
 | Private | $a \xleftarrow{\textdollar} \{1,\ldots,2^n{-}1\}$ | $b \xleftarrow{\textdollar} \{1,\ldots,2^n{-}1\}$ |
-| Public | $C = g^a \in \mathbb{GF}(2^n)^*$ | $C_2 = g^b \in \mathbb{GF}(2^n)^*$ |
+| Public | $C = g^a \in \mathbb{GF}(2^n)^{\ast}$ | $C_2 = g^b \in \mathbb{GF}(2^n)^{\ast}$ |
 | Shared | $sk = C_2^{\,a} = g^{ab}$ | $sk = C^{\,b} = g^{ab}$ |
 
 **Correctness proof:**
 
 $$C_2^{\,a} = (g^b)^a = g^{ba} = g^{ab} = (g^a)^b = C^{\,b} \qquad \blacksquare$$
 
-This holds by commutativity and associativity of multiplication in $\mathbb{GF}(2^n)^*$, which are ring axioms satisfied for any polynomial choice (irreducible or not). Irreducibility is required only for the group to be a field (every non-zero element invertible).
+This holds by commutativity and associativity of multiplication in $\mathbb{GF}(2^n)^{\ast}$, which are ring axioms satisfied for any polynomial choice (irreducible or not). Irreducibility is required only for the group to be a field (every non-zero element invertible).
 
 #### 9.2.3 Why Eve's formula fails
 
@@ -721,9 +721,9 @@ because $S_{r+1}$ is the $\mathbb{GF}(2)$-linear FSCX partial-sum operator actin
 
 #### 9.2.4 Security assumption
 
-The hardness of HKEX-GF reduces to the **Computational Diffie-Hellman (CDH)** problem in $\mathbb{GF}(2^n)^*$: given $g^a$ and $g^b$, compute $g^{ab}$.
+The hardness of HKEX-GF reduces to the **Computational Diffie-Hellman (CDH)** problem in $\mathbb{GF}(2^n)^{\ast}$: given $g^a$ and $g^b$, compute $g^{ab}$.
 
-CDH in $\mathbb{GF}(2^n)^*$ is believed hard for large $n$, under the assumption that the Discrete Logarithm Problem (DLP) in $\mathbb{GF}(2^n)^*$ is hard. Sub-exponential attacks (index calculus, function field sieve variants) exist for binary extension fields; practical parameters:
+CDH in $\mathbb{GF}(2^n)^{\ast}$ is believed hard for large $n$, under the assumption that the Discrete Logarithm Problem (DLP) in $\mathbb{GF}(2^n)^{\ast}$ is hard. Sub-exponential attacks (index calculus, function field sieve variants) exist for binary extension fields; practical parameters:
 
 | $n$ | Estimated classical security | Note |
 |-----|------------------------------|------|
@@ -736,7 +736,7 @@ For production use, elliptic curve Diffie-Hellman over a binary curve (or a prim
 
 #### 9.2.5 FSCX period preserved
 
-FSCX, fscx\_revolve, and all symmetric protocols (HSKE, HPKS, HPKE) are **unchanged**. Their correctness proofs (Theorems 1–6, Corollaries 1–3) remain valid. The HKEX-GF key exchange produces $sk \in \mathbb{GF}(2^n)^*$, which is passed to HSKE/HPKS/HPKE as a pre-shared symmetric key — the existing interface.
+FSCX, fscx\_revolve, and all symmetric protocols (HSKE, HPKS, HPKE) are **unchanged**. Their correctness proofs (Theorems 1–6, Corollaries 1–3) remain valid. The HKEX-GF key exchange produces $sk \in \mathbb{GF}(2^n)^{\ast}$, which is passed to HSKE/HPKS/HPKE as a pre-shared symmetric key — the existing interface.
 
 **Verified experimentally:** `fscx_revolve(fscx_revolve(P, K, i), K, r) = P` for $i + r = n$ holds at 4000/4000 trials across $n \in \{32, 64\}$ (Section I-D of `hkex_nl_proposal.py`).
 
@@ -827,7 +827,7 @@ Under FSCX-CY, each public value $C = g_B^i(A)$ encodes private carry terms $\de
 | Eve's $S_{r+1}(C \oplus C_2)$ fails | Yes (0/4 000 trials) | Yes (0/2 000 trials) |
 | Operations | XOR + left-shift | XOR + rotation + ADD |
 | FSCX period preserved | Yes (HSKE/HPKS/HPKE unchanged) | No (key-dependent, exponentially large) |
-| Security assumption | DLP in $\mathbb{GF}(2^n)^*$ | Unknown |
+| Security assumption | DLP in $\mathbb{GF}(2^n)^{\ast}$ | Unknown |
 | Copies a known cipher | No (DH is a key-exchange, not a cipher) | No |
 
 **Recommended fix.** Replace the HKEX key-exchange step with HKEX-GF. All symmetric protocols (HSKE, HPKS, HPKE) continue using standard FSCX with no changes. The period structure $M^n = I$, $S_n = 0$ remains valid; all correctness proofs (Theorems 1–6, Corollaries 1–3) are unaffected. The only change is in how the shared symmetric key $sk$ is established: via $\mathbb{GF}(2^n)$ DH rather than via FSCX iteration.
@@ -844,7 +844,7 @@ Version 1.4.0 replaces the broken HKEX key exchange with HKEX-GF across all impl
 
 | Function | v1.3.x (broken) | v1.4.0 (fixed) |
 |----------|-----------------|----------------|
-| Key exchange | FSCX-based (linear, $sk$ public) | DH over $\mathbb{GF}(2^n)^*$ |
+| Key exchange | FSCX-based (linear, $sk$ public) | DH over $\mathbb{GF}(2^n)^{\ast}$ |
 | `fscx_revolve_n` | Used in HKEX/HPKS/HPKE | **Removed** — nonce cancels identically |
 | HSKE | `fscx_revolve_n(P, K, K, i)` | `fscx_revolve(P, K, i)` |
 | HPKS | $S = sk \oplus P$, where $sk = \text{FSCX-based}$ | $S = sk \oplus P$, where $sk = g^{ab}$ |
@@ -890,12 +890,12 @@ All results from `Herradura_tests.py`, `Herradura_tests.go`, `Herradura_tests.c`
 | W2: $sk$ computable from $(C, C_2)$ | **ACTIVE** (Thm. 7) | **Mitigated** — $sk = g^{ab}$ requires DLP |
 | W3: HPKE no confidentiality | **ACTIVE** | **Mitigated** — $E = sk \oplus P$ with CDH-hard $sk$ |
 | W5: Single $(P,S)$ reveals $sk$ | **ACTIVE** | **Mitigated** — $sk$ is CDH-hard to compute |
-| W6: No hardness assumption established | **ACTIVE** | **Mitigated** — CDH in $\mathbb{GF}(2^n)^*$ |
+| W6: No hardness assumption established | **ACTIVE** | **Mitigated** — CDH in $\mathbb{GF}(2^n)^{\ast}$ |
 | W4: Bit malleability (no IND-CCA2) | Active | Still active (structural to XOR encryption) |
 | W7: Short orbit space | Active | Still active for FSCX; irrelevant for GF DH |
 | W8: No authenticated encryption | Active | Still active (no MAC component) |
 
-The key exchange is now provably secure under CDH in $\mathbb{GF}(2^n)^*$. Remaining weaknesses (W4, W7, W8) are structural to the XOR-based symmetric protocols and are documented; they do not affect the key exchange itself.
+The key exchange is now provably secure under CDH in $\mathbb{GF}(2^n)^{\ast}$. Remaining weaknesses (W4, W7, W8) are structural to the XOR-based symmetric protocols and are documented; they do not affect the key exchange itself.
 
 ---
 
@@ -1020,7 +1020,7 @@ $O(r \cdot n/2)$ FSCX steps — same asymptotic order as standard HSKE.
 
 ### 11.4 HKEX-RNL: PQC Key Exchange (B2)
 
-HKEX-GF relies on the DLP in $\mathbb{GF}(2^n)^*$, which Shor's algorithm solves in polynomial time
+HKEX-GF relies on the DLP in $\mathbb{GF}(2^n)^{\ast}$, which Shor's algorithm solves in polynomial time
 on a quantum computer.  The following replacement is proposed.
 
 #### 11.4.1 Ring structure
@@ -1065,8 +1065,8 @@ The centered $\ell_1$-norm of $m^{-1}(x)$ scales as $\|m^{-1}\|_1 \approx n \cdo
 Both use the **same** $m_\text{blind}$.  ($\lfloor \cdot \rceil_p$ denotes rounding from $\mathbb{Z}/q\mathbb{Z}$ to $\mathbb{Z}/p\mathbb{Z}$.)
 
 **Key agreement:**
-$$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind} \cdot s_B \in \mathcal{R}_q$$
-$$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind} \cdot s_A \in \mathcal{R}_q$$
+$$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind} \cdot s_B \in \mathcal R_q$$
+$$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind} \cdot s_A \in \mathcal R_q$$
 
 Commutativity of $\mathcal R_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
 
@@ -1188,22 +1188,22 @@ The C3 hybrid assignment (table above) governs the current implementation.
 
 ### 12.1 Classical DLP Attacks on GF(2^n)*
 
-The security of HKEX-GF, HPKS, and HPKE rests on the DLP in $\mathbb{GF}(2^n)^*$.
+The security of HKEX-GF, HPKS, and HPKE rests on the DLP in $\mathbb{GF}(2^n)^{\ast}$.
 The group has order $2^n - 1$.  Known classical attack complexities:
 
 | Algorithm | Complexity | Notes |
 |-----------|------------|-------|
 | Baby-step giant-step (BSGS) | $O(2^{n/2})$ time, $O(2^{n/2})$ space | Generic group algorithm |
 | Pohlig–Hellman | $O(\sqrt{q_{\max}})$ where $q_{\max}$ = largest prime factor of group order | Dangerous when order is smooth |
-| Index calculus (function field sieve) | $L_{2^n}[1/2, c]$ (sub-exponential) | General DLP in $\mathbb{GF}(2^n)^*$ |
+| Index calculus (function field sieve) | $L_{2^n}[1/2, c]$ (sub-exponential) | General DLP in $\mathbb{GF}(2^n)^{\ast}$ |
 | **Quasi-polynomial (Barbulescu–Joux–Pierrot 2013)** | $(\log 2^n)^{O(\log\log 2^n)}$ | Specific to characteristic-2 fields |
 
 The **quasi-polynomial algorithm** is the dominant classical threat.  It exploits the
-characteristic-2 structure of $\mathbb{GF}(2^n)^*$ via a descent using sparse linear systems in
+characteristic-2 structure of $\mathbb{GF}(2^n)^{\ast}$ via a descent using sparse linear systems in
 function fields — a technique with no known analogue for DLP in prime-order elliptic curve groups
-or in $\mathbb{Z}_p^*$.  In practice it has broken DLP in $\mathbb{GF}(2^{1279})$ and related
-fields.  The recommended minimum for $\mathbb{GF}(2^n)^*$ DLP (if it must be used) is $n \geq 3000$;
-most standards bodies advise **against** using $\mathbb{GF}(2^n)^*$ for new DLP-based designs.
+or in $\mathbb{Z}_p^{\ast}$.  In practice it has broken DLP in $\mathbb{GF}(2^{1279})$ and related
+fields.  The recommended minimum for $\mathbb{GF}(2^n)^{\ast}$ DLP (if it must be used) is $n \geq 3000$;
+most standards bodies advise **against** using $\mathbb{GF}(2^n)^{\ast}$ for new DLP-based designs.
 
 **Experimental verification at $n = 32$ (demo parameters).**
 
@@ -1223,7 +1223,7 @@ sk_from_dlp = gf_pow(C2, a_rec)   # == 0xD3DB6BC3  (matches actual sk)
 ```
 
 The recovered $a_\text{rec} \neq A_\text{PRIV}$ because $g = 3$ is not a primitive element of
-$\mathbb{GF}(2^{32})^*$: its order is a proper divisor of $2^{32}-1$.  Multiple exponents share
+$\mathbb{GF}(2^{32})^{\ast}$: its order is a proper divisor of $2^{32}-1$.  Multiple exponents share
 the same public key; BSGS finds the smallest representative.  The shared secret is nevertheless
 fully recovered because $g^{ab}$ is the same regardless of which representative is used.
 
@@ -1246,16 +1246,16 @@ determined.  **HSKE provides no security under known-plaintext attack at any $n$
 
 #### 12.2.2 HPKS — Classical Forgery Resistance
 
-Forgery requires finding $(R^*, s^*)$ satisfying $g^{s^*} \cdot C^{e^*} = R^*$ where
-$e^* = \text{fscx}\textunderscore\text{revolve}(R^*_\text{bits}, P^*, i)$, without knowing the private key $a$.
+Forgery requires finding $(R^{\ast}, s^{\ast})$ satisfying $g^{s^{\ast}} \cdot C^{e^{\ast}} = R^{\ast}$ where
+$e^{\ast} = \text{fscx}\textunderscore\text{revolve}(R^{\ast}_\text{bits}, P^{\ast}, i)$, without knowing the private key $a$.
 
-- If Eve fixes $R^*$ first: she needs $s^* = \log_g(R^* \cdot C^{-e^*})$ — a DLP instance.
-- If Eve fixes $s^*$ first: she can compute $g^{s^*} \cdot C^{e^*}$ for any $e^*$, but the
-  constraint $e^* = \text{fscx}\textunderscore\text{revolve}(R^*_\text{bits}, P^*, i)$ ties $R^*$ and $e^*$
+- If Eve fixes $R^{\ast}$ first: she needs $s^{\ast} = \log_g(R^{\ast} \cdot C^{-e^{\ast}})$ — a DLP instance.
+- If Eve fixes $s^{\ast}$ first: she can compute $g^{s^{\ast}} \cdot C^{e^{\ast}}$ for any $e^{\ast}$, but the
+  constraint $e^{\ast} = \text{fscx}\textunderscore\text{revolve}(R^{\ast}_\text{bits}, P^{\ast}, i)$ ties $R^{\ast}$ and $e^{\ast}$
   together.  Since fscx\_revolve is an affine bijection in its first argument (see §12.3),
   solving both simultaneously reduces to DLP hardness.
 
-Forgery resistance is equivalent to DLP hardness in $\mathbb{GF}(2^n)^*$, subject to the
+Forgery resistance is equivalent to DLP hardness in $\mathbb{GF}(2^n)^{\ast}$, subject to the
 quasi-polynomial attack in §12.1 and the challenge-function caveat in §12.3.
 
 #### 12.2.3 HPKE — Classical Attack
@@ -1308,7 +1308,7 @@ adversary computes the challenge $e_2$ for $(R, P')$ as $e_2 = e_1 \oplus M^i \c
 The rewound challenge is deterministically related to the original — the forking lemma
 does not apply in its standard form.
 
-**Practical implication.** The DLP in $\mathbb{GF}(2^n)^*$ still protects the private key
+**Practical implication.** The DLP in $\mathbb{GF}(2^n)^{\ast}$ still protects the private key
 $a$: Eve cannot recover $a$ from the Schnorr equation without solving DLP.  But the
 non-ROM challenge means the standard Schnorr security proof does not carry over, and
 subtle attacks exploiting challenge predictability cannot be excluded by proof alone.
@@ -1326,7 +1326,7 @@ $O(2^{n/2})$ with Grover.  For $n = 256$: $2^{128}$ post-quantum symmetric secur
 against key-only attacks.  This bound is vacuous when plaintexts are available — the
 classical 1-pair KPT attack recovers the key in $O(n^2)$ regardless.
 
-**HKEX-GF, HPKS, HPKE.**  Security rests on DLP in $\mathbb{GF}(2^n)^*$.  Shor's
+**HKEX-GF, HPKS, HPKE.**  Security rests on DLP in $\mathbb{GF}(2^n)^{\ast}$.  Shor's
 algorithm (§12.4.4) solves DLP in polynomial quantum time and strictly dominates
 Grover for all these protocols.  **Grover is irrelevant for the GF-DLP protocols.**
 
@@ -1335,7 +1335,7 @@ Grover for all these protocols.  **Grover is irrelevant for the GF-DLP protocols
 **Simon's problem:** find the hidden period $s$ of a function $f(x) = f(x \oplus s)$
 in $O(n)$ quantum queries, where $s$ is $\mathbb{GF}(2)$-linear.
 
-**Applicability.** The DLP function $f(x) = g^x$ in $\mathbb{GF}(2^n)^*$ has collisions
+**Applicability.** The DLP function $f(x) = g^x$ in $\mathbb{GF}(2^n)^{\ast}$ has collisions
 determined by the *cyclic* group structure of the exponent: $g^{x_1} = g^{x_2}$ iff
 $x_1 \equiv x_2 \pmod{|\langle g \rangle|}$.  This is a $\mathbb{Z}$-linear period, not a
 $\mathbb{GF}(2)$-linear period.  Simon's QFT over $\mathbb{GF}(2)^n$ cannot extract it;
@@ -1352,21 +1352,21 @@ oracle access (fixed key, variable plaintext), BV recovers $c_K$ in **1 quantum 
 matching the classical known-plaintext bound.  No asymptotic quantum advantage over the
 classical attack.
 
-**HKEX-GF, HPKS, HPKE.** Involve $\mathbb{GF}(2^n)^*$ exponentiation, which is not
+**HKEX-GF, HPKS, HPKE.** Involve $\mathbb{GF}(2^n)^{\ast}$ exponentiation, which is not
 $\mathbb{GF}(2)$-affine in the exponent.  BV does not apply.
 
 #### 12.4.4 Shor's Algorithm — Primary Quantum Threat
 
 Shor's algorithm solves the DLP in any cyclic group $G = \langle g \rangle$ of order $N$
 in $O((\log N)^2 \log\log N \cdot \log\log\log N)$ quantum gate operations.  For
-$\mathbb{GF}(2^n)^*$: group order $N = 2^n - 1$, quantum time $O(n^2 \log n)$.
+$\mathbb{GF}(2^n)^{\ast}$: group order $N = 2^n - 1$, quantum time $O(n^2 \log n)$.
 
-| Adversary | Best DLP attack on $\mathbb{GF}(2^n)^*$ | Complexity |
+| Adversary | Best DLP attack on $\mathbb{GF}(2^n)^{\ast}$ | Complexity |
 |-----------|----------------------------------------|------------|
 | Classical | Quasi-polynomial (Barbulescu 2013) | $(\log N)^{O(\log\log N)}$ |
 | Quantum | Shor's algorithm | $O((\log N)^2 \log\log N)$ |
 
-Both attacks break $\mathbb{GF}(2^n)^*$ DLP at all practical parameter sizes.
+Both attacks break $\mathbb{GF}(2^n)^{\ast}$ DLP at all practical parameter sizes.
 
 **HKEX-GF.** Given $(C, C_2) = (g^a, g^b)$, Shor's algorithm recovers $a$ (or $b$) in
 $O(n^2 \log n)$ quantum time; the shared secret $g^{ab} = C_2^a$ follows immediately.
@@ -1394,17 +1394,17 @@ without solving a linear system at all (direct XOR), HHL is irrelevant.
 
 | Protocol | Security assumption | Classical attack | Quantum attack | Post-quantum security |
 |----------|---------------------|------------------|----------------|-----------------------|
-| **HKEX-GF** | DLP in $\mathbb{GF}(2^n)^*$ | Quasi-polynomial (Barbulescu 2013) | Shor's DLP | **None** |
+| **HKEX-GF** | DLP in $\mathbb{GF}(2^n)^{\ast}$ | Quasi-polynomial (Barbulescu 2013) | Shor's DLP | **None** |
 | **HSKE** (key-only) | Exhaustive search | Brute force $2^n$ | Grover $2^{n/2}$ | $n/2$ bits |
 | **HSKE** (known-plaintext) | — | 1 KPT pair → full $c_K$, $O(n^2)$ | BV: 1 query | **None** |
-| **HPKS** | DLP in $\mathbb{GF}(2^n)^*$ + non-ROM challenge | Quasi-polynomial DLP | Shor's DLP | **None** |
-| **HPKE** | CDH in $\mathbb{GF}(2^n)^*$ | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
+| **HPKS** | DLP in $\mathbb{GF}(2^n)^{\ast}$ + non-ROM challenge | Quasi-polynomial DLP | Shor's DLP | **None** |
+| **HPKE** | CDH in $\mathbb{GF}(2^n)^{\ast}$ | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
 | **HSKE-NL-A1** (§11.3.1, key-only) | NL-FSCX v1 PRF | Brute force $2^n$ (linear recovery blocked) | Grover $2^{n/2}$ | $n/2$ bits |
 | **HSKE-NL-A1** (known-plaintext) | — | Linear recovery blocked; 1-pair attack still recovers keystream | BV inapplicable (non-affine) | **None** (keystream recoverable) |
 | **HSKE-NL-A2** (§11.3.2, key-only) | NL-FSCX v2 bijection | Brute force $2^n$ (linear recovery blocked) | Grover $2^{n/2}$ | $n/2$ bits |
 | **HSKE-NL-A2** (known-plaintext) | — | Linear recovery blocked; 1-pair attack still recovers keystream | BV inapplicable (non-affine) | **None** (keystream recoverable) |
-| **HPKS-NL** (§11.2.1) | DLP in $\mathbb{GF}(2^n)^*$ + NL challenge | Quasi-polynomial DLP; challenge non-predictable | Shor's DLP | **None** |
-| **HPKE-NL** (§11.2.2) | CDH in $\mathbb{GF}(2^n)^*$ + NL-FSCX v2 | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
+| **HPKS-NL** (§11.2.1) | DLP in $\mathbb{GF}(2^n)^{\ast}$ + NL challenge | Quasi-polynomial DLP; challenge non-predictable | Shor's DLP | **None** |
+| **HPKE-NL** (§11.2.2) | CDH in $\mathbb{GF}(2^n)^{\ast}$ + NL-FSCX v2 | CDH $\leq$ DLP, quasi-polynomial | Shor's CDH | **None** |
 | **HKEX-RNL** (§11.4) | Ring-LWR with blinded $m$ | No known sub-exponential attack | No known polynomial-time quantum attack | Conjectured — pending proof |
 
 **HSKE key-only** provides $n/2$ bits of post-quantum security only when no plaintext
@@ -1417,18 +1417,18 @@ the 1-pair attack because the underlying structure remains affine.
 
 ### 12.6 Root Cause: Why GF(2^n)* Is the Wrong Group
 
-The choice of $\mathbb{GF}(2^n)^*$ as the DLP group introduces weaknesses absent in
+The choice of $\mathbb{GF}(2^n)^{\ast}$ as the DLP group introduces weaknesses absent in
 standard DLP groups:
 
 1. **Characteristic-2 quasi-polynomial attack** (Barbulescu et al., 2013): exploits
    sparse relations in the function field $\mathbb{GF}(2^n)(t)$, achieving
    $(\log N)^{O(\log\log N)}$ classical complexity.  This does not apply to prime-order
-   elliptic curves or $\mathbb{Z}_p^*$.
+   elliptic curves or $\mathbb{Z}_p^{\ast}$.
 
 2. **Shor's algorithm at $O(n^2 \log n)$**: applies to any cyclic group DLP; the
    characteristic-2 structure provides no resistance.
 
-3. **Generator order**: when $g = 3$ is not a primitive element of $\mathbb{GF}(2^n)^*$
+3. **Generator order**: when $g = 3$ is not a primitive element of $\mathbb{GF}(2^n)^{\ast}$
    (its actual order divides $2^n - 1$), the effective group size is smaller than assumed,
    reducing security further.
 
@@ -1436,8 +1436,8 @@ standard DLP groups:
 
 | Group | Classical DLP | Quantum DLP |
 |-------|--------------|-------------|
-| $\mathbb{GF}(2^n)^*$ | Quasi-polynomial (weak) | Shor's polynomial |
-| $\mathbb{Z}_p^*$, $p$ prime | Sub-exponential (NFS) | Shor's polynomial |
+| $\mathbb{GF}(2^n)^{\ast}$ | Quasi-polynomial (weak) | Shor's polynomial |
+| $\mathbb{Z}_p^{\ast}$, $p$ prime | Sub-exponential (NFS) | Shor's polynomial |
 | Elliptic curve over $\mathbb{GF}(p)$ | Exponential (ECDLP) | Shor's polynomial |
 | Ring-LWR ($\mathcal{R}_q$, blinded $m$, §11.4) | Exponential (conjectured) | No known polynomial attack |
 


### PR DESCRIPTION
## Summary

Two new classes of cross-span emphasis collision fixed in `SecurityProofs.md`:

- **`^*` in inline math** — `*` between `^` and `$`/`,`/`}` (all CommonMark punctuation) is both-flanking and can open AND close `*`-emphasis. Multiple `$\mathbb{GF}(2^n)^*$` spans in the same paragraph (lines 726, 1202–1206) and dense `$R^*$`/`$s^*$`/`$e^*$` spans in the forgery section (§12.2.2, lines 1249–1254) caused openers to pair with closers across span boundaries, garbling the surrounding text. Fix: `^*` → `^{\ast}` throughout all inline math (`\ast` renders as ∗ identically but has no literal `*` in markdown).
- **Lines 1068–1069** (`$$K_A$$`/`$$K_B$$` display math) — `\mathcal{R}_q` (where `}` precedes `_q`) across consecutive display-math blocks creates a cross-block emphasis pair. Fixed with `\mathcal R_q`.

## Test plan

- [ ] §9.2 CDH paragraph (line 726): `$\mathbb{GF}(2^n)^{\ast}$` renders as math, no garbled text
- [ ] §12.1 quasi-polynomial paragraph (lines 1202–1206): full paragraph renders correctly
- [ ] §12.2.2 forgery section (lines 1249–1254): `$R^{\ast}$`, `$s^{\ast}$`, `$e^{\ast}$` render as math
- [ ] §11.4.2 key-agreement display math (lines 1068–1069): `K_A` and `K_B` formulas render with correct subscripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)