### PR TITLE
v1.5.7: precomputed M⁻¹ rotation table for nl_fscx_v2_inv

### DIFF
--- a/CryptosuiteTests/Herradura_tests.asm
+++ b/CryptosuiteTests/Herradura_tests.asm
@@ -1,4 +1,4 @@
-;  Herradura KEx -- Correctness Tests v1.5.4
+;  Herradura KEx -- Correctness Tests v1.5.7
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS Schnorr, HPKE El Gamal,
 ;                        NL-FSCX v2 inv, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS=32; I_VALUE=8; R_VALUE=24; HKEX-RNL N=32, q=65537, p=4096
@@ -53,7 +53,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura KEx v1.5.4 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr         db "=== Herradura KEx v1.5.7 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
     hdr_l       equ $-hdr
 
     t1_hdr      db "[1] HKEX-GF key exchange correctness: sk_alice == sk_bob (20 iterations)", 10
@@ -954,16 +954,73 @@ nl_fscx_v2:
     ret
 
 ; ============================================================
-; m_inv_32: EAX=X --> EAX=M^{-1}(X) = fscx_revolve(X, 0, 15)
+; m_inv_32: EAX=X --> EAX=M^{-1}(X) via precomputed rotation table
+; M^{-1}(X) = XOR of ROL(X,k) for k in {0,2,3,5,6,8,9,...,29,30}
 ; ============================================================
 m_inv_32:
-    push ebx
-    push ecx
-    mov  ebx, 0
-    mov  ecx, 15
-    call FSCX_revolve
-    pop  ecx
-    pop  ebx
+    push    ebx
+    mov     ebx, eax
+    mov     ecx, ebx
+    rol     ecx, 2
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 3
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 5
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 6
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 8
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 9
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 11
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 12
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 14
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 15
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 17
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 18
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 20
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 21
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 23
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 24
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 26
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 27
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 29
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 30
+    xor     eax, ecx
+    pop     ebx
     ret
 
 ; ============================================================

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+    v1.5.7: m_inv_32/64/128 use precomputed rotation tables (0x6DB6DB6D / constants).
     v1.5.6: rnl_rand_coeff bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: added PQC benchmarks [22]–[25] matching Python/Go; aligned test output labels
             ([CLASSICAL]/[PQC-EXT]) and section headers; fixed version banner.
@@ -356,11 +357,24 @@ static uint32_t nl_fscx_v2_32(uint32_t a, uint32_t b)
     return fscx32(a, b) + nl_fscx_delta_v2_32(b);
 }
 
-/* M^{-1}(x) = fscx_revolve(x, 0, 15)  (32/2 - 1 = 15 steps) */
+/* M^{-1}(x) = XOR of ROL(x,k) for k in bits of 0x6DB6DB6D
+   Table = {0,2,3,5,6,8,9,11,12,14,15,17,18,20,21,23,24,26,27,29,30} (n=32) */
+#define ROL32(v,k) (((v)<<(k))|((v)>>(32-(k))))
 static uint32_t m_inv_32(uint32_t x)
 {
-    return fscx_revolve32(x, 0, 15);
+    return x
+        ^ ROL32(x, 2)  ^ ROL32(x, 3)
+        ^ ROL32(x, 5)  ^ ROL32(x, 6)
+        ^ ROL32(x, 8)  ^ ROL32(x, 9)
+        ^ ROL32(x, 11) ^ ROL32(x, 12)
+        ^ ROL32(x, 14) ^ ROL32(x, 15)
+        ^ ROL32(x, 17) ^ ROL32(x, 18)
+        ^ ROL32(x, 20) ^ ROL32(x, 21)
+        ^ ROL32(x, 23) ^ ROL32(x, 24)
+        ^ ROL32(x, 26) ^ ROL32(x, 27)
+        ^ ROL32(x, 29) ^ ROL32(x, 30);
 }
+#undef ROL32
 
 /* NL-FSCX v2 inverse: b ^ M^{-1}(y - delta(b)) */
 static uint32_t nl_fscx_v2_inv_32(uint32_t y, uint32_t b)
@@ -466,8 +480,16 @@ static uint64_t nl_fscx_v2_64(uint64_t a, uint64_t b)
     return fscx64(a, b) + nl_fscx_delta_v2_64(b);
 }
 
-/* M^{-1}(x) = fscx_revolve(x, 0, 31)  (64/2 - 1 = 31 steps) */
-static uint64_t m_inv_64(uint64_t x) { return fscx_revolve64(x, 0, 31); }
+/* M^{-1}(x) = XOR of ROL(x,k) for k in bits of 0xB6DB6DB6DB6DB6DB (n=64) */
+static uint64_t m_inv_64(uint64_t x)
+{
+    static const uint64_t tbl = UINT64_C(0xB6DB6DB6DB6DB6DB);
+    uint64_t r = x; /* k=0 term */
+    int k;
+    for (k = 1; k < 64; k++)
+        if ((tbl >> k) & 1) r ^= (x << k) | (x >> (64 - k));
+    return r;
+}
 
 static uint64_t nl_fscx_v2_inv_64(uint64_t y, uint64_t b)
 {
@@ -538,8 +560,19 @@ static __uint128_t nl_fscx_v2_128(__uint128_t a, __uint128_t b)
     return fscx128(a, b) + nl_fscx_delta_v2_128(b);
 }
 
-/* M^{-1}(x) = fscx_revolve(x, 0, 63)  (128/2 - 1 = 63 steps) */
-static __uint128_t m_inv_128(__uint128_t x) { return fscx_revolve128(x, 0, 63); }
+/* M^{-1}(x) = XOR of ROL(x,k) for k in bits of
+   (0x6DB6DB6DB6DB6DB6 << 64) | 0xDB6DB6DB6DB6DB6D  (n=128) */
+static __uint128_t m_inv_128(__uint128_t x)
+{
+    static const __uint128_t tbl =
+        ((__uint128_t)UINT64_C(0x6DB6DB6DB6DB6DB6) << 64)
+        | UINT64_C(0xDB6DB6DB6DB6DB6D);
+    __uint128_t r = x; /* k=0 term */
+    int k;
+    for (k = 1; k < 128; k++)
+        if ((tbl >> k) & 1) r ^= (x << k) | (x >> (128 - k));
+    return r;
+}
 
 static __uint128_t nl_fscx_v2_inv_128(__uint128_t y, __uint128_t b)
 {
@@ -1972,7 +2005,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.6 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.5.7 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.7: MInv uses precomputed rotation table (sync.Map cache per bit-size).
     v1.5.6: rnlRandPoly bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: aligned version banner with C and Python.
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(n log n)).
@@ -41,6 +42,7 @@ import (
 	"math/big"
 	"math/bits"
 	"os"
+	"sync"
 	"strconv"
 	"time"
 )
@@ -231,9 +233,35 @@ func GfPow(base, exp *big.Int, poly *big.Int, n int) *big.Int {
 // NL-FSCX primitives (v1.5.0)
 // ---------------------------------------------------------------------------
 
+var mInvCache sync.Map // map[int][]int
+
+func computeMInvRotations(n int) []int {
+	unit := &BitArray{size: n}
+	unit.val.SetInt64(1)
+	zero := &BitArray{size: n}
+	v := FscxRevolve(unit, zero, n/2-1)
+	var rotations []int
+	for k := 0; k < n; k++ {
+		if v.val.Bit(k) == 1 {
+			rotations = append(rotations, k)
+		}
+	}
+	return rotations
+}
+
 func MInv(x *BitArray) *BitArray {
-	zero := &BitArray{size: x.size}
-	return FscxRevolve(x, zero, x.size/2-1)
+	n := x.size
+	val, ok := mInvCache.Load(n)
+	if !ok {
+		rotations := computeMInvRotations(n)
+		val, _ = mInvCache.LoadOrStore(n, rotations)
+	}
+	rotations := val.([]int)
+	result := &BitArray{size: n}
+	for _, k := range rotations {
+		result = result.Xor(x.RotateLeft(k))
+	}
+	return result
 }
 
 func NlFscxV1(a, b *BitArray) *BitArray {
@@ -1218,7 +1246,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.6 \u2014 Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.7 \u2014 Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -1,4 +1,4 @@
-/*  Herradura KEx — Security Tests v1.5.4 (Arduino, 32-bit)
+/*  Herradura KEx — Security Tests v1.5.7 (Arduino, 32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, NL-FSCX, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -7,6 +7,7 @@
     Target: Any Arduino board with Serial support.
     Upload via Arduino IDE. Monitor at 9600 baud.
 
+    v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(N log N)).
     v1.5.3: HKEX-RNL secret sampler upgraded to CBD(eta=1); zero-mean distribution.
     v1.5.0: added PQC extension tests [5]-[10].
@@ -91,8 +92,20 @@ uint32 gf_pow_32(uint32 base, uint32 exp) {
 /* NL-FSCX primitives (v1.5.0)                                        */
 /* ------------------------------------------------------------------ */
 
+/* M^{-1}(X) = XOR of ROL(X,k) for k in bits of 0x6DB6DB6D (n=32) */
+static uint32 _rol32(uint32 v, int k) { return (v << k) | (v >> (32 - k)); }
 uint32 m_inv_32(uint32 x) {
-    return fscx_revolve(x, 0, KEYBITS / 2 - 1);
+    return x
+        ^ _rol32(x, 2)  ^ _rol32(x, 3)
+        ^ _rol32(x, 5)  ^ _rol32(x, 6)
+        ^ _rol32(x, 8)  ^ _rol32(x, 9)
+        ^ _rol32(x, 11) ^ _rol32(x, 12)
+        ^ _rol32(x, 14) ^ _rol32(x, 15)
+        ^ _rol32(x, 17) ^ _rol32(x, 18)
+        ^ _rol32(x, 20) ^ _rol32(x, 21)
+        ^ _rol32(x, 23) ^ _rol32(x, 24)
+        ^ _rol32(x, 26) ^ _rol32(x, 27)
+        ^ _rol32(x, 29) ^ _rol32(x, 30);
 }
 
 uint32 nl_fscx_delta_v2(uint32 B) {

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.7: _m_inv uses precomputed rotation table (lazy init, cached per bit-size).
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: fixed version banner (was stuck at v1.5.3).
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(n log n), ~6× speedup at n=32).
@@ -165,11 +166,20 @@ def gf_pow(base: int, exp: int, poly: int, n: int) -> int:
 # NL-FSCX primitives (v1.5.0 — non-linear; for PQC-hardened protocols)
 # ---------------------------------------------------------------------------
 
+_m_inv_rotations: dict[int, tuple[int, ...]] = {}
+
 def _m_inv(X: BitArray) -> BitArray:
-    """M^{-1}(X) = M^{n/2-1}(X).  M^{n/2} = I so M^{-1} = M^{n/2-1}."""
-    n    = X._size
-    zero = BitArray(n, 0)
-    return fscx_revolve(X, zero, n // 2 - 1)
+    """M^{-1}(X) via precomputed rotation table, cached per bit-size."""
+    n = X._size
+    if n not in _m_inv_rotations:
+        unit = BitArray(n, 1)
+        zero = BitArray(n, 0)
+        v = fscx_revolve(unit, zero, n // 2 - 1)
+        _m_inv_rotations[n] = tuple(k for k in range(n) if (v.uint >> k) & 1)
+    result = BitArray(n, 0)
+    for k in _m_inv_rotations[n]:
+        result = result ^ X.rotated(k)
+    return result
 
 
 def nl_fscx_v1(A: BitArray, B: BitArray) -> BitArray:
@@ -873,7 +883,7 @@ def bench_hkex_rnl_handshake():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.6 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.5.7 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -901,7 +911,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.6 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.7 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/CryptosuiteTests/Herradura_tests.s
+++ b/CryptosuiteTests/Herradura_tests.s
@@ -1,4 +1,4 @@
-/*  Herradura KEx -- Correctness Tests v1.5.4
+/*  Herradura KEx -- Correctness Tests v1.5.7
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        NL-FSCX v2 inv, HSKE-NL-A2,
                                        HKEX-RNL, HPKS-NL, HPKE-NL
@@ -31,7 +31,7 @@
     .data
     .balign 4
 
-fmt_hdr:  .asciz "=== Herradura KEx v1.5.3 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
+fmt_hdr:  .asciz "=== Herradura KEx v1.5.7 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
 fmt_t1:   .asciz "[1] HKEX-GF key exchange: sk_alice == sk_bob (20 iterations)\n"
 fmt_t2:   .asciz "[2] HSKE encrypt+decrypt round-trip: D == plaintext (100 iterations)\n"
 fmt_t3:   .asciz "[3] HPKS Schnorr: g^s * C^e == R (20 iterations)\n"
@@ -958,15 +958,54 @@ nl_fscx_v2:
     .ltorg
 
 /* ------------------------------------------------------------------ */
-/* m_inv_32: r0=X -> r0=fscx_revolve(X,0,15)                          */
+/* m_inv_32: r0=X -> r0=M^{-1}(X) via precomputed rotation table     */
+/* M^{-1}(X) = XOR of ROL(X,k) for k in {0,2,3,5,6,8,9,...,29,30}   */
 /* ------------------------------------------------------------------ */
     .thumb_func
 m_inv_32:
-    push    {lr}
-    mov     r1, #0
-    mov     r2, #15
-    bl      fscx_revolve
-    pop     {pc}
+    @ r0=X; result in r0; r1=saved X, r2=scratch (all caller-saved)
+    mov     r1, r0
+    ror     r2, r1, #30
+    eor     r0, r0, r2
+    ror     r2, r1, #29
+    eor     r0, r0, r2
+    ror     r2, r1, #27
+    eor     r0, r0, r2
+    ror     r2, r1, #26
+    eor     r0, r0, r2
+    ror     r2, r1, #24
+    eor     r0, r0, r2
+    ror     r2, r1, #23
+    eor     r0, r0, r2
+    ror     r2, r1, #21
+    eor     r0, r0, r2
+    ror     r2, r1, #20
+    eor     r0, r0, r2
+    ror     r2, r1, #18
+    eor     r0, r0, r2
+    ror     r2, r1, #17
+    eor     r0, r0, r2
+    ror     r2, r1, #15
+    eor     r0, r0, r2
+    ror     r2, r1, #14
+    eor     r0, r0, r2
+    ror     r2, r1, #12
+    eor     r0, r0, r2
+    ror     r2, r1, #11
+    eor     r0, r0, r2
+    ror     r2, r1, #9
+    eor     r0, r0, r2
+    ror     r2, r1, #8
+    eor     r0, r0, r2
+    ror     r2, r1, #6
+    eor     r0, r0, r2
+    ror     r2, r1, #5
+    eor     r0, r0, r2
+    ror     r2, r1, #3
+    eor     r0, r0, r2
+    ror     r2, r1, #2
+    eor     r0, r0, r2
+    bx      lr
     .ltorg
 
 /* ------------------------------------------------------------------ */

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.6
+;  Herradura Cryptographic Suite v1.5.7
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -94,7 +94,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.5.6 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.5.7 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "
@@ -1100,16 +1100,74 @@ nl_fscx_v2:
     ret
 
 ; ============================================================
-; m_inv_32: EAX=X --> EAX=M^{-1}(X) = fscx_revolve(X, 0, 15)
+; m_inv_32: EAX=X --> EAX=M^{-1}(X) via precomputed rotation table
+; M^{-1}(X) = XOR of ROL(X,k) for k in {0,2,3,5,6,8,9,...,29,30}
+; (bits of 0x6DB6DB6D = fscx_revolve(1,0,15) for n=32)
 ; ============================================================
 m_inv_32:
-    push ebx
-    push ecx
-    mov  ebx, 0
-    mov  ecx, 15
-    call FSCX_revolve
-    pop  ecx
-    pop  ebx
+    push    ebx
+    mov     ebx, eax            ; save original X; eax = ROL(X,0) = X
+    mov     ecx, ebx
+    rol     ecx, 2              ; ROL(X, 2)
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 3
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 5
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 6
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 8
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 9
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 11
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 12
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 14
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 15
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 17
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 18
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 20
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 21
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 23
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 24
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 26
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 27
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 29
+    xor     eax, ecx
+    mov     ecx, ebx
+    rol     ecx, 30
+    xor     eax, ecx
+    pop     ebx
     ret
 
 ; ============================================================

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.6
+/*  Herradura Cryptographic Suite v1.5.7
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,12 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.7: precomputed M^{-1} for nl_fscx_v2_inv_ba ---
+    m_inv_ba now computes the rotation table for M^{-1} = M^{127}(X) once on first call
+    (bootstrapping from ba_fscx_revolve(1, 0, 127)), caches the rotation offsets in a
+    static array, then applies M^{-1}(X) as XOR of ba_rol_k(X, k) for each k in the
+    table.  New ba_rol_k helper performs arbitrary-bit cyclic rotation on 256-bit arrays.
 
     --- v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling ---
     rnl_rand_poly now draws 3 bytes (24-bit) with rejection sampling (threshold =
@@ -304,6 +310,24 @@ static void ba_rol64_256(BitArray *dst, const BitArray *src)
     memcpy(dst->b + KEYBYTES - 8, tmp, 8);
 }
 
+/* Cyclic left-rotation by k bits on KEYBYTES big-endian array.
+   byte_shift = k/8 positions; bit_shift = k%8 bits within each byte. */
+static void ba_rol_k(BitArray *dst, const BitArray *src, int k)
+{
+    int byte_shift = (k / 8) % KEYBYTES;
+    int bit_shift  = k % 8;
+    int i;
+    if (bit_shift == 0) {
+        for (i = 0; i < KEYBYTES; i++)
+            dst->b[i] = src->b[(i + byte_shift) % KEYBYTES];
+    } else {
+        int rshift = 8 - bit_shift;
+        for (i = 0; i < KEYBYTES; i++)
+            dst->b[i] = (uint8_t)((src->b[(i + byte_shift) % KEYBYTES] << bit_shift)
+                                | (src->b[(i + byte_shift + 1) % KEYBYTES] >> rshift));
+    }
+}
+
 /* Low 256-bit schoolbook multiply: dst = a*b mod 2^256 */
 static void ba_mul256_lo(BitArray *dst, const BitArray *a, const BitArray *b)
 {
@@ -416,10 +440,35 @@ static const BitArray ONE_BA  = {{
     0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0x01
 }};
 
-/* M^{-1}(X) = M^{127}(X): apply fscx with B=0 for KEYBITS/2-1 = 127 steps */
+/* M^{-1}(X): apply precomputed rotation table, bootstrapped once on first call.
+   Table = bit positions of fscx_revolve(1, 0, KEYBITS/2-1); M^{-1}(X) = XOR of
+   ba_rol_k(X, k) for each k in the table (~2n/3 rotations vs n/2-1 FSCX steps). */
 static void m_inv_ba(BitArray *dst, const BitArray *src)
 {
-    ba_fscx_revolve(dst, src, &ZERO_BA, KEYBITS / 2 - 1);
+    static int initialized = 0;
+    static int rotations[KEYBITS];
+    static int nrot = 0;
+    int i;
+
+    if (!initialized) {
+        BitArray unit = {{0}}, tmp;
+        int k;
+        unit.b[KEYBYTES - 1] = 1;   /* unit = 1 (bit 0 set in big-endian) */
+        ba_fscx_revolve(&tmp, &unit, &ZERO_BA, KEYBITS / 2 - 1);
+        for (k = 0; k < KEYBITS; k++)
+            if (tmp.b[KEYBYTES - 1 - k / 8] & (1u << (k % 8)))
+                rotations[nrot++] = k;
+        initialized = 1;
+    }
+
+    {
+        BitArray acc = {{0}}, tmp;
+        for (i = 0; i < nrot; i++) {
+            ba_rol_k(&tmp, src, rotations[i]);
+            ba_xor(&acc, &acc, &tmp);
+        }
+        *dst = acc;
+    }
 }
 
 /* NL-FSCX v1: fscx(A,B) XOR ROL((A+B) mod 2^n, n/4) */

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.6
+/*  Herradura Cryptographic Suite v1.5.7
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,11 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.7: precomputed M^{-1} for NlFscxV2Inv ---
+    MInv now computes the rotation table for M^{-1} = M^{n/2-1} once on first call
+    (bootstrapping from FscxRevolve(1, 0, n/2-1)), caches it per bit-size via sync.Map,
+    then applies M^{-1}(X) as XOR of RotateLeft(X, k) for each k in the table.
 
     --- v1.5.6: rnlRandPoly bias fix — 3-byte rejection sampling ---
     rnlRandPoly now draws 3 bytes (24-bit) with rejection sampling (threshold =
@@ -73,6 +78,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"sync"
 )
 
 // ---------------------------------------------------------------------------
@@ -223,11 +229,39 @@ func GfPow(base, exp *big.Int, poly *big.Int, n int) *big.Int {
 // NL-FSCX primitives (v1.5.0 — non-linear; for PQC-hardened protocols)
 // ---------------------------------------------------------------------------
 
-// MInv computes M^{-1}(X) = M^{n/2-1}(X).
-// Since M^{n/2} = I, M^{-1} = M^{n/2-1}. Applies n/2-1 Fscx steps with B=0.
+// mInvCache holds per-bit-size precomputed rotation tables for MInv.
+var mInvCache sync.Map // map[int][]int
+
+// computeMInvRotations bootstraps the rotation table for M^{-1} at bit-size n.
+func computeMInvRotations(n int) []int {
+	unit := &BitArray{size: n}
+	unit.val.SetInt64(1)
+	zero := &BitArray{size: n}
+	v := FscxRevolve(unit, zero, n/2-1, false)
+	var rotations []int
+	for k := 0; k < n; k++ {
+		if v.val.Bit(k) == 1 {
+			rotations = append(rotations, k)
+		}
+	}
+	return rotations
+}
+
+// MInv applies M^{-1}(X) via a precomputed rotation table (cached per bit-size).
+// The table is bootstrapped once from FscxRevolve(1, 0, n/2-1).
 func MInv(x *BitArray) *BitArray {
-	zero := &BitArray{size: x.size}
-	return FscxRevolve(x, zero, x.size/2-1, false)
+	n := x.size
+	val, ok := mInvCache.Load(n)
+	if !ok {
+		rotations := computeMInvRotations(n)
+		val, _ = mInvCache.LoadOrStore(n, rotations)
+	}
+	rotations := val.([]int)
+	result := &BitArray{size: n}
+	for _, k := range rotations {
+		result = result.Xor(x.RotateLeft(k))
+	}
+	return result
 }
 
 // NlFscxV1 computes Fscx(A,B) XOR ROL((A+B) mod 2^n, n/4).

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.6 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.7 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32
 
@@ -9,6 +9,7 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
+    v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=0xFF00FF).
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(n log n)).
     v1.5.3: HKEX-RNL secret sampler upgraded to CBD(eta=1); zero-mean distribution.
@@ -112,9 +113,21 @@ static void printHexLine(const char *label, uint32 val) {
 /* NL-FSCX primitives (v1.5.0)                                        */
 /* ------------------------------------------------------------------ */
 
-/* M^{-1}(X) = fscx_revolve(X, 0, KEYBITS/2 - 1) */
+/* M^{-1}(X) = XOR of ROL(X,k) for k in bits of 0x6DB6DB6D.
+   Table = {0,2,3,5,6,8,9,11,12,14,15,17,18,20,21,23,24,26,27,29,30} (n=32). */
+static uint32 _rol32(uint32 v, int k) { return (v << k) | (v >> (32 - k)); }
 uint32 m_inv_32(uint32 x) {
-    return fscx_revolve(x, 0, KEYBITS / 2 - 1);
+    return x
+        ^ _rol32(x, 2)  ^ _rol32(x, 3)
+        ^ _rol32(x, 5)  ^ _rol32(x, 6)
+        ^ _rol32(x, 8)  ^ _rol32(x, 9)
+        ^ _rol32(x, 11) ^ _rol32(x, 12)
+        ^ _rol32(x, 14) ^ _rol32(x, 15)
+        ^ _rol32(x, 17) ^ _rol32(x, 18)
+        ^ _rol32(x, 20) ^ _rol32(x, 21)
+        ^ _rol32(x, 23) ^ _rol32(x, 24)
+        ^ _rol32(x, 26) ^ _rol32(x, 27)
+        ^ _rol32(x, 29) ^ _rol32(x, 30);
 }
 
 /* delta(B) = ROL32(B * floor((B+1)/2), 8) */

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.5.6
+    Herradura Cryptographic Suite v1.5.7
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,6 +17,13 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.7: precomputed M^{-1} for nl_fscx_v2_inv ---
+
+    _m_inv now computes the rotation table for M^{-1} = M^{n/2-1} once on first call
+    (bootstrapping from fscx_revolve(1, 0, n/2-1)), caches it per bit-size, then applies
+    M^{-1}(X) as XOR of ROL(X,k) for each k in the table.  Reduces each inverse step
+    from n/2-1 FSCX iterations to ~2n/3 XOR-rotation pairs.
 
     --- v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling ---
 
@@ -241,12 +248,23 @@ def gf_pow(base: int, exp: int, poly: int, n: int) -> int:
 # NL-FSCX primitives (v1.5.0 — non-linear; for PQC-hardened protocols)
 # ---------------------------------------------------------------------------
 
+# Rotation-table cache: maps bit-size n to tuple of rotation offsets k such that
+# M^{-1}(X) = XOR of ROL(X, k) for k in the tuple.  Populated lazily on first call.
+_m_inv_rotations: dict[int, tuple[int, ...]] = {}
+
 def _m_inv(X: BitArray) -> BitArray:
-    """M^{-1}(X): inverse of the FSCX linear map M = I+ROL+ROR over GF(2).
-    Since M^{n/2} = I, M^{-1} = M^{n/2-1}.  Applies n/2-1 fscx steps with B=0."""
-    n    = X._size
-    zero = BitArray(n, 0)
-    return fscx_revolve(X, zero, n // 2 - 1)
+    """M^{-1}(X): apply precomputed rotation table for M^{n/2-1}.
+    Table is bootstrapped once from fscx_revolve(1, 0, n/2-1) and cached per bit-size."""
+    n = X._size
+    if n not in _m_inv_rotations:
+        unit = BitArray(n, 1)
+        zero = BitArray(n, 0)
+        v = fscx_revolve(unit, zero, n // 2 - 1)
+        _m_inv_rotations[n] = tuple(k for k in range(n) if (v.uint >> k) & 1)
+    result = BitArray(n, 0)
+    for k in _m_inv_rotations[n]:
+        result = result ^ X.rotated(k)
+    return result
 
 
 def nl_fscx_v1(A: BitArray, B: BitArray) -> BitArray:

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.6
+/*  Herradura Cryptographic Suite v1.5.7
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -42,7 +42,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.6 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.7 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 
@@ -1129,15 +1129,55 @@ nl_fscx_v2:
     .ltorg
 
 /* ------------------------------------------------------------------ */
-/* m_inv_32: r0=X -> r0=fscx_revolve(X, 0, 15)                       */
+/* m_inv_32: r0=X -> r0=M^{-1}(X) via precomputed rotation table     */
+/* M^{-1}(X) = XOR of ROL(X,k) for k in {0,2,3,5,6,8,9,...,29,30}   */
+/* (bits of 0x6DB6DB6D = fscx_revolve(1,0,15) for n=32)              */
 /* ------------------------------------------------------------------ */
     .thumb_func
 m_inv_32:
-    push    {lr}
-    mov     r1, #0
-    mov     r2, #15
-    bl      fscx_revolve
-    pop     {pc}
+    @ r0=X; result in r0; r1=saved X, r2=scratch (all caller-saved)
+    mov     r1, r0              @ save original X
+    ror     r2, r1, #30         @ ROL(X, 2)
+    eor     r0, r0, r2
+    ror     r2, r1, #29         @ ROL(X, 3)
+    eor     r0, r0, r2
+    ror     r2, r1, #27         @ ROL(X, 5)
+    eor     r0, r0, r2
+    ror     r2, r1, #26         @ ROL(X, 6)
+    eor     r0, r0, r2
+    ror     r2, r1, #24         @ ROL(X, 8)
+    eor     r0, r0, r2
+    ror     r2, r1, #23         @ ROL(X, 9)
+    eor     r0, r0, r2
+    ror     r2, r1, #21         @ ROL(X,11)
+    eor     r0, r0, r2
+    ror     r2, r1, #20         @ ROL(X,12)
+    eor     r0, r0, r2
+    ror     r2, r1, #18         @ ROL(X,14)
+    eor     r0, r0, r2
+    ror     r2, r1, #17         @ ROL(X,15)
+    eor     r0, r0, r2
+    ror     r2, r1, #15         @ ROL(X,17)
+    eor     r0, r0, r2
+    ror     r2, r1, #14         @ ROL(X,18)
+    eor     r0, r0, r2
+    ror     r2, r1, #12         @ ROL(X,20)
+    eor     r0, r0, r2
+    ror     r2, r1, #11         @ ROL(X,21)
+    eor     r0, r0, r2
+    ror     r2, r1, #9          @ ROL(X,23)
+    eor     r0, r0, r2
+    ror     r2, r1, #8          @ ROL(X,24)
+    eor     r0, r0, r2
+    ror     r2, r1, #6          @ ROL(X,26)
+    eor     r0, r0, r2
+    ror     r2, r1, #5          @ ROL(X,27)
+    eor     r0, r0, r2
+    ror     r2, r1, #3          @ ROL(X,29)
+    eor     r0, r0, r2
+    ror     r2, r1, #2          @ ROL(X,30)
+    eor     r0, r0, r2
+    bx      lr
 
     .ltorg
 


### PR DESCRIPTION
## Summary

- Replaces the iterative `m_inv` / `MInv` / `m_inv_32` implementations (O(n/2) FSCX iterations per call) with a precomputed rotation-table approach across all 12 language targets (6 suite + 6 test files)
- M⁻¹(X) = XOR of ROL(X,k) for each k where bit k of M⁻¹(1) is set; table derived once via `fscx_revolve(1, 0, n/2−1)` then cached
- Fixed constants: n=32 → `0x6DB6DB6D` (21 rotations), n=64 → `0xB6DB6DB6DB6DB6DB` (43 rotations), n=128 → `0x6DB6DB6DB6DB6DB6‖0xDB6DB6DB6DB6DB6D` (85 rotations); n=256 uses lazy-init bootstrap
- Replaces up to 127 FSCX iterations (n=256) with ~170 XOR-rotation pairs (~2n/3 density) per invocation

## Test plan

- [x] C: `gcc -O2 -o CryptosuiteTests/Herradura_tests CryptosuiteTests/Herradura_tests.c && ./CryptosuiteTests/Herradura_tests` — tests [11] bijectivity, [13] HSKE-NL-A2 round-trip, [16] HPKE-NL all PASS
- [ ] Go: `cd CryptosuiteTests && go run Herradura_tests.go` — same tests PASS
- [x] Python: `python3 CryptosuiteTests/Herradura_tests.py` — same tests PASS
- [ ] ARM Thumb-2: build + `qemu-arm` run — m_inv_32 unrolled ROR/EOR sequence
- [ ] NASM i386: build + `qemu-i386` run — m_inv_32 unrolled ROL/XOR sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)