### PR TITLE
v1.5.9: HSKE-NL-A1 per-session nonce + delta(B) precompute (all targets)

### DIFF
--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -1478,7 +1478,7 @@ static void test_nl_fscx_v2_bijective_inverse(void)
     putchar('\n');
 }
 
-/* [12] HSKE-NL-A1 counter-mode correctness: D == P */
+/* [12] HSKE-NL-A1 counter-mode correctness: D == P (with per-session nonce) */
 static void test_hske_nl_a1_correctness(void)
 {
     static const int sizes[] = {64, 128};
@@ -1492,14 +1492,16 @@ static void test_hske_nl_a1_correctness(void)
         clock_gettime(CLOCK_MONOTONIC, &t0);
         for (i = 0; i < N; i++) {
             if (size == 128) {
-                __uint128_t K = rand128(), P = rand128();
+                __uint128_t K = rand128(), nonce = rand128(), P = rand128();
+                __uint128_t base = K ^ nonce;
                 __uint128_t ctr = (uint32_t)i & 0xFFFF;
-                __uint128_t ks = nl_fscx_revolve_v1_128(K, K ^ ctr, iv);
+                __uint128_t ks = nl_fscx_revolve_v1_128(base, base ^ ctr, iv);
                 if ((P ^ ks ^ ks) == P) ok++;
             } else {
-                uint64_t K = rand64(), P = rand64();
+                uint64_t K = rand64(), nonce = rand64(), P = rand64();
+                uint64_t base = K ^ nonce;
                 uint64_t ctr = (uint32_t)i & 0xFFFF;
-                uint64_t ks = nl_fscx_revolve_v1_64(K, K ^ ctr, iv);
+                uint64_t ks = nl_fscx_revolve_v1_64(base, base ^ ctr, iv);
                 if ((P ^ ks ^ ks) == P) ok++;
             }
             if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }
@@ -1874,7 +1876,7 @@ static void bench_nl_fscx_revolve(void)
     putchar('\n');
 }
 
-/* [23] HSKE-NL-A1 counter-mode throughput (32-bit, ctr=0) */
+/* [23] HSKE-NL-A1 counter-mode throughput (32-bit, ctr=0, with nonce) */
 static void bench_hske_nl_a1_roundtrip(void)
 {
     uint32_t K, P, ks, sink = 0;
@@ -1884,12 +1886,18 @@ static void bench_hske_nl_a1_roundtrip(void)
     int i;
     printf("[23] HSKE-NL-A1 counter-mode throughput  (bits=32)  [PQC-EXT]\n    ");
     K = rand32(); P = rand32();
-    for (i = 0; i < 10; i++) { ks = nl_fscx_revolve_v1_32(K, K, NL_I32); sink ^= P ^ ks; }
+    for (i = 0; i < 10; i++) {
+        uint32_t nonce = rand32(), base = K ^ nonce;
+        ks = nl_fscx_revolve_v1_32(base, base, NL_I32);
+        sink ^= P ^ ks;
+    }
     clock_gettime(CLOCK_MONOTONIC, &t0);
     do {
         for (i = 0; i < 100; i++) {
-            K  = rand32(); P = rand32();
-            ks = nl_fscx_revolve_v1_32(K, K, NL_I32);   /* ctr=0 for throughput */
+            uint32_t nonce = rand32();
+            K = rand32(); P = rand32();
+            uint32_t base = K ^ nonce;
+            ks = nl_fscx_revolve_v1_32(base, base, NL_I32);  /* ctr=0 */
             sink ^= P ^ ks;
         }
         ops += 100;

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -899,16 +899,18 @@ func testNlFscxV2BijectiveInverse() {
 }
 
 func testHskeNlA1Correctness() {
+	// HSKE-NL-A1 with per-session nonce: base = K XOR N; ks = NlFscxRevolveV1(base, base XOR ctr, n/4).
 	fmt.Println("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
 		ok, N := 0, testRounds(1000)
 		t0 := time.Now()
 		for trial := 0; trial < N; trial++ {
-			K := randBA(size); P := randBA(size)
+			K := randBA(size); nonce := randBA(size); P := randBA(size)
+			base := newBA(size, new(big.Int).Xor(&K.val, &nonce.val))
 			ctr := int64(trial % (1 << 16))
-			bCtr := newBA(size, new(big.Int).Xor(&K.val, big.NewInt(ctr)))
-			ks := NlFscxRevolveV1(K, bCtr, iv)
+			bCtr := newBA(size, new(big.Int).Xor(&base.val, big.NewInt(ctr)))
+			ks := NlFscxRevolveV1(base, bCtr, iv)
 			C := newBA(size, new(big.Int).Xor(&P.val, &ks.val))
 			D := newBA(size, new(big.Int).Xor(&C.val, &ks.val))
 			if D.Equal(P) { ok++ }
@@ -1162,10 +1164,12 @@ func benchHskeNlA1RoundTrip() {
 		iv := iVal(size)
 		sink := randBA(size)
 		ops, elapsed := bench("", func() {
-			K := randBA(size)
-			P := randBA(size)
-			bCtr := newBA(size, new(big.Int).Set(&K.val)) // counter=0
-			ks := NlFscxRevolveV1(K, bCtr, iv)
+			K     := randBA(size)
+			nonce := randBA(size)
+			base  := newBA(size, new(big.Int).Xor(&K.val, &nonce.val))
+			P     := randBA(size)
+			bCtr  := newBA(size, new(big.Int).Set(&base.val)) // counter=0
+			ks    := NlFscxRevolveV1(base, bCtr, iv)
 			sink = sink.Xor(newBA(size, new(big.Int).Xor(&P.val, &ks.val)))
 		})
 		fmt.Printf("    bits=%3d                          : %s  (%d ops in %.2fs)\n",

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -621,20 +621,22 @@ def test_nl_fscx_v2_bijective_inverse():
 
 
 def test_hske_nl_a1_correctness():
-    # HSKE-NL-A1 counter-mode: C = P XOR keystream; D = C XOR keystream = P.
-    # keystream[i] = nl_fscx_revolve_v1(K, K XOR i, n/4).
+    # HSKE-NL-A1 counter-mode with per-session nonce: N random; base = K XOR N.
+    # keystream[i] = nl_fscx_revolve_v1(base, base XOR i, n/4).
     print("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); ok = 0; n_run = 0
         for trial in _trange(_iters(1000)):
             n_run += 1
-            K   = BitArray.random(size)
-            P   = BitArray.random(size)
-            ctr = trial % (1 << min(size, 16))
-            B   = BitArray(size, K.uint ^ ctr)
-            ks  = nl_fscx_revolve_v1(K, B, iv)
-            C   = BitArray(size, P.uint ^ ks.uint)
-            D   = BitArray(size, C.uint ^ ks.uint)
+            K    = BitArray.random(size)
+            N    = BitArray.random(size)                 # per-session nonce
+            P    = BitArray.random(size)
+            base = BitArray(size, K.uint ^ N.uint)       # session key base
+            ctr  = trial % (1 << min(size, 16))
+            B    = BitArray(size, base.uint ^ ctr)
+            ks   = nl_fscx_revolve_v1(base, B, iv)
+            C    = BitArray(size, P.uint ^ ks.uint)
+            D    = BitArray(size, C.uint ^ ks.uint)
             if D == P: ok += 1
         status = "PASS" if ok == n_run else "FAIL"
         print(f"    bits={size:3d}  {ok:4d} / {n_run} correct  [{status}]")
@@ -843,9 +845,11 @@ def bench_hske_nl_a1_roundtrip():
         iv = i_val(size); sink = BitArray(size, 0)
         def fn(size=size, iv=iv):
             nonlocal sink
-            K = BitArray.random(size); P = BitArray.random(size)
-            B = BitArray(size, K.uint ^ 0)
-            ks = nl_fscx_revolve_v1(K, B, iv)
+            K    = BitArray.random(size); P = BitArray.random(size)
+            N    = BitArray.random(size)
+            base = BitArray(size, K.uint ^ N.uint)
+            B    = BitArray(size, base.uint ^ 0)  # counter=0
+            ks   = nl_fscx_revolve_v1(base, B, iv)
             sink ^= BitArray(size, P.uint ^ ks.uint)
         _bench(f"bits={size:3d}", fn)
     print()

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -56,6 +56,7 @@ section .data
     prng_state  dd 0xDEADBEEE
 
     ; NL / RNL scratch scalars
+    val_nonce_nl1 dd 0  ; HSKE-NL-A1 per-session nonce
     val_ks_nl1  dd 0    ; HSKE-NL-A1 keystream
     val_E_nl1   dd 0
     val_E_nl2   dd 0    ; HSKE-NL-A2 ciphertext (saved for Eve)
@@ -149,6 +150,8 @@ section .data
     ; v1.5.0 section headers
     hske_nl1_hdr db 10, "--- HSKE-NL-A1 [PQC-HARDENED -- counter-mode with NL-FSCX v1]", 10
     hske_nl1_hdr_l equ $-hske_nl1_hdr
+    lbl_N_nl1    db "N (nonce)    : "
+    lbl_N_nl1_l  equ $-lbl_N_nl1
     hske_nl2_hdr db 10, "--- HSKE-NL-A2 [PQC-HARDENED -- revolve-mode with NL-FSCX v2]", 10
     hske_nl2_hdr_l equ $-hske_nl2_hdr
     hkex_rnl_hdr db 10, "--- HKEX-RNL [PQC -- Ring-LWR key exchange; N=32, q=65537]", 10
@@ -520,11 +523,13 @@ _start:
     mov  ecx, hske_nl1_hdr_l
     call print_str
 
-    ; ks = nl_fscx_revolve_v1(K, K, 8)  [counter=0 -> B=K]
-    mov  eax, [val_key]
-    mov  ebx, [val_key]
+    ; N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(base, base, I_VALUE)
+    call prng_next              ; eax = nonce N
+    mov  [val_nonce_nl1], eax
+    xor  eax, [val_key]         ; eax = base = N XOR key
+    mov  ebx, eax               ; ebx = base (counter=0: B = base)
     mov  ecx, I_VALUE
-    call nl_fscx_revolve_v1
+    call nl_fscx_revolve_v1     ; eax = ks
     mov  [val_ks_nl1], eax
 
     ; E = plain XOR ks
@@ -532,14 +537,16 @@ _start:
     xor  eax, [val_ks_nl1]
     mov  [val_E_nl1], eax
 
-    ; D = E XOR ks
-    mov  eax, [val_E_nl1]
-    xor  eax, [val_ks_nl1]
+    ; print N
+    mov  eax, lbl_N_nl1
+    mov  ecx, lbl_N_nl1_l
+    call print_str
+    mov  eax, [val_nonce_nl1]
+    call print_hex32
 
-    mov  ecx, eax              ; save D
+    ; print E
     mov  eax, lbl_E_nl
-    mov  ecx, lbl_E_nl_l       ; oops, clobber -- use push/pop
-    push ecx
+    mov  ecx, lbl_E_nl_l
     call print_str
     mov  eax, [val_E_nl1]
     call print_hex32
@@ -547,7 +554,7 @@ _start:
     mov  eax, lbl_D_nl
     mov  ecx, lbl_D_nl_l
     call print_str
-    ; recompute D
+    ; D = E XOR ks
     mov  eax, [val_E_nl1]
     xor  eax, [val_ks_nl1]
     push eax

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -17,8 +17,11 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.9: nl_fscx_revolve_v2_inv_ba precomputes delta(B) once ---
-    delta(B) is now computed once before the loop and reused each step.
+    --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv_ba delta precompute ---
+    HSKE-NL-A1 now generates a random per-session nonce N and derives session base
+    = K XOR N (transmitted alongside ciphertext).  Eliminates keystream reuse when
+    the same long-term key K is used across sessions.
+    nl_fscx_revolve_v2_inv_ba precomputes delta(B) once before the loop.
     Loop body: ba_sub256(z, buf, delta); m_inv_ba(mz, z); ba_xor(buf, b, mz).
     Eliminates one nl_fscx_delta_v2 call (arbitrary-precision mul+rol) per step.
 
@@ -752,7 +755,8 @@ HPKE (El Gamal public key encryption, 256-bit):
     Alice decrypts: dec_key=R^a; D=fscx_revolve(E,dec_key,r) = P
 
 HSKE-NL-A1 (counter-mode with NL-FSCX v1, 256-bit):
-    ks = nl_fscx_revolve_v1(K, K XOR counter, I_VALUE)
+    N = random(256 bits); base = K XOR N  [per-session nonce; N transmitted with ciphertext]
+    ks = nl_fscx_revolve_v1(base, base XOR counter, I_VALUE)
     E = P XOR ks;  D = E XOR ks = P
 
 HSKE-NL-A2 (revolve-mode with NL-FSCX v2, 256-bit):
@@ -886,11 +890,13 @@ int main(void)
     /* --- HSKE-NL-A1 [PQC-HARDENED -- counter-mode with NL-FSCX v1] */
     printf("\n--- HSKE-NL-A1 [PQC-HARDENED \xe2\x80\x94 counter-mode with NL-FSCX v1]\n");
     {
-        BitArray ks_nl1, E_nl1, D_nl1;
-        /* counter=0: B = preshared XOR 0 = preshared */
-        nl_fscx_revolve_v1_ba(&ks_nl1, &preshared, &preshared, I_VALUE);
+        BitArray N_a1, base_a1, ks_nl1, E_nl1, D_nl1;
+        ba_rand(&N_a1, urnd);                         /* per-session nonce          */
+        ba_xor(&base_a1, &preshared, &N_a1);          /* base = K XOR N             */
+        nl_fscx_revolve_v1_ba(&ks_nl1, &base_a1, &base_a1, I_VALUE); /* counter=0  */
         ba_xor(&E_nl1, &plaintext, &ks_nl1);
         ba_xor(&D_nl1, &E_nl1,    &ks_nl1);
+        ba_print_hex("N (nonce) : ", &N_a1);
         ba_print_hex("P (plain) : ", &plaintext);
         ba_print_hex("E (Alice) : ", &E_nl1);
         ba_print_hex("D (Bob)   : ", &D_nl1);

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -17,8 +17,11 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once ---
-    delta(B) is now computed once before the loop and reused each step.
+    --- v1.5.9: HSKE-NL-A1 per-session nonce; NlFscxRevolveV2Inv delta precompute ---
+    HSKE-NL-A1 now generates a random per-session nonce N and derives session base
+    = K XOR N (transmitted alongside ciphertext).  Eliminates keystream reuse when
+    the same long-term key K is used across sessions.
+    NlFscxRevolveV2Inv precomputes delta(B) once before the loop.
     Loop body: diff = result - delta; result = b.Xor(MInv(diff)).
     Eliminates one nlFscxDeltaV2 big.Int multiply per iteration.
 
@@ -631,11 +634,14 @@ func main() {
 
 	// ── PQC-HARDENED protocols ───────────────────────────────────────────────
 	fmt.Println("\n--- HSKE-NL-A1 [PQC-HARDENED — counter-mode with NL-FSCX v1]")
+	nA1    := randBA(n)                                                    // per-session nonce
+	baseA1 := NewBitArray(n, new(big.Int).Xor(&preshared.val, &nA1.val)) // base = K XOR N
 	counter := 0
-	bA1 := NewBitArray(n, new(big.Int).Xor(&preshared.val, big.NewInt(int64(counter))))
-	ksA1 := NlFscxRevolveV1(preshared, bA1, n/4)
+	bA1 := NewBitArray(n, new(big.Int).Xor(&baseA1.val, big.NewInt(int64(counter))))
+	ksA1 := NlFscxRevolveV1(baseA1, bA1, n/4)
 	eA1 := NewBitArray(n, new(big.Int).Xor(&plaintext.val, &ksA1.val))
 	dA1 := NewBitArray(n, new(big.Int).Xor(&eA1.val, &ksA1.val))
+	fmt.Printf("N (nonce) : %x\n", nA1)
 	fmt.Printf("P (plain) : %x\n", plaintext)
 	fmt.Printf("E (Alice) : %x\n", eA1)
 	fmt.Printf("D (Bob)   : %x\n", dA1)

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -9,7 +9,7 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
-    v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
+    v1.5.9: HSKE-NL-A1 per-session nonce (lcg_next XOR K); nl_fscx_revolve_v2_inv delta precompute.
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=0xFF00FF).
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(n log n)).
@@ -393,10 +393,12 @@ void loop() {
     /* ---------------------------------------------------------------- */
     Serial.println("--- HSKE-NL-A1 [PQC-HARDENED -- counter-mode with NL-FSCX v1]");
     {
-        /* counter=0: B = K XOR 0 = K */
-        uint32 ks = nl_fscx_revolve_v1(K, K, I_VALUE);
-        uint32 E  = PLAIN ^ ks;
-        uint32 D  = E ^ ks;
+        uint32 N    = lcg_next();              /* per-session nonce            */
+        uint32 base = K ^ N;                   /* session key base = K XOR N   */
+        uint32 ks   = nl_fscx_revolve_v1(base, base, I_VALUE);  /* counter=0  */
+        uint32 E    = PLAIN ^ ks;
+        uint32 D    = E ^ ks;
+        printHexLine("N (nonce) : ", N);
         printHexLine("E (Alice) : ", E);
         printHexLine("D (Bob)   : ", D);
         Serial.println(D == PLAIN ? "+ plaintext correctly decrypted" : "- decryption failed!");

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -18,11 +18,14 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once ---
+    --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv delta precompute ---
 
-    delta(B) is now computed once before the loop and reused each step, eliminating
-    redundant multiply-and-rotate work per iteration.  Loop body: z = y - delta;
-    y = B XOR _m_inv(z).  Reduces per-step cost from O(delta+M^{-1}) to O(M^{-1}).
+    HSKE-NL-A1 now generates a random per-session nonce N and derives the session
+    key base as K XOR N (transmitted alongside ciphertext).  Eliminates keystream
+    reuse when the same long-term key K is used across sessions.
+
+    nl_fscx_revolve_v2_inv precomputes delta(B) once before the loop; loop body:
+    z = y - delta; y = B XOR _m_inv(z).  Eliminates per-step multiply-and-rotate.
 
     --- v1.5.7: precomputed M^{-1} for nl_fscx_v2_inv ---
 
@@ -502,11 +505,13 @@ PQC-HARDENED PROTOCOLS (v1.5.0, C3 hybrid — see SecurityProofs.md §11)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 HSKE-NL-A1 (counter-mode HSKE with NL-FSCX v1):
-  keystream[i] = nl_fscx_revolve_v1(K, K XOR i, n/4)
-  Encrypt:  C = P XOR keystream[counter]
-  Decrypt:  P = C XOR keystream[counter]   (XOR-symmetric)
-  Security: keystream non-linearity defeats linear key-recovery; counter
-            ensures keystream uniqueness per block.  Assumes NL-FSCX v1 as PRF.
+  Nonce:    N = random(n bits)   [per-session; transmitted alongside ciphertext]
+  base      = K XOR N            [session key base]
+  keystream[i] = nl_fscx_revolve_v1(base, base XOR i, n/4)
+  Encrypt:  C = (N, P XOR keystream[0])
+  Decrypt:  base = K XOR N; P = C XOR keystream[0]
+  Security: per-session nonce ensures distinct keystreams across sessions;
+            NL non-linearity defeats linear key-recovery. Assumes NL-FSCX v1 as PRF.
 
 HSKE-NL-A2 (revolve-mode HSKE with NL-FSCX v2):
   Encrypt:  E = nl_fscx_revolve_v2(P, K, r)
@@ -622,11 +627,14 @@ def main():
     # ── PQC-HARDENED protocols ───────────────────────────────────────────────
     print("\n--- HSKE-NL-A1 [PQC-HARDENED — counter-mode with NL-FSCX v1]")
     counter    = 0
-    ks_a1      = nl_fscx_revolve_v1(preshared,
-                                    BitArray(KEYBITS, preshared.uint ^ counter),
+    N_a1       = BitArray.random(KEYBITS)                         # per-session nonce
+    base_a1    = BitArray(KEYBITS, preshared.uint ^ N_a1.uint)   # K XOR N
+    ks_a1      = nl_fscx_revolve_v1(base_a1,
+                                    BitArray(KEYBITS, base_a1.uint ^ counter),
                                     KEYBITS // 4)
     E_a1 = BitArray(KEYBITS, plaintext.uint ^ ks_a1.uint)
     D_a1 = BitArray(KEYBITS, E_a1.uint ^ ks_a1.uint)
+    print(f"N (nonce) : {N_a1.hex}")
     print(f"P (plain) : {plaintext.hex}")
     print(f"E (Alice) : {E_a1.hex}")
     print(f"D (Bob)   : {D_a1.hex}")

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -87,6 +87,7 @@ lbl_r_hpke:  .asciz "r (ephem)   "
 lbl_R_hpke:  .asciz "R = g^r     "
 lbl_E_hpke:  .asciz "E (Bob)     "
 lbl_D_hpke:  .asciz "D (Alice)   "
+lbl_N_nl1:   .asciz "N (nonce)   "
 lbl_ks_nl1:  .asciz "ks (NL-v1)  "
 lbl_E_nl1:   .asciz "E (NL-A1)   "
 lbl_D_nl1:   .asciz "D (NL-A1)   "
@@ -128,6 +129,7 @@ val_E_hpke:  .word 0
 val_dec_key: .word 0
 val_D_hpke:  .word 0
 /* v1.5.0 storage */
+val_nonce_nl1: .word 0
 val_ks_nl1:  .word 0
 val_E_nl1:   .word 0
 val_D_nl1:   .word 0
@@ -523,18 +525,21 @@ hpke_done:
 
     /* ================================================================
        HSKE-NL-A1  (counter-mode with NL-FSCX v1)
-       ks = nl_fscx_revolve_v1(key, key, I_VALUE)
-       E  = plain XOR ks;  D = E XOR ks  (must == plain)
+       N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(base, base, I_VALUE)
+       E = plain XOR ks;  D = E XOR ks  (must == plain)
        ================================================================ */
     ldr     r0, =fmt_hske_nl1_hdr
     bl      printf
 
-    ldr     r0, =val_key
-    ldr     r0, [r0]
+    bl      prng_next               @ r0 = nonce N
+    ldr     r3, =val_nonce_nl1
+    str     r0, [r3]                @ save N
     ldr     r1, =val_key
     ldr     r1, [r1]
+    eor     r0, r0, r1              @ r0 = base = N XOR key
+    mov     r1, r0                  @ r1 = base (counter=0: B = base)
     mov     r2, #I_VALUE
-    bl      nl_fscx_revolve_v1
+    bl      nl_fscx_revolve_v1      @ r0 = ks
     ldr     r3, =val_ks_nl1
     str     r0, [r3]
 
@@ -550,8 +555,8 @@ hpke_done:
     str     r4, [r3]
 
     ldr     r0, =fmt_hex
-    ldr     r1, =lbl_ks_nl1
-    ldr     r2, =val_ks_nl1
+    ldr     r1, =lbl_N_nl1
+    ldr     r2, =val_nonce_nl1
     ldr     r2, [r2]
     bl      printf
     ldr     r0, =fmt_hex

--- a/TODO.md
+++ b/TODO.md
@@ -70,7 +70,11 @@ Counter always starts at 0 per-session. If the same key K is reused across
 sessions the keystream is identical. Fix: generate a random nonce N, derive the
 session base as K XOR N, transmit N alongside ciphertext.
 
-Status: **TODO**
+Status: **DONE (v1.5.9)** — Random nonce N added to HSKE-NL-A1 across all language targets
+(Python, C, Go, Arduino, ARM Thumb-2, NASM i386 suite + test files). Session base is now
+`base = K XOR N`; keystream is `nl_fscx_revolve_v1(base, base XOR ctr, n/4)`. N is generated
+fresh each session and displayed alongside ciphertext. Eliminates keystream reuse when K is
+reused across sessions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Precompute `delta(B)` once in `nl_fscx_revolve_v2_inv` before the r-step loop (TODO #8) — eliminates one multiply-and-rotate per step since B is constant across all revolve steps
- Add per-session random nonce N to HSKE-NL-A1 counter-mode (TODO #3) — session base is now `K XOR N`, preventing keystream reuse when K is reused across sessions; N is displayed alongside ciphertext

Both fixes applied across all 6 language targets: Python, C, Go, Arduino, ARM Thumb-2, NASM i386 (suite + test files). Version bumped to v1.5.9.

## Test plan

- [x] C suite builds clean (`gcc -O2`)
- [x] Python suite shows `N (nonce)` line and `D == P` for HSKE-NL-A1
- [x] C suite shows `N (nonce)` line and `D == P` for HSKE-NL-A1
- [x] ARM suite shows `N (nonce)` line and `+ correct!`
- [x] NASM suite shows `N (nonce)` line and `+ correct!`
- [x] Python test [12] HSKE-NL-A1: 50/50 PASS
- [x] C test [12] HSKE-NL-A1: 50/50 PASS
- [x] Go test [12] HSKE-NL-A1: 50/50 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)