### PR TITLE
v1.5.8: build and run scripts for all language targets

### DIFF
--- a/build_arduino.sh
+++ b/build_arduino.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — Arduino (AVR) build script
+# Compiles the suite and test .ino files to ATmega2560 ELF binaries
+# by linking against the Arduino core library.
+#
+# Target board: Arduino Mega 2560 (ATmega2560, 8 KB SRAM)
+# Note: ATmega328P (Uno, 2 KB SRAM) is insufficient — the Ring-LWR
+#       polynomial arrays require ~2.5 KB BSS, exceeding its memory.
+#
+# Dependencies (build):
+#   avr-gcc + avr-libc + Arduino core headers
+#     sudo apt-get install -y gcc-avr avr-libc arduino-core
+#
+# Dependencies (run — see run_arduino.sh):
+#   simavr
+#     sudo apt-get install -y simavr
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="1.5.8"
+
+SUITE_INO="Herradura cryptographic suite.ino"
+SUITE_ELF="Herradura cryptographic suite_avr.elf"
+TESTS_INO="CryptosuiteTests/Herradura_tests.ino"
+TESTS_ELF="CryptosuiteTests/Herradura_tests_avr.elf"
+
+MCU="atmega2560"
+F_CPU="16000000UL"
+ARDUINO_CORE="/usr/share/arduino/hardware/arduino/avr/cores/arduino"
+ARDUINO_VARIANT="/usr/share/arduino/hardware/arduino/avr/variants/mega"
+BUILD_DIR="/tmp/herr_avr_build"
+
+AVR_FLAGS="-O2 -mmcu=${MCU} -DF_CPU=${F_CPU} -I${ARDUINO_CORE} -I${ARDUINO_VARIANT}"
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+if ! command -v avr-gcc &>/dev/null; then
+    echo "ERROR: avr-gcc not found."
+    echo "  Install: sudo apt-get install -y gcc-avr"
+    exit 1
+fi
+
+if ! command -v avr-g++ &>/dev/null; then
+    echo "ERROR: avr-g++ not found."
+    echo "  Install: sudo apt-get install -y gcc-avr"
+    exit 1
+fi
+
+if [ ! -f "${ARDUINO_CORE}/Arduino.h" ]; then
+    echo "ERROR: Arduino core headers not found at ${ARDUINO_CORE}"
+    echo "  Install: sudo apt-get install -y arduino-core"
+    exit 1
+fi
+
+if [ ! -f "${ARDUINO_VARIANT}/pins_arduino.h" ]; then
+    echo "ERROR: ATmega2560 variant headers not found at ${ARDUINO_VARIANT}"
+    echo "  Install: sudo apt-get install -y arduino-core"
+    exit 1
+fi
+
+# ── build Arduino core library ────────────────────────────────────────────────
+echo "=== HerraduraKEx v${VERSION} — Arduino (ATmega2560) build ==="
+
+mkdir -p "${BUILD_DIR}/core"
+
+echo "  Compiling Arduino core (.c)..."
+for SRC in "${ARDUINO_CORE}"/*.c; do
+    BASE="$(basename "${SRC}" .c)"
+    avr-gcc ${AVR_FLAGS} -c -o "${BUILD_DIR}/core/${BASE}.o" "${SRC}"
+done
+
+echo "  Compiling Arduino core (.cpp)..."
+for SRC in "${ARDUINO_CORE}"/*.cpp; do
+    BASE="$(basename "${SRC}" .cpp)"
+    avr-g++ ${AVR_FLAGS} -c -o "${BUILD_DIR}/core/${BASE}.o" "${SRC}"
+done
+
+echo "  Assembling Arduino core (.S)..."
+for SRC in "${ARDUINO_CORE}"/*.S; do
+    BASE="$(basename "${SRC}" .S)"
+    avr-gcc ${AVR_FLAGS} -x assembler-with-cpp \
+        -c -o "${BUILD_DIR}/core/${BASE}.o" "${SRC}"
+done
+
+CORE_OBJS=( "${BUILD_DIR}"/core/*.o )
+
+# ── helper: build one .ino target ────────────────────────────────────────────
+build_ino() {
+    local INO="$1"
+    local ELF="$2"
+    local LABEL="$3"
+    local OBJ="${BUILD_DIR}/$(basename "${INO}" .ino).o"
+    local WRAPPER="${BUILD_DIR}/$(basename "${INO}" .ino)_wrap.cpp"
+
+    echo "  Compiling ${LABEL}..."
+
+    # Arduino IDE prepends #include <Arduino.h> before compiling .ino files
+    printf '#include <Arduino.h>\n' > "${WRAPPER}"
+    cat "${INO}" >> "${WRAPPER}"
+
+    avr-g++ ${AVR_FLAGS} -c -o "${OBJ}" "${WRAPPER}"
+
+    echo "  Linking ${LABEL}..."
+    avr-gcc -mmcu="${MCU}" -o "${ELF}" "${OBJ}" "${CORE_OBJS[@]}"
+
+    echo "    -> ${ELF}"
+    avr-size "${ELF}" 2>/dev/null || true
+}
+
+# ── build suite and tests ─────────────────────────────────────────────────────
+build_ino "${SUITE_INO}" "${SUITE_ELF}" "suite"
+echo ""
+build_ino "${TESTS_INO}" "${TESTS_ELF}" "tests"
+
+echo ""
+echo "Build complete. Run with: ./run_arduino.sh"
+echo "  (requires simavr — sudo apt-get install -y simavr)"

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — ARM Thumb-2 build script
+# Cross-compiles the suite and tests from ARM Thumb-2 assembly using
+# arm-linux-gnueabi-gcc.  Produces ELF binaries runnable under qemu-arm.
+#
+# Dependencies (build):
+#   arm-linux-gnueabi-gcc + ARM sysroot
+#     sudo apt-get install -y gcc-arm-linux-gnueabi libc6-armel-cross
+#
+# Dependencies (run — see run_arm.sh):
+#   qemu-arm
+#     sudo apt-get install -y qemu-user
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="1.5.8"
+SUITE_SRC="Herradura cryptographic suite.s"
+SUITE_BIN="Herradura cryptographic suite_arm"
+TESTS_SRC="CryptosuiteTests/Herradura_tests.s"
+TESTS_BIN="CryptosuiteTests/Herradura_tests_arm"
+
+ARM_CC="arm-linux-gnueabi-gcc"
+ARM_SYSROOT_LIB="/usr/arm-linux-gnueabi/lib"
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+if ! command -v "${ARM_CC}" &>/dev/null; then
+    echo "ERROR: ${ARM_CC} not found."
+    echo "  Install: sudo apt-get install -y gcc-arm-linux-gnueabi"
+    exit 1
+fi
+
+if [ ! -f "${ARM_SYSROOT_LIB}/crt1.o" ]; then
+    echo "ERROR: ARM sysroot not found at ${ARM_SYSROOT_LIB}/crt1.o"
+    echo "  Install: sudo apt-get install -y libc6-armel-cross"
+    exit 1
+fi
+
+echo "=== HerraduraKEx v${VERSION} — ARM Thumb-2 build ==="
+
+echo "  Compiling suite..."
+"${ARM_CC}" -O2 \
+    -L"${ARM_SYSROOT_LIB}" \
+    -B"${ARM_SYSROOT_LIB}" \
+    -o "${SUITE_BIN}" "${SUITE_SRC}"
+echo "    -> ${SUITE_BIN}"
+
+echo "  Compiling tests..."
+"${ARM_CC}" -O2 \
+    -L"${ARM_SYSROOT_LIB}" \
+    -B"${ARM_SYSROOT_LIB}" \
+    -o "${TESTS_BIN}" "${TESTS_SRC}"
+echo "    -> ${TESTS_BIN}"
+
+echo ""
+echo "Build complete. Run with: ./run_arm.sh"
+echo "  (requires qemu-arm — sudo apt-get install -y qemu-user)"

--- a/build_asm_i386.sh
+++ b/build_asm_i386.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — NASM i386 build script
+# Assembles the suite and tests from NASM i386 source using nasm + ld.
+# Produces static ELF32 binaries runnable under qemu-i386.
+#
+# Dependencies (build):
+#   nasm     — sudo apt-get install -y nasm
+#   ld       — sudo apt-get install -y binutils
+#
+# Dependencies (run — see run_asm_i386.sh):
+#   qemu-i386
+#     sudo apt-get install -y qemu-user
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="1.5.8"
+SUITE_SRC="Herradura cryptographic suite.asm"
+SUITE_OBJ="/tmp/herr_suite32.o"
+SUITE_BIN="Herradura cryptographic suite_i386"
+TESTS_SRC="CryptosuiteTests/Herradura_tests.asm"
+TESTS_OBJ="/tmp/herr_tests32.o"
+TESTS_BIN="CryptosuiteTests/Herradura_tests_i386"
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+if ! command -v nasm &>/dev/null; then
+    echo "ERROR: nasm not found."
+    echo "  Install: sudo apt-get install -y nasm"
+    exit 1
+fi
+
+if ! command -v x86_64-linux-gnu-ld &>/dev/null && ! command -v ld &>/dev/null; then
+    echo "ERROR: linker (ld / x86_64-linux-gnu-ld) not found."
+    echo "  Install: sudo apt-get install -y binutils"
+    exit 1
+fi
+
+# Prefer the explicit cross linker; fall back to system ld if capable
+if command -v x86_64-linux-gnu-ld &>/dev/null; then
+    LD="x86_64-linux-gnu-ld"
+else
+    LD="ld"
+fi
+
+echo "=== HerraduraKEx v${VERSION} — NASM i386 build ==="
+
+echo "  Assembling suite..."
+nasm -f elf32 "${SUITE_SRC}" -o "${SUITE_OBJ}"
+${LD} -m elf_i386 -o "${SUITE_BIN}" "${SUITE_OBJ}"
+rm -f "${SUITE_OBJ}"
+echo "    -> ${SUITE_BIN}"
+
+echo "  Assembling tests..."
+nasm -f elf32 "${TESTS_SRC}" -o "${TESTS_OBJ}"
+${LD} -m elf_i386 -o "${TESTS_BIN}" "${TESTS_OBJ}"
+rm -f "${TESTS_OBJ}"
+echo "    -> ${TESTS_BIN}"
+
+echo ""
+echo "Build complete. Run with: ./run_asm_i386.sh"
+echo "  (requires qemu-i386 — sudo apt-get install -y qemu-user)"

--- a/build_c.sh
+++ b/build_c.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — C build script
+# Compiles the cryptographic suite and test suite using gcc.
+#
+# Dependencies:
+#   gcc   — sudo apt-get install -y gcc
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="1.5.8"
+SUITE_SRC="Herradura cryptographic suite.c"
+SUITE_BIN="Herradura cryptographic suite"
+TESTS_SRC="CryptosuiteTests/Herradura_tests.c"
+TESTS_BIN="CryptosuiteTests/Herradura_tests"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+if ! command -v gcc &>/dev/null; then
+    echo "ERROR: gcc not found."
+    echo "  Install: sudo apt-get install -y gcc"
+    exit 1
+fi
+
+echo "=== HerraduraKEx v${VERSION} — C build ==="
+
+echo "  Compiling suite..."
+gcc -O2 -o "${SUITE_BIN}" "${SUITE_SRC}"
+echo "    -> ${SUITE_BIN}"
+
+echo "  Compiling tests..."
+gcc -O2 -o "${TESTS_BIN}" "${TESTS_SRC}"
+echo "    -> ${TESTS_BIN}"
+
+echo ""
+echo "Build complete. Run:"
+echo "  ./${SUITE_BIN}"
+echo "  ./${TESTS_BIN} [-r ROUNDS] [-t SECONDS]"

--- a/build_go.sh
+++ b/build_go.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — Go build script
+# Compiles the cryptographic suite and test suite using go build.
+#
+# Dependencies:
+#   go   — sudo apt-get install -y golang-go
+#           (or install from https://go.dev/dl/ for a newer version)
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="1.5.8"
+SUITE_SRC="Herradura cryptographic suite.go"
+SUITE_BIN="Herradura cryptographic suite_go"
+TESTS_DIR="CryptosuiteTests"
+TESTS_BIN="Herradura_tests_go"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+if ! command -v go &>/dev/null; then
+    echo "ERROR: go not found."
+    echo "  Install: sudo apt-get install -y golang-go"
+    echo "  Or download: https://go.dev/dl/"
+    exit 1
+fi
+
+echo "=== HerraduraKEx v${VERSION} — Go build ==="
+
+echo "  Compiling suite..."
+go build -o "${SUITE_BIN}" "${SUITE_SRC}"
+echo "    -> ${SUITE_BIN}"
+
+echo "  Compiling tests..."
+(cd "${TESTS_DIR}" && go build -o "${TESTS_BIN}" Herradura_tests.go)
+echo "    -> ${TESTS_DIR}/${TESTS_BIN}"
+
+echo ""
+echo "Build complete. Run:"
+echo "  ./${SUITE_BIN}"
+echo "  ./${TESTS_DIR}/${TESTS_BIN} [-r ROUNDS] [-t SECONDS]"

--- a/run_arduino.sh
+++ b/run_arduino.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — Arduino (AVR) run script
+# Runs the ATmega2560 ELF binaries under simavr (AVR cycle-accurate emulator).
+# Output appears on the emulated UART0 (simavr maps it to stdout).
+#
+# Dependencies:
+#   simavr   — sudo apt-get install -y simavr
+#
+# Build first with: ./build_arduino.sh
+#
+# Usage:
+#   ./run_arduino.sh                   # run suite then tests
+#   ./run_arduino.sh suite             # run suite only
+#   ./run_arduino.sh tests             # run tests only
+#
+# Note: simavr exits automatically when the firmware calls exit() or loops
+#       forever after the last Serial.print.  If it hangs, Ctrl-C to stop.
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+SUITE_ELF="Herradura cryptographic suite_avr.elf"
+TESTS_ELF="CryptosuiteTests/Herradura_tests_avr.elf"
+MCU="atmega2560"
+FREQ="16000000"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+if ! command -v simavr &>/dev/null; then
+    echo "ERROR: simavr not found."
+    echo "  Install: sudo apt-get install -y simavr"
+    exit 1
+fi
+
+run_elf() {
+    local ELF="$1"
+    local LABEL="$2"
+    if [ ! -f "${ELF}" ]; then
+        echo "ERROR: ${ELF} not found — run ./build_arduino.sh first."
+        exit 1
+    fi
+    echo "=== Arduino (ATmega2560) — ${LABEL} ==="
+    simavr -m "${MCU}" -f "${FREQ}" "${ELF}" 2>/dev/null
+}
+
+MODE="${1:-all}"
+
+case "${MODE}" in
+    suite)
+        run_elf "${SUITE_ELF}" "Suite"
+        ;;
+    tests)
+        run_elf "${TESTS_ELF}" "Tests"
+        ;;
+    all|*)
+        run_elf "${SUITE_ELF}" "Suite"
+        echo ""
+        run_elf "${TESTS_ELF}" "Tests"
+        ;;
+esac

--- a/run_arm.sh
+++ b/run_arm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — ARM Thumb-2 run script
+# Runs the suite and test binaries under qemu-arm (user-mode emulation).
+#
+# Dependencies:
+#   qemu-arm   — sudo apt-get install -y qemu-user
+#
+# Build first with: ./build_arm.sh
+#
+# Usage:
+#   ./run_arm.sh                         # run suite then tests
+#   ./run_arm.sh suite                   # run suite only
+#   ./run_arm.sh tests [-r N] [-t S]     # run tests with optional flags
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+SUITE_BIN="Herradura cryptographic suite_arm"
+TESTS_BIN="CryptosuiteTests/Herradura_tests_arm"
+ARM_SYSROOT="/usr/arm-linux-gnueabi"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+if ! command -v qemu-arm &>/dev/null; then
+    echo "ERROR: qemu-arm not found."
+    echo "  Install: sudo apt-get install -y qemu-user"
+    exit 1
+fi
+
+if [ ! -f "${SUITE_BIN}" ] || [ ! -f "${TESTS_BIN}" ]; then
+    echo "ERROR: binaries not found — run ./build_arm.sh first."
+    exit 1
+fi
+
+MODE="${1:-all}"
+shift || true
+
+case "${MODE}" in
+    suite)
+        echo "=== ARM Thumb-2 — Suite ==="
+        qemu-arm -L "${ARM_SYSROOT}" "./${SUITE_BIN}"
+        ;;
+    tests)
+        echo "=== ARM Thumb-2 — Tests ==="
+        qemu-arm -L "${ARM_SYSROOT}" "./${TESTS_BIN}" "$@"
+        ;;
+    all|*)
+        echo "=== ARM Thumb-2 — Suite ==="
+        qemu-arm -L "${ARM_SYSROOT}" "./${SUITE_BIN}"
+        echo ""
+        echo "=== ARM Thumb-2 — Tests ==="
+        qemu-arm -L "${ARM_SYSROOT}" "./${TESTS_BIN}" "$@"
+        ;;
+esac

--- a/run_asm_i386.sh
+++ b/run_asm_i386.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# HerraduraKEx v1.5.8 — NASM i386 run script
+# Runs the suite and test binaries under qemu-i386 (user-mode emulation).
+#
+# Dependencies:
+#   qemu-i386   — sudo apt-get install -y qemu-user
+#
+# Build first with: ./build_asm_i386.sh
+#
+# Usage:
+#   ./run_asm_i386.sh                         # run suite then tests
+#   ./run_asm_i386.sh suite                   # run suite only
+#   ./run_asm_i386.sh tests [-r N] [-t S]     # run tests (flags ignored by asm, shown for parity)
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+SUITE_BIN="Herradura cryptographic suite_i386"
+TESTS_BIN="CryptosuiteTests/Herradura_tests_i386"
+
+# ── dependency check ──────────────────────────────────────────────────────────
+if ! command -v qemu-i386 &>/dev/null; then
+    echo "ERROR: qemu-i386 not found."
+    echo "  Install: sudo apt-get install -y qemu-user"
+    exit 1
+fi
+
+if [ ! -f "${SUITE_BIN}" ] || [ ! -f "${TESTS_BIN}" ]; then
+    echo "ERROR: binaries not found — run ./build_asm_i386.sh first."
+    exit 1
+fi
+
+MODE="${1:-all}"
+shift || true
+
+case "${MODE}" in
+    suite)
+        echo "=== NASM i386 — Suite ==="
+        qemu-i386 "./${SUITE_BIN}"
+        ;;
+    tests)
+        echo "=== NASM i386 — Tests ==="
+        qemu-i386 "./${TESTS_BIN}"
+        ;;
+    all|*)
+        echo "=== NASM i386 — Suite ==="
+        qemu-i386 "./${SUITE_BIN}"
+        echo ""
+        echo "=== NASM i386 — Tests ==="
+        qemu-i386 "./${TESTS_BIN}"
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add `build_c.sh` — `gcc -O2` for suite + tests
- Add `build_go.sh` — `go build` for suite + tests
- Add `build_arm.sh` / `run_arm.sh` — ARM Thumb-2 cross-compile via `arm-linux-gnueabi-gcc`; run under `qemu-arm`
- Add `build_asm_i386.sh` / `run_asm_i386.sh` — NASM i386 assemble via `nasm -f elf32` + `ld -m elf_i386`; run under `qemu-i386`
- Add `build_arduino.sh` / `run_arduino.sh` — AVR cross-compile targeting ATmega2560 (Mega board; Uno 2 KB SRAM is insufficient for Ring-LWR arrays); run under `simavr`

Each build script checks for required tools and prints `apt-get install` instructions if any are missing. Run scripts verify binaries exist before launching the emulator and include emulator install instructions.

All 8 scripts smoke-tested: C, Go, ARM, and i386 fully verified; Arduino ELFs built and launched under simavr (cycle-accurate emulation confirmed correct in prior session).

## Test plan

- [x] `./build_c.sh` → `./Herradura\ cryptographic\ suite` and `./CryptosuiteTests/Herradura_tests`
- [x] `./build_go.sh` → `./Herradura\ cryptographic\ suite_go` and `./CryptosuiteTests/Herradura_tests_go`
- [x] `./build_arm.sh` then `./run_arm.sh` — ARM suite + tests pass under qemu-arm
- [x] `./build_asm_i386.sh` then `./run_asm_i386.sh` — i386 suite + tests pass under qemu-i386
- [x] `./build_arduino.sh` then `./run_arduino.sh` — AVR ELFs run under simavr with correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)