### PR TITLE
v1.5.9: precompute delta(B) once in nl_fscx_revolve_v2_inv (all targets)

### DIFF
--- a/CryptosuiteTests/Herradura_tests.asm
+++ b/CryptosuiteTests/Herradura_tests.asm
@@ -1,4 +1,4 @@
-;  Herradura KEx -- Correctness Tests v1.5.7
+;  Herradura KEx -- Correctness Tests v1.5.9
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS Schnorr, HPKE El Gamal,
 ;                        NL-FSCX v2 inv, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS=32; I_VALUE=8; R_VALUE=24; HKEX-RNL N=32, q=65537, p=4096
@@ -53,7 +53,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura KEx v1.5.7 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr         db "=== Herradura KEx v1.5.9 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
     hdr_l       equ $-hdr
 
     t1_hdr      db "[1] HKEX-GF key exchange correctness: sk_alice == sk_bob (20 iterations)", 10
@@ -1067,22 +1067,30 @@ nl_fscx_revolve_v2:
 
 ; ============================================================
 ; nl_fscx_revolve_v2_inv: EAX=Y, EBX=B, ECX=steps --> EAX
+; delta(B) precomputed once — B constant throughout the revolve
 ; ============================================================
 nl_fscx_revolve_v2_inv:
     push esi
     push edi
-    mov  esi, eax
-    mov  edi, ecx
+    push ebp
+    mov  esi, eax               ; esi = current y
+    mov  edi, ecx               ; edi = steps
+    mov  eax, ebx
+    call nl_fscx_delta_v2       ; eax = delta(B)
+    mov  ebp, eax               ; ebp = delta (precomputed once)
 .rv2i_loop:
     test edi, edi
     jz   .rv2i_done
+    sub  esi, ebp               ; z = y - delta  (mod 2^32)
     mov  eax, esi
-    call nl_fscx_v2_inv
+    call m_inv_32               ; eax = M^{-1}(z)
+    xor  eax, ebx               ; y = B XOR M^{-1}(z)
     mov  esi, eax
     dec  edi
     jmp  .rv2i_loop
 .rv2i_done:
     mov  eax, esi
+    pop  ebp
     pop  edi
     pop  esi
     ret

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+    v1.5.9: nl_fscx_revolve_v2_inv_{32,64,128} precompute delta(B) once — eliminates per-step multiply.
     v1.5.7: m_inv_32/64/128 use precomputed rotation tables (0x6DB6DB6D / constants).
     v1.5.6: rnl_rand_coeff bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: added PQC benchmarks [22]–[25] matching Python/Go; aligned test output labels
@@ -391,8 +392,9 @@ static uint32_t nl_fscx_revolve_v2_32(uint32_t a, uint32_t b, int steps)
 
 static uint32_t nl_fscx_revolve_v2_inv_32(uint32_t y, uint32_t b, int steps)
 {
+    uint32_t delta = nl_fscx_delta_v2_32(b);  /* precompute once */
     int i;
-    for (i = 0; i < steps; i++) y = nl_fscx_v2_inv_32(y, b);
+    for (i = 0; i < steps; i++) y = b ^ m_inv_32(y - delta);
     return y;
 }
 
@@ -505,8 +507,9 @@ static uint64_t nl_fscx_revolve_v2_64(uint64_t a, uint64_t b, int steps)
 
 static uint64_t nl_fscx_revolve_v2_inv_64(uint64_t y, uint64_t b, int steps)
 {
+    uint64_t delta = nl_fscx_delta_v2_64(b);  /* precompute once */
     int i;
-    for (i = 0; i < steps; i++) y = nl_fscx_v2_inv_64(y, b);
+    for (i = 0; i < steps; i++) y = b ^ m_inv_64(y - delta);
     return y;
 }
 
@@ -588,8 +591,9 @@ static __uint128_t nl_fscx_revolve_v2_128(__uint128_t a, __uint128_t b, int step
 
 static __uint128_t nl_fscx_revolve_v2_inv_128(__uint128_t y, __uint128_t b, int steps)
 {
+    __uint128_t delta = nl_fscx_delta_v2_128(b);  /* precompute once */
     int i;
-    for (i = 0; i < steps; i++) y = nl_fscx_v2_inv_128(y, b);
+    for (i = 0; i < steps; i++) y = b ^ m_inv_128(y - delta);
     return y;
 }
 
@@ -2005,7 +2009,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.7 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.5.9 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: MInv uses precomputed rotation table (sync.Map cache per bit-size).
     v1.5.6: rnlRandPoly bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: aligned version banner with C and Python.
@@ -326,9 +327,16 @@ func NlFscxRevolveV2(a, b *BitArray, steps int) *BitArray {
 }
 
 func NlFscxRevolveV2Inv(y, b *BitArray, steps int) *BitArray {
+	n := y.size
+	mask := bitArrayMask(n)
+	delta := nlFscxDeltaV2(b)
 	result := y.Copy()
 	for i := 0; i < steps; i++ {
-		result = NlFscxV2Inv(result, b)
+		diff := new(big.Int).Sub(&result.val, &delta.val)
+		diff.And(diff, mask)
+		zBA := &BitArray{size: n}
+		zBA.val.Set(diff)
+		result = b.Xor(MInv(zBA))
 	}
 	return result
 }
@@ -1246,7 +1254,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.7 \u2014 Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.9 \u2014 Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -1,4 +1,4 @@
-/*  Herradura KEx — Security Tests v1.5.7 (Arduino, 32-bit)
+/*  Herradura KEx — Security Tests v1.5.9 (Arduino, 32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, NL-FSCX, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -137,7 +137,8 @@ uint32 nl_fscx_revolve_v2(uint32 a, uint32 b, int steps) {
 }
 
 uint32 nl_fscx_revolve_v2_inv(uint32 y, uint32 b, int steps) {
-    for (int i = 0; i < steps; i++) y = nl_fscx_v2_inv(y, b);
+    uint32 delta = nl_fscx_delta_v2(b);  /* precompute once — b is constant */
+    for (int i = 0; i < steps; i++) y = b ^ m_inv_32(y - delta);
     return y;
 }
 

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: _m_inv uses precomputed rotation table (lazy init, cached per bit-size).
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=16711935).
     v1.5.5: fixed version banner (was stuck at v1.5.3).
@@ -223,9 +224,13 @@ def nl_fscx_revolve_v2(A: BitArray, B: BitArray, steps: int) -> BitArray:
 
 
 def nl_fscx_revolve_v2_inv(Y: BitArray, B: BitArray, steps: int) -> BitArray:
+    n     = Y._size
+    mask  = Y._mask
+    delta = BitArray(n, (B.uint * ((B.uint + 1) >> 1)) & mask).rotated(n // 4)
     result = Y.copy()
     for _ in range(steps):
-        result = nl_fscx_v2_inv(result, B)
+        z      = BitArray(n, (result.uint - delta.uint) & mask)
+        result = B ^ _m_inv(z)
     return result
 
 
@@ -883,7 +888,7 @@ def bench_hkex_rnl_handshake():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.7 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.5.9 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -911,7 +916,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.7 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.9 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/CryptosuiteTests/Herradura_tests.s
+++ b/CryptosuiteTests/Herradura_tests.s
@@ -1,4 +1,4 @@
-/*  Herradura KEx -- Correctness Tests v1.5.7
+/*  Herradura KEx -- Correctness Tests v1.5.9
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        NL-FSCX v2 inv, HSKE-NL-A2,
                                        HKEX-RNL, HPKS-NL, HPKE-NL
@@ -31,7 +31,7 @@
     .data
     .balign 4
 
-fmt_hdr:  .asciz "=== Herradura KEx v1.5.7 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
+fmt_hdr:  .asciz "=== Herradura KEx v1.5.9 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
 fmt_t1:   .asciz "[1] HKEX-GF key exchange: sk_alice == sk_bob (20 iterations)\n"
 fmt_t2:   .asciz "[2] HSKE encrypt+decrypt round-trip: D == plaintext (100 iterations)\n"
 fmt_t3:   .asciz "[3] HPKS Schnorr: g^s * C^e == R (20 iterations)\n"
@@ -1049,24 +1049,28 @@ nlrv2_done:
 
 /* ------------------------------------------------------------------ */
 /* nl_fscx_revolve_v2_inv: r0=Y, r1=B, r2=steps -> r0                */
+/* delta(B) precomputed once — b constant throughout the revolve      */
 /* ------------------------------------------------------------------ */
     .thumb_func
 nl_fscx_revolve_v2_inv:
-    push    {r4-r6, lr}
-    mov     r4, r0
-    mov     r5, r1
-    mov     r6, r2
+    push    {r4-r7, lr}
+    mov     r4, r0              @ r4 = current y
+    mov     r5, r1              @ r5 = B
+    mov     r6, r2              @ r6 = steps
+    mov     r0, r5
+    bl      nl_fscx_delta_v2    @ r0 = delta(B)
+    mov     r7, r0              @ r7 = delta (precomputed once)
 nlrv2i_loop:
     cbz     r6, nlrv2i_done
+    sub     r4, r4, r7          @ z = y - delta  (mod 2^32)
     mov     r0, r4
-    mov     r1, r5
-    bl      nl_fscx_v2_inv
-    mov     r4, r0
+    bl      m_inv_32            @ r0 = M^{-1}(z)
+    eor     r4, r0, r5          @ y = B XOR M^{-1}(z)
     subs    r6, r6, #1
     b       nlrv2i_loop
 nlrv2i_done:
     mov     r0, r4
-    pop     {r4-r6, pc}
+    pop     {r4-r7, pc}
     .ltorg
 
 /* ------------------------------------------------------------------ */

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.7
+;  Herradura Cryptographic Suite v1.5.9
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -94,7 +94,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.5.7 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.5.9 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "
@@ -1218,22 +1218,30 @@ nl_fscx_revolve_v2:
 
 ; ============================================================
 ; nl_fscx_revolve_v2_inv: EAX=Y, EBX=B, ECX=steps --> EAX
+; delta(B) precomputed once — B constant throughout the revolve
 ; ============================================================
 nl_fscx_revolve_v2_inv:
     push esi
     push edi
-    mov  esi, eax
-    mov  edi, ecx
+    push ebp
+    mov  esi, eax               ; esi = current y
+    mov  edi, ecx               ; edi = steps
+    mov  eax, ebx
+    call nl_fscx_delta_v2       ; eax = delta(B)
+    mov  ebp, eax               ; ebp = delta (precomputed once)
 .rv2i_loop:
     test edi, edi
     jz   .rv2i_done
+    sub  esi, ebp               ; z = y - delta  (mod 2^32)
     mov  eax, esi
-    call nl_fscx_v2_inv
+    call m_inv_32               ; eax = M^{-1}(z)
+    xor  eax, ebx               ; y = B XOR M^{-1}(z)
     mov  esi, eax
     dec  edi
     jmp  .rv2i_loop
 .rv2i_done:
     mov  eax, esi
+    pop  ebp
     pop  edi
     pop  esi
     ret

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.7
+/*  Herradura Cryptographic Suite v1.5.9
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,11 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.9: nl_fscx_revolve_v2_inv_ba precomputes delta(B) once ---
+    delta(B) is now computed once before the loop and reused each step.
+    Loop body: ba_sub256(z, buf, delta); m_inv_ba(mz, z); ba_xor(buf, b, mz).
+    Eliminates one nl_fscx_delta_v2 call (arbitrary-precision mul+rol) per step.
 
     --- v1.5.7: precomputed M^{-1} for nl_fscx_v2_inv_ba ---
     m_inv_ba now computes the rotation table for M^{-1} = M^{127}(X) once on first call
@@ -539,11 +544,15 @@ static void nl_fscx_revolve_v2_ba(BitArray *result, const BitArray *a,
 static void nl_fscx_revolve_v2_inv_ba(BitArray *result, const BitArray *y,
                                        const BitArray *b, int steps)
 {
-    BitArray buf[2];
+    BitArray delta, buf[2];
     int idx = 0, i;
+    nl_fscx_delta_v2(&delta, b);   /* precompute once — b is constant */
     buf[0] = *y;
     for (i = 0; i < steps; i++) {
-        nl_fscx_v2_inv_ba(&buf[1 - idx], &buf[idx], b);
+        BitArray z, mz;
+        ba_sub256(&z, &buf[idx], &delta);
+        m_inv_ba(&mz, &z);
+        ba_xor(&buf[1 - idx], b, &mz);
         idx ^= 1;
     }
     *result = buf[idx];

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.7
+/*  Herradura Cryptographic Suite v1.5.9
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,11 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once ---
+    delta(B) is now computed once before the loop and reused each step.
+    Loop body: diff = result - delta; result = b.Xor(MInv(diff)).
+    Eliminates one nlFscxDeltaV2 big.Int multiply per iteration.
 
     --- v1.5.7: precomputed M^{-1} for NlFscxV2Inv ---
     MInv now computes the rotation table for M^{-1} = M^{n/2-1} once on first call
@@ -338,10 +343,18 @@ func NlFscxRevolveV2(a, b *BitArray, steps int) *BitArray {
 }
 
 // NlFscxRevolveV2Inv inverts NlFscxRevolveV2 by applying NlFscxV2Inv steps times.
+// delta(b) is precomputed once — b is constant throughout the revolve.
 func NlFscxRevolveV2Inv(y, b *BitArray, steps int) *BitArray {
+	n := y.size
+	mask := bitArrayMask(n)
+	delta := nlFscxDeltaV2(b)
 	result := y.Copy()
 	for i := 0; i < steps; i++ {
-		result = NlFscxV2Inv(result, b)
+		diff := new(big.Int).Sub(&result.val, &delta.val)
+		diff.And(diff, mask)
+		zBA := &BitArray{size: n}
+		zBA.val.Set(diff)
+		result = b.Xor(MInv(zBA))
 	}
 	return result
 }

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.7 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.9 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32
 
@@ -9,6 +9,7 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
+    v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=0xFF00FF).
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(n log n)).
@@ -163,7 +164,8 @@ uint32 nl_fscx_revolve_v2(uint32 a, uint32 b, int steps) {
 }
 
 uint32 nl_fscx_revolve_v2_inv(uint32 y, uint32 b, int steps) {
-    for (int i = 0; i < steps; i++) y = nl_fscx_v2_inv(y, b);
+    uint32 delta = nl_fscx_delta_v2(b);  /* precompute once — b is constant */
+    for (int i = 0; i < steps; i++) y = b ^ m_inv_32(y - delta);
     return y;
 }
 

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.5.7
+    Herradura Cryptographic Suite v1.5.9
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,6 +17,12 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once ---
+
+    delta(B) is now computed once before the loop and reused each step, eliminating
+    redundant multiply-and-rotate work per iteration.  Loop body: z = y - delta;
+    y = B XOR _m_inv(z).  Reduces per-step cost from O(delta+M^{-1}) to O(M^{-1}).
 
     --- v1.5.7: precomputed M^{-1} for nl_fscx_v2_inv ---
 
@@ -325,10 +331,15 @@ def nl_fscx_revolve_v2(A: BitArray, B: BitArray, steps: int) -> BitArray:
 
 
 def nl_fscx_revolve_v2_inv(Y: BitArray, B: BitArray, steps: int) -> BitArray:
-    """Invert nl_fscx_revolve_v2: apply nl_fscx_v2_inv *steps* times."""
+    """Invert nl_fscx_revolve_v2: apply nl_fscx_v2_inv *steps* times.
+    delta(B) is precomputed once — B is constant throughout the revolve."""
+    n     = Y._size
+    mask  = Y._mask
+    delta = BitArray(n, (B.uint * ((B.uint + 1) >> 1)) & mask).rotated(n // 4)
     result = Y.copy()
     for _ in range(steps):
-        result = nl_fscx_v2_inv(result, B)
+        z      = BitArray(n, (result.uint - delta.uint) & mask)
+        result = B ^ _m_inv(z)
     return result
 
 

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.7
+/*  Herradura Cryptographic Suite v1.5.9
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -42,7 +42,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.7 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.9 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 
@@ -1224,24 +1224,28 @@ rv2_done:
 
 /* ------------------------------------------------------------------ */
 /* nl_fscx_revolve_v2_inv: r0=Y, r1=B, r2=steps -> r0                */
+/* delta(B) precomputed once — b constant throughout the revolve      */
 /* ------------------------------------------------------------------ */
     .thumb_func
 nl_fscx_revolve_v2_inv:
-    push    {r4-r6, lr}
-    mov     r4, r0
-    mov     r5, r1
-    mov     r6, r2
+    push    {r4-r7, lr}
+    mov     r4, r0              @ r4 = current y
+    mov     r5, r1              @ r5 = B
+    mov     r6, r2              @ r6 = steps
+    mov     r0, r5
+    bl      nl_fscx_delta_v2    @ r0 = delta(B)
+    mov     r7, r0              @ r7 = delta (precomputed once)
 rv2i_loop:
     cbz     r6, rv2i_done
+    sub     r4, r4, r7          @ z = y - delta  (mod 2^32)
     mov     r0, r4
-    mov     r1, r5
-    bl      nl_fscx_v2_inv
-    mov     r4, r0
+    bl      m_inv_32            @ r0 = M^{-1}(z)
+    eor     r4, r0, r5          @ y = B XOR M^{-1}(z)
     subs    r6, r6, #1
     b       rv2i_loop
 rv2i_done:
     mov     r0, r4
-    pop     {r4-r6, pc}
+    pop     {r4-r7, pc}
 
     .ltorg
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,292 @@
+# HerraduraKEx — PQC Improvement Backlog
+
+Generated from security/performance review of v1.5.x NL-FSCX + Ring-LWR implementation.
+
+---
+
+## Security
+
+### 1. RNLB=1 — sparse secrets (Critical)
+**Files:** `Herradura cryptographic suite.py:85`, C `:497`
+
+Secrets drawn from {0,1} enable sparse-secret lattice attacks. Replace with a
+centered binomial distribution (η=2 or η=3), matching the Kyber baseline.
+
+```python
+def _rnl_cbd_poly(n, eta, q):
+    """Centered binomial: each coeff = sum(eta bits) - sum(eta bits), mod q."""
+    out = []
+    for _ in range(n):
+        byte_count = (2 * eta + 7) // 8
+        raw = int.from_bytes(os.urandom(byte_count), 'big')
+        a = bin(raw >> eta).count('1') & ((1 << eta) - 1).bit_length()
+        # cleaner: count bits in two eta-bit windows
+        mask = (1 << eta) - 1
+        a = bin(raw & mask).count('1')
+        b = bin((raw >> eta) & mask).count('1')
+        out.append((a - b) % q)
+    return out
+```
+Set `RNLB = 2` (η=2) and wire `_rnl_cbd_poly(n, RNLB, RNLQ)` instead of
+`_rnl_small_poly`.
+
+Status: **DONE (v1.5.x)** — CBD(eta=1) implemented. Chose eta=1 over eta=2 because
+the deployed parameters (q=65537, p=4096) have a tight noise budget: max noise per
+coefficient ≤ n·eta·q/p. Jumping to eta=2 doubles the noise floor and causes frequent
+key-agreement failures. CBD(1) achieves the security goal (centered, zero-mean, proper
+LWR distribution) with the same max-magnitude as the old {0,1} sampler.
+
+---
+
+### 2. Modular bias in `_rnl_rand_poly` (Medium)
+**File:** `Herradura cryptographic suite.py:335`
+
+`int.from_bytes(os.urandom(4), 'big') % q` with q=65537 introduces a bias of
+~1/2^32 per coefficient (2^32 mod 65537 = 65536 ≠ 0). Fix with rejection sampling
+using 3-byte draws (2^24 / 65537 ≈ 255.996 — negligible residual after rejection).
+
+```python
+def _rnl_rand_poly(n, q):
+    threshold = (1 << 24) - (1 << 24) % q
+    out = []
+    while len(out) < n:
+        v = int.from_bytes(os.urandom(3), 'big')
+        if v < threshold:
+            out.append(v % q)
+    return out
+```
+
+Status: **DONE (v1.5.6)** — 3-byte (24-bit) rejection sampling implemented across all
+language targets (Python, C, Go, ARM Thumb-2, NASM i386, Arduino, C tests).
+Threshold = (1<<24) − (1<<24)%65537 = 16711935 (0xFF00FF); rejection probability ≈ 0.39%.
+Eliminates the ~1/2^32 per-coefficient bias present in the previous 4-byte draw.
+
+---
+
+### 3. No per-session nonce in HSKE-NL-A1 (Medium)
+**File:** `Herradura cryptographic suite.py:518–530`
+
+Counter always starts at 0 per-session. If the same key K is reused across
+sessions the keystream is identical. Fix: generate a random nonce N, derive the
+session base as K XOR N, transmit N alongside ciphertext.
+
+Status: **TODO**
+
+---
+
+### 4. Ad-hoc KDF for HKEX-RNL (Medium)
+**File:** `Herradura cryptographic suite.py:554–555`
+
+NL-FSCX v1 is used as the sole KDF with no formal PRF proof. Pass the NL-FSCX
+output through SHAKE-256 for final extraction, replacing an unproven PRF claim
+with a standard-model assumption.
+
+```python
+import hashlib
+sk_bytes = hashlib.shake_256(nl_fscx_raw.bytes).digest(KEYBITS // 8)
+```
+
+Status: **TODO**
+
+---
+
+### 5. HPKS-NL / HPKE-NL — not truly PQC (Structural / Known)
+
+Both protocols retain the GF(2^n)* DLP which Shor's algorithm breaks. They are
+linearity-hardened classical protocols, not post-quantum. Replacing the DH
+exponentiation with a lattice-based commitment (e.g., Ring-LWE-based Schnorr)
+would be required for full PQC. Currently documented as a known limitation.
+
+Status: **KNOWN / DEFERRED**
+
+---
+
+## Performance
+
+### 6. O(n²) polynomial multiplication — no NTT (High)
+**Files:** `Herradura cryptographic suite.py:302–314`, C `:504–517`
+
+Naive negacyclic poly-mul is O(n²). Since q=65537=2^16+1 is a Fermat prime,
+NTT over Z_{65537} applies for any n ≤ 2^16. At n=256 this gives ~32× speedup.
+Implement Cooley-Tukey NTT and replace `_rnl_poly_mul` calls.
+
+Status: **DONE (v1.5.4)** — Cooley-Tukey NTT with negacyclic twist implemented
+across all language implementations (C, Go, Python, ARM Thumb-2, NASM i386, Arduino).
+
+---
+
+### 7. `_m_inv` recomputes n/2−1 FSCX steps every call (Medium)
+**File:** `Herradura cryptographic suite.py:225–230`
+
+M^{-1} is a fixed linear map for a given n. Precompute it once as a set of
+(rotation, sign) pairs and apply as a single pass — O(1) FSCX-equivalent cost
+instead of O(n/2) iterations.
+
+Status: **DONE (v1.5.7)** — Precomputed rotation table implemented across all
+language targets. M^{-1}(X) = XOR of ROL(X,k) for k in the non-zero bits of
+M^{-1}(1) = fscx_revolve(1, 0, n/2-1). For n=32: table constant 0x6DB6DB6D
+(21 rotations); for n=64: 0xB6DB6DB6DB6DB6DB (43 rotations); for n=128: two
+64-bit halves (85 rotations). For n=256 (C/Go/Python suite): lazy-init via
+ba_fscx_revolve/FscxRevolve bootstrap on first call, cached thereafter.
+Assembly (ARM Thumb-2 and NASM i386) use unrolled ROR/ROL+XOR instruction
+sequences for n=32. Replaces 127 FSCX iterations (n=256) with ~170 XOR-rotation
+pairs (~2n/3 density).
+
+---
+
+### 8. HSKE-NL-A2 decryption is quadratic (Medium, follows from #7)
+**File:** `Herradura cryptographic suite.py:290–294`
+
+`nl_fscx_revolve_v2_inv` runs r=3n/4 steps each costing n/2−1 FSCX iterations:
+192 × 127 = 24,384 iterations at n=256. With precomputed M^{-1} (fix #7) this
+drops to 192 iterations — linear in r.
+
+Status: **DONE (v1.5.9)** — `nl_fscx_revolve_v2_inv` (all language targets: Python, C,
+Go, Arduino, ARM Thumb-2, NASM i386) now precomputes `delta(B)` once before the loop.
+Loop body is `z = y − delta; y = B XOR m_inv(z)`, eliminating one multiply-and-rotate
+per step. For n=32 (assembly/Arduino/C-32): saves `r2 = steps × B*(B+1)/2 + ROL` ops.
+For n=256 (Python/C/Go): saves `steps` big-integer multiply calls.
+
+---
+
+## Priority order
+
+1. #1 — CBD secrets (security correctness, easy to test)
+2. #2 — rand_poly bias (security correctness, one-liner)
+3. #6 — NTT poly mul (biggest performance win)
+4. #7 + #8 — precomputed M^{-1} (second performance win)
+5. #3 — session nonce (protocol hygiene)
+6. #4 — SHAKE KDF (hardening, low effort)
+7. #5 — deferred
+
+---
+
+## Assembly Build / Logic Fixes
+
+### A1. ARM Thumb-2 — `cbz` with high registers (build error)
+**Files:** `Herradura cryptographic suite.s`, `CryptosuiteTests/Herradura_tests.s`
+
+`cbz` (Compare and Branch if Zero) is a 16-bit Thumb instruction that only accepts
+lo registers r0–r7.  The `rnl_poly_mul` function loads f[i] into r9 and g[j] into
+r10, then uses `cbz r9` / `cbz r10` to skip zero coefficients — both are illegal.
+
+Fix in each file (two occurrences each):
+```asm
+; Before:
+    cbz     r9, rpm_outer_next
+    cbz     r10, rpm_inner_next
+; After:
+    cmp     r9, #0
+    beq     rpm_outer_next
+    cmp     r10, #0
+    beq     rpm_inner_next
+```
+
+Status: **DONE (v1.5.3)**
+
+---
+
+### A2. NASM i386 — wrong stack offset in `rnl_poly_mul` (silent logic error)
+**Files:** `Herradura cryptographic suite.asm`, `CryptosuiteTests/Herradura_tests.asm`
+
+After computing `prod mod q`, the code saves eax/ecx/edx/ebx on the stack, then
+reads back the target index k = i+j.  After `pop ebx` (restoring j), the stack is:
+  [esp]=k, [esp+4]=i, [esp+8]=prod
+
+The code reads `[esp+4]` (= i) instead of `[esp]` (= k), writing every partial
+product to `rnl_tmp[i]` instead of `rnl_tmp[k]`.  The polynomial product is silently
+wrong.  Occurs in both the positive-index branch (.rpm_add_no_sub) and the
+negative/wrap branch (.rpm_neg_no_sub).
+
+Fix in each file (two occurrences each):
+```asm
+; Before:
+    mov  ecx, [esp+4]   ; restore k from stack  ← actually reads i
+; After:
+    mov  ecx, [esp]     ; restore k from stack
+```
+
+| File | Branch | Line |
+|---|---|---|
+| `Herradura cryptographic suite.asm` | .rpm_add_no_sub | 1346 |
+| `Herradura cryptographic suite.asm` | .rpm_neg_no_sub | 1370 |
+| `CryptosuiteTests/Herradura_tests.asm` | .rpm_add_no_sub | 1183 |
+| `CryptosuiteTests/Herradura_tests.asm` | .rpm_neg_no_sub | 1206 |
+
+Status: **DONE (v1.5.3)**
+
+---
+
+## Test Parity (C vs Python/Go) — Improvement Backlog
+
+Identified from cross-language analysis of v1.5.4 test files.
+
+### Phase 1. Version banner and output label fixes (Trivial)
+
+**Files:** `CryptosuiteTests/Herradura_tests.c`, `CryptosuiteTests/Herradura_tests.py`, `CryptosuiteTests/Herradura_tests.go`
+
+- C and Python banners printed `v1.5.3` instead of the current version.
+- C test output labels lacked `[CLASSICAL]` / `[PQC-EXT]` markers present in Python and Go.
+- C section headers `"--- Security Assumption Tests ---"` and `"--- v1.5.0 NL-FSCX and PQC Tests ---"`
+  differed from Python/Go equivalents.
+
+Status: **DONE (v1.5.5)**
+
+---
+
+### Phase 2. Missing PQC benchmarks [22]–[25] in C (High)
+
+**File:** `CryptosuiteTests/Herradura_tests.c`
+
+C stops at benchmark [21]; Python and Go have four additional PQC benchmarks:
+- [22] NL-FSCX v1 revolve throughput (n/4 steps, 32-bit)
+- [22b] NL-FSCX v2 revolve+inv throughput (32-bit)
+- [23] HSKE-NL-A1 counter-mode throughput (32-bit)
+- [24] HSKE-NL-A2 revolve-mode round-trip (32-bit)
+- [25] HKEX-RNL handshake throughput (n=32)
+
+Status: **DONE (v1.5.5)**
+
+---
+
+### Phase 3. Multi-size GF loops for tests [1],[5]–[9],[14]–[16] in C (Medium)
+
+**File:** `CryptosuiteTests/Herradura_tests.c`
+
+C runs GF-heavy tests at a single fixed size; Python and Go loop over multiple sizes.
+Add `gf_mul_64`/`gf_pow_64` (poly `0x1B`, `uint64_t`) and loop tests over `{32, 64}`.
+For test [14] HKEX-RNL, add `n=64` variant matching Python/Go `RNL_SIZES=[32,64]`.
+
+Status: **DONE (v1.5.5)** — Added 64-bit GF(2^64), 64-bit FSCX/NL-FSCX, and
+generic-n RNL helpers. Tests [1],[5],[6] loop {32,64,256}; tests [7]–[9],[14]–[16]
+loop {32,64}. Key-sensitivity PASS criterion aligned to `mean >= n/4` (Phase 5
+partial fix). Generic-n uses VLA functions reusing `rnl32_ntt` for n=64 NTT.
+
+---
+
+### Phase 4. Multi-size FSCX loops for tests [2]–[4],[10]–[13] in C (Medium)
+
+**File:** `CryptosuiteTests/Herradura_tests.c`
+
+C runs FSCX-based tests at 256-bit only; Python and Go loop over `{64, 128, 256}`.
+Add `fscx64`/`fscx_revolve64` (`uint64_t`) and `fscx128`/`fscx_revolve128` (`__uint128_t`),
+plus matching 64/128-bit NL-FSCX variants, then loop affected tests.
+
+Status: **DONE (v1.5.5)** — Added 128-bit `fscx128`/`fscx_revolve128`/NL-FSCX via
+`__uint128_t` and `rand128()`. Tests [2]–[4] loop `{64, 128, 256}`; tests [10]–[13]
+loop `{64, 128}`. 256-bit NL-FSCX deferred (requires 256-bit integer multiply).
+
+---
+
+### Phase 5. Test methodology alignment (Low)
+
+**File:** `CryptosuiteTests/Herradura_tests.c`
+
+- **[5] Key sensitivity PASS criteria**: C checks symmetric range `0.35·n ≤ mean ≤ 0.65·n`;
+  Python/Go check lower bound only `mean ≥ n/4`. Align C to `mean ≥ n/4`.
+- **[11] Bijectivity test**: C uses single pair-wise collision check; Python/Go sample 256 random
+  `A` values per `B` with collision detection in a hash map. Upgrade C to match.
+
+Status: **DONE (v1.5.5)** — [5] fixed in Phase 3 (criterion changed to `mean >= n/4`).
+[11] upgraded to `BIJ_SAMPLES=256` random A values per B with O(n²) pairwise output
+collision scan, matching Python/Go 256-sample hash-map methodology.


### PR DESCRIPTION
## Summary

- In all `nl_fscx_revolve_v2_inv` implementations, `delta(B)` was recomputed on every iteration despite `B` being constant throughout the revolve
- Now precomputed once before the loop; inner body is `z = y − delta; y = B XOR m_inv(z)`
- Eliminates one multiply-and-rotate (or big-integer multiply for n=256) per decryption step
- Closes TODO #8 — HSKE-NL-A2 decryption optimization (follows from v1.5.7 precomputed M⁻¹)

## Files changed (12 source files + TODO.md)

| Target | Function(s) |
|---|---|
| Python suite + tests | `nl_fscx_revolve_v2_inv` |
| C suite | `nl_fscx_revolve_v2_inv_ba` (256-bit BitArray) |
| C tests | `nl_fscx_revolve_v2_inv_{32,64,128}` |
| Go suite + tests | `NlFscxRevolveV2Inv` |
| Arduino suite + tests | `nl_fscx_revolve_v2_inv` |
| ARM Thumb-2 suite + tests | `nl_fscx_revolve_v2_inv` (r7 added to save frame) |
| NASM i386 suite + tests | `nl_fscx_revolve_v2_inv` (ebp added to save frame) |

## Test plan

- [x] C suite builds cleanly (`gcc -O2`)
- [x] C tests: all HSKE-NL-A2 correctness tests pass (50/50)
- [x] Python suite: HSKE-NL-A2 `+ plaintext correctly decrypted`
- [x] Python tests: test [13] 50/50 correct at 64/128/256-bit
- [x] Go suite: HSKE-NL-A2 `+ plaintext correctly decrypted`
- [x] Go tests: test [13] 50/50 correct
- [x] ARM build + run: v1.5.9 banner, test [6] HSKE-NL-A2 20/20 passed
- [x] NASM i386 build + run: v1.5.9 banner, test [6] HSKE-NL-A2 20/20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)