### PR TITLE
v1.5.10: HKEX-RNL KDF seed fix — ROL(K, n/8) breaks step-1 degeneracy

### DIFF
--- a/CryptosuiteTests/Herradura_tests.asm
+++ b/CryptosuiteTests/Herradura_tests.asm
@@ -1,4 +1,4 @@
-;  Herradura KEx -- Correctness Tests v1.5.9
+;  Herradura KEx -- Correctness Tests v1.5.10
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS Schnorr, HPKE El Gamal,
 ;                        NL-FSCX v2 inv, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS=32; I_VALUE=8; R_VALUE=24; HKEX-RNL N=32, q=65537, p=4096
@@ -53,7 +53,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura KEx v1.5.9 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr         db "=== Herradura KEx v1.5.10 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
     hdr_l       equ $-hdr
 
     t1_hdr      db "[1] HKEX-GF key exchange correctness: sk_alice == sk_bob (20 iterations)", 10

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=ROL(K,n/8), v1+v2).
     v1.5.9: nl_fscx_revolve_v2_inv_{32,64,128} precompute delta(B) once — eliminates per-step multiply.
     v1.5.7: m_inv_32/64/128 use precomputed rotation tables (0x6DB6DB6D / constants).
     v1.5.6: rnl_rand_coeff bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -1573,8 +1574,13 @@ static void test_hkex_rnl_correctness(void)
                 K_A = rnl32_agree(s_A, c_B);
                 K_B = rnl32_agree(s_B, c_A);
                 if (K_A == K_B) ok_raw++;
-                if (nl_fscx_revolve_v1_32(K_A, K_A, NL_I32) ==
-                    nl_fscx_revolve_v1_32(K_B, K_B, NL_I32)) ok_sk++;
+                {   /* two-pass KDF: seed=ROL32(K,4); mid=v1(seed,K,n/4); sk=v2(mid,K,n/4) */
+                    uint32_t sA = nl_fscx_revolve_v2_32(
+                        nl_fscx_revolve_v1_32((K_A<<4)|(K_A>>28), K_A, NL_I32), K_A, NL_I32);
+                    uint32_t sB = nl_fscx_revolve_v2_32(
+                        nl_fscx_revolve_v1_32((K_B<<4)|(K_B>>28), K_B, NL_I32), K_B, NL_I32);
+                    if (sA == sB) ok_sk++;
+                }
                 if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
             }
         } else {
@@ -1590,8 +1596,13 @@ static void test_hkex_rnl_correctness(void)
                 K_A64 = rnl_agree_n(s_A64, c_B64, 64);
                 K_B64 = rnl_agree_n(s_B64, c_A64, 64);
                 if (K_A64 == K_B64) ok_raw++;
-                if (nl_fscx_revolve_v1_64(K_A64, K_A64, NL_I64) ==
-                    nl_fscx_revolve_v1_64(K_B64, K_B64, NL_I64)) ok_sk++;
+                {   /* two-pass KDF: seed=ROL64(K,8); mid=v1(seed,K,n/4); sk=v2(mid,K,n/4) */
+                    uint64_t sA64 = nl_fscx_revolve_v2_64(
+                        nl_fscx_revolve_v1_64((K_A64<<8)|(K_A64>>56), K_A64, NL_I64), K_A64, NL_I64);
+                    uint64_t sB64 = nl_fscx_revolve_v2_64(
+                        nl_fscx_revolve_v1_64((K_B64<<8)|(K_B64>>56), K_B64, NL_I64), K_B64, NL_I64);
+                    if (sA64 == sB64) ok_sk++;
+                }
                 if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
             }
         }
@@ -2017,7 +2028,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.9 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.5.10 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,7 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
-    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=ROL(K,n/8), v1+v2).
+    v1.5.10: HKEX-RNL KDF seed fix — seed=ROL(K,n/8) breaks step-1 degeneracy.
     v1.5.9: nl_fscx_revolve_v2_inv_{32,64,128} precompute delta(B) once — eliminates per-step multiply.
     v1.5.7: m_inv_32/64/128 use precomputed rotation tables (0x6DB6DB6D / constants).
     v1.5.6: rnl_rand_coeff bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -1574,13 +1574,8 @@ static void test_hkex_rnl_correctness(void)
                 K_A = rnl32_agree(s_A, c_B);
                 K_B = rnl32_agree(s_B, c_A);
                 if (K_A == K_B) ok_raw++;
-                {   /* two-pass KDF: seed=ROL32(K,4); mid=v1(seed,K,n/4); sk=v2(mid,K,n/4) */
-                    uint32_t sA = nl_fscx_revolve_v2_32(
-                        nl_fscx_revolve_v1_32((K_A<<4)|(K_A>>28), K_A, NL_I32), K_A, NL_I32);
-                    uint32_t sB = nl_fscx_revolve_v2_32(
-                        nl_fscx_revolve_v1_32((K_B<<4)|(K_B>>28), K_B, NL_I32), K_B, NL_I32);
-                    if (sA == sB) ok_sk++;
-                }
+                if (nl_fscx_revolve_v1_32((K_A<<4)|(K_A>>28), K_A, NL_I32) ==
+                    nl_fscx_revolve_v1_32((K_B<<4)|(K_B>>28), K_B, NL_I32)) ok_sk++;
                 if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
             }
         } else {
@@ -1596,13 +1591,8 @@ static void test_hkex_rnl_correctness(void)
                 K_A64 = rnl_agree_n(s_A64, c_B64, 64);
                 K_B64 = rnl_agree_n(s_B64, c_A64, 64);
                 if (K_A64 == K_B64) ok_raw++;
-                {   /* two-pass KDF: seed=ROL64(K,8); mid=v1(seed,K,n/4); sk=v2(mid,K,n/4) */
-                    uint64_t sA64 = nl_fscx_revolve_v2_64(
-                        nl_fscx_revolve_v1_64((K_A64<<8)|(K_A64>>56), K_A64, NL_I64), K_A64, NL_I64);
-                    uint64_t sB64 = nl_fscx_revolve_v2_64(
-                        nl_fscx_revolve_v1_64((K_B64<<8)|(K_B64>>56), K_B64, NL_I64), K_B64, NL_I64);
-                    if (sA64 == sB64) ok_sk++;
-                }
+                if (nl_fscx_revolve_v1_64((K_A64<<8)|(K_A64>>56), K_A64, NL_I64) ==
+                    nl_fscx_revolve_v1_64((K_B64<<8)|(K_B64>>56), K_B64, NL_I64)) ok_sk++;
                 if ((i & 15) == 15 && time_exceeded(&t0)) { N = i + 1; break; }
             }
         }

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=RotateLeft(K,n/8), v1+v2).
     v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: MInv uses precomputed rotation table (sync.Map cache per bit-size).
     v1.5.6: rnlRandPoly bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -964,8 +965,10 @@ func testHkexRnlCorrectness() {
 			KA := rnlAgree(sA, CB, rnlQ, rnlP, rnlPP, nRnl, nRnl)
 			KB := rnlAgree(sB, CA, rnlQ, rnlP, rnlPP, nRnl, nRnl)
 			if KA.Equal(KB) { okRaw++ }
-			skA := NlFscxRevolveV1(KA, KA, nRnl/4)
-			skB := NlFscxRevolveV1(KB, KB, nRnl/4)
+			seedA := KA.RotateLeft(nRnl / 8)
+			skA   := NlFscxRevolveV2(NlFscxRevolveV1(seedA, KA, nRnl/4), KA, nRnl/4)
+			seedB := KB.RotateLeft(nRnl / 8)
+			skB   := NlFscxRevolveV2(NlFscxRevolveV1(seedB, KB, nRnl/4), KB, nRnl/4)
 			if skA.Equal(skB) { okSk++ }
 			if i&15 == 15 && timeExceeded(t0) { trials = i + 1; break }
 		}
@@ -1258,7 +1261,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.9 \u2014 Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.10 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,5 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
-    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=RotateLeft(K,n/8), v1+v2).
+    v1.5.10: HKEX-RNL KDF seed fix — seed=RotateLeft(K,n/8) breaks step-1 degeneracy.
     v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: MInv uses precomputed rotation table (sync.Map cache per bit-size).
     v1.5.6: rnlRandPoly bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -965,10 +965,8 @@ func testHkexRnlCorrectness() {
 			KA := rnlAgree(sA, CB, rnlQ, rnlP, rnlPP, nRnl, nRnl)
 			KB := rnlAgree(sB, CA, rnlQ, rnlP, rnlPP, nRnl, nRnl)
 			if KA.Equal(KB) { okRaw++ }
-			seedA := KA.RotateLeft(nRnl / 8)
-			skA   := NlFscxRevolveV2(NlFscxRevolveV1(seedA, KA, nRnl/4), KA, nRnl/4)
-			seedB := KB.RotateLeft(nRnl / 8)
-			skB   := NlFscxRevolveV2(NlFscxRevolveV1(seedB, KB, nRnl/4), KB, nRnl/4)
+			skA := NlFscxRevolveV1(KA.RotateLeft(nRnl/8), KA, nRnl/4)
+			skB := NlFscxRevolveV1(KB.RotateLeft(nRnl/8), KB, nRnl/4)
 			if skA.Equal(skB) { okSk++ }
 			if i&15 == 15 && timeExceeded(t0) { trials = i + 1; break }
 		}

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -7,7 +7,7 @@
     Target: Any Arduino board with Serial support.
     Upload via Arduino IDE. Monitor at 9600 baud.
 
-    v1.5.10: HKEX-RNL KDF: seed=ROL32(K,4); mid=nl_fscx_revolve_v1(seed,K,I); sk=nl_fscx_revolve_v2(mid,K,I).
+    v1.5.10: HKEX-RNL KDF seed fix: seed=ROL32(K,4); sk=nl_fscx_revolve_v1(seed,K,I).
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(N log N)).
     v1.5.3: HKEX-RNL secret sampler upgraded to CBD(eta=1); zero-mean distribution.
@@ -382,10 +382,8 @@ void test_hkex_rnl() {
         uint32 KB = rnl_agree(s_B, C_A);
         if (KA == KB) {
             ok_raw++;
-            uint32 seedA = _rol32(KA, 4);
-            uint32 skA   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seedA, KA, I_VALUE), KA, I_VALUE);
-            uint32 seedB = _rol32(KB, 4);
-            uint32 skB   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seedB, KB, I_VALUE), KB, I_VALUE);
+            uint32 skA = nl_fscx_revolve_v1(_rol32(KA, 4), KA, I_VALUE);
+            uint32 skB = nl_fscx_revolve_v1(_rol32(KB, 4), KB, I_VALUE);
             if (skA == skB) ok_sk++;
         }
     }

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -1,4 +1,4 @@
-/*  Herradura KEx — Security Tests v1.5.9 (Arduino, 32-bit)
+/*  Herradura KEx — Security Tests v1.5.10 (Arduino, 32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, NL-FSCX, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -7,6 +7,7 @@
     Target: Any Arduino board with Serial support.
     Upload via Arduino IDE. Monitor at 9600 baud.
 
+    v1.5.10: HKEX-RNL KDF: seed=ROL32(K,4); mid=nl_fscx_revolve_v1(seed,K,I); sk=nl_fscx_revolve_v2(mid,K,I).
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.4: NTT-based negacyclic polynomial multiplication (O(N log N)).
     v1.5.3: HKEX-RNL secret sampler upgraded to CBD(eta=1); zero-mean distribution.
@@ -381,8 +382,10 @@ void test_hkex_rnl() {
         uint32 KB = rnl_agree(s_B, C_A);
         if (KA == KB) {
             ok_raw++;
-            uint32 skA = nl_fscx_revolve_v1(KA, KA, I_VALUE);
-            uint32 skB = nl_fscx_revolve_v1(KB, KB, I_VALUE);
+            uint32 seedA = _rol32(KA, 4);
+            uint32 skA   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seedA, KA, I_VALUE), KA, I_VALUE);
+            uint32 seedB = _rol32(KB, 4);
+            uint32 skB   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seedB, KB, I_VALUE), KB, I_VALUE);
             if (skA == skB) ok_sk++;
         }
     }

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,6 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
-    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=ROL(K,n/8), v1+v2).
+    v1.5.10: HKEX-RNL KDF seed fix — seed=ROL(K,n/8) breaks step-1 degeneracy.
     v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: _m_inv uses precomputed rotation table (lazy init, cached per bit-size).
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -686,12 +686,8 @@ def test_hkex_rnl_correctness():
             K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
             K_B = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
             if K_A == K_B: ok_raw += 1
-            seed_A = K_A.rotated(n_rnl // 8)
-            sk_A   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seed_A, K_A, n_rnl // 4),
-                                        K_A, n_rnl // 4)
-            seed_B = K_B.rotated(n_rnl // 8)
-            sk_B   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seed_B, K_B, n_rnl // 4),
-                                        K_B, n_rnl // 4)
+            sk_A = nl_fscx_revolve_v1(K_A.rotated(n_rnl // 8), K_A, n_rnl // 4)
+            sk_B = nl_fscx_revolve_v1(K_B.rotated(n_rnl // 8), K_B, n_rnl // 4)
             if sk_A == sk_B: ok_sk += 1
         status = "PASS" if ok_raw >= n_run * 90 // 100 else "FAIL"
         print(f"    n={n_rnl:3d}  raw agree={ok_raw}/{n_run}  sk agree={ok_sk}/{n_run}  [{status}]")

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.10: HKEX-RNL KDF upgraded to two-pass chain (seed=ROL(K,n/8), v1+v2).
     v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: _m_inv uses precomputed rotation table (lazy init, cached per bit-size).
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=16711935).
@@ -685,8 +686,12 @@ def test_hkex_rnl_correctness():
             K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
             K_B = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, n_rnl)
             if K_A == K_B: ok_raw += 1
-            sk_A = nl_fscx_revolve_v1(K_A, K_A, n_rnl // 4)
-            sk_B = nl_fscx_revolve_v1(K_B, K_B, n_rnl // 4)
+            seed_A = K_A.rotated(n_rnl // 8)
+            sk_A   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seed_A, K_A, n_rnl // 4),
+                                        K_A, n_rnl // 4)
+            seed_B = K_B.rotated(n_rnl // 8)
+            sk_B   = nl_fscx_revolve_v2(nl_fscx_revolve_v1(seed_B, K_B, n_rnl // 4),
+                                        K_B, n_rnl // 4)
             if sk_A == sk_B: ok_sk += 1
         status = "PASS" if ok_raw >= n_run * 90 // 100 else "FAIL"
         print(f"    n={n_rnl:3d}  raw agree={ok_raw}/{n_run}  sk agree={ok_sk}/{n_run}  [{status}]")
@@ -892,7 +897,7 @@ def bench_hkex_rnl_handshake():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.9 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.5.10 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -920,7 +925,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.9 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.10 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/CryptosuiteTests/Herradura_tests.s
+++ b/CryptosuiteTests/Herradura_tests.s
@@ -1,4 +1,4 @@
-/*  Herradura KEx -- Correctness Tests v1.5.9
+/*  Herradura KEx -- Correctness Tests v1.5.10
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        NL-FSCX v2 inv, HSKE-NL-A2,
                                        HKEX-RNL, HPKS-NL, HPKE-NL
@@ -31,7 +31,7 @@
     .data
     .balign 4
 
-fmt_hdr:  .asciz "=== Herradura KEx v1.5.9 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
+fmt_hdr:  .asciz "=== Herradura KEx v1.5.10 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
 fmt_t1:   .asciz "[1] HKEX-GF key exchange: sk_alice == sk_bob (20 iterations)\n"
 fmt_t2:   .asciz "[2] HSKE encrypt+decrypt round-trip: D == plaintext (100 iterations)\n"
 fmt_t3:   .asciz "[3] HPKS Schnorr: g^s * C^e == R (20 iterations)\n"

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -661,26 +661,20 @@ _start:
     call rnl_agree
     mov  [val_KB], eax
 
-    ; skA = two-pass KDF(KA): seed=ROL32(KA,4); mid=v1(seed,KA,I); sk=v2(mid,KA,I)
+    ; skA = nl_fscx_revolve_v1(ROL32(KA,4), KA, I_VALUE)
     mov  eax, [val_KA]
     rol  eax, 4              ; seed = ROL32(KA, 4)  [n/8 = 32/8 = 4]
     mov  ebx, [val_KA]
     mov  ecx, I_VALUE
-    call nl_fscx_revolve_v1  ; eax = mid
-    mov  ebx, [val_KA]       ; reload B = KA
-    mov  ecx, I_VALUE
-    call nl_fscx_revolve_v2  ; eax = sk
+    call nl_fscx_revolve_v1  ; eax = sk
     mov  [val_sk_rnl], eax
 
-    ; skB = two-pass KDF(KB)
+    ; skB = nl_fscx_revolve_v1(ROL32(KB,4), KB, I_VALUE)
     mov  eax, [val_KB]
     rol  eax, 4
     mov  ebx, [val_KB]
     mov  ecx, I_VALUE
     call nl_fscx_revolve_v1
-    mov  ebx, [val_KB]
-    mov  ecx, I_VALUE
-    call nl_fscx_revolve_v2
 
     push eax
     mov  eax, lbl_sk_alice

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.9
+;  Herradura Cryptographic Suite v1.5.10
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -95,7 +95,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.5.9 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.5.10 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "
@@ -661,18 +661,26 @@ _start:
     call rnl_agree
     mov  [val_KB], eax
 
-    ; skA = nl_fscx_revolve_v1(KA, KA, I_VALUE)
+    ; skA = two-pass KDF(KA): seed=ROL32(KA,4); mid=v1(seed,KA,I); sk=v2(mid,KA,I)
     mov  eax, [val_KA]
+    rol  eax, 4              ; seed = ROL32(KA, 4)  [n/8 = 32/8 = 4]
     mov  ebx, [val_KA]
     mov  ecx, I_VALUE
-    call nl_fscx_revolve_v1
+    call nl_fscx_revolve_v1  ; eax = mid
+    mov  ebx, [val_KA]       ; reload B = KA
+    mov  ecx, I_VALUE
+    call nl_fscx_revolve_v2  ; eax = sk
     mov  [val_sk_rnl], eax
 
-    ; skB = nl_fscx_revolve_v1(KB, KB, I_VALUE)
+    ; skB = two-pass KDF(KB)
     mov  eax, [val_KB]
+    rol  eax, 4
     mov  ebx, [val_KB]
     mov  ecx, I_VALUE
     call nl_fscx_revolve_v1
+    mov  ebx, [val_KB]
+    mov  ecx, I_VALUE
+    call nl_fscx_revolve_v2
 
     push eax
     mov  eax, lbl_sk_alice

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.9
+/*  Herradura Cryptographic Suite v1.5.10
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,14 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.10: HKEX-RNL two-pass KDF with ROL(K, n/8) seed ---
+
+    HKEX-RNL KDF upgraded to two-pass chain:
+      seed = ROL(K, n/8); mid = nl_fscx_revolve_v1(seed, K, n/4);
+      sk   = nl_fscx_revolve_v2(mid, K, n/4)
+    Eliminates step-1 degeneracy (fscx(K,K)=0) and chains v1 carry-XOR
+    with v2 multiplicative-delta non-linearity.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv_ba delta precompute ---
     HSKE-NL-A1 now generates a random per-session nonce N and derives session base
@@ -768,7 +776,8 @@ HKEX-RNL (Ring-LWR key exchange, n=256):
     Alice: s_A small, C_A = round_p(m_blind * s_A)
     Bob:   s_B small, C_B = round_p(m_blind * s_B)
     K_A = round_pp(s_A * lift(C_B));  K_B = round_pp(s_B * lift(C_A))
-    K_A ~= K_B (with high probability); sk = nl_fscx_revolve_v1(K, K, I_VALUE)
+    K_A ~= K_B (with high probability)
+    KDF: seed=ba_rol_k(K,n/8); mid=nl_fscx_revolve_v1(seed,K,n/4); sk=nl_fscx_revolve_v2(mid,K,n/4)
 
 HPKS-NL (NL-hardened Schnorr, 256-bit):
     e = nl_fscx_revolve_v1(R, P, I_VALUE)  (NL challenge)
@@ -939,8 +948,13 @@ int main(void)
         rnl_keygen(s_B_poly, C_B, m_blind, urnd);
         rnl_agree(&KA, s_A_poly, C_B);
         rnl_agree(&KB, s_B_poly, C_A);
-        nl_fscx_revolve_v1_ba(&skA_nl, &KA, &KA, I_VALUE);
-        nl_fscx_revolve_v1_ba(&skB_nl, &KB, &KB, I_VALUE);
+        BitArray seedA, midA, seedB, midB;
+        ba_rol_k(&seedA, &KA, KEYBYTES);           /* ROL(K, n/8) = ROL(K, 32) */
+        nl_fscx_revolve_v1_ba(&midA, &seedA, &KA, I_VALUE);
+        nl_fscx_revolve_v2_ba(&skA_nl, &midA, &KA, I_VALUE);
+        ba_rol_k(&seedB, &KB, KEYBYTES);
+        nl_fscx_revolve_v1_ba(&midB, &seedB, &KB, I_VALUE);
+        nl_fscx_revolve_v2_ba(&skB_nl, &midB, &KB, I_VALUE);
         ba_print_hex("sk (Alice): ", &skA_nl);
         ba_print_hex("sk (Bob)  : ", &skB_nl);
         if (ba_equal(&KA, &KB)) {

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -17,13 +17,11 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.10: HKEX-RNL two-pass KDF with ROL(K, n/8) seed ---
+    --- v1.5.10: HKEX-RNL KDF seed fix — ROL(K, n/8) breaks step-1 degeneracy ---
 
-    HKEX-RNL KDF upgraded to two-pass chain:
-      seed = ROL(K, n/8); mid = nl_fscx_revolve_v1(seed, K, n/4);
-      sk   = nl_fscx_revolve_v2(mid, K, n/4)
-    Eliminates step-1 degeneracy (fscx(K,K)=0) and chains v1 carry-XOR
-    with v2 multiplicative-delta non-linearity.
+    HKEX-RNL KDF: seed = ba_rol_k(K, n/8); sk = nl_fscx_revolve_v1(seed, K, n/4).
+    When A0=B=K, fscx(K,K)=0 so step 1 was a pure rotation (linear).
+    ROL(K,n/8) ensures seed!=K, activating full carry non-linearity from step 1.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv_ba delta precompute ---
     HSKE-NL-A1 now generates a random per-session nonce N and derives session base
@@ -777,7 +775,7 @@ HKEX-RNL (Ring-LWR key exchange, n=256):
     Bob:   s_B small, C_B = round_p(m_blind * s_B)
     K_A = round_pp(s_A * lift(C_B));  K_B = round_pp(s_B * lift(C_A))
     K_A ~= K_B (with high probability)
-    KDF: seed=ba_rol_k(K,n/8); mid=nl_fscx_revolve_v1(seed,K,n/4); sk=nl_fscx_revolve_v2(mid,K,n/4)
+    KDF: seed=ba_rol_k(K,n/8); sk=nl_fscx_revolve_v1(seed,K,n/4)
 
 HPKS-NL (NL-hardened Schnorr, 256-bit):
     e = nl_fscx_revolve_v1(R, P, I_VALUE)  (NL challenge)
@@ -948,13 +946,11 @@ int main(void)
         rnl_keygen(s_B_poly, C_B, m_blind, urnd);
         rnl_agree(&KA, s_A_poly, C_B);
         rnl_agree(&KB, s_B_poly, C_A);
-        BitArray seedA, midA, seedB, midB;
+        BitArray seedA, seedB;
         ba_rol_k(&seedA, &KA, KEYBYTES);           /* ROL(K, n/8) = ROL(K, 32) */
-        nl_fscx_revolve_v1_ba(&midA, &seedA, &KA, I_VALUE);
-        nl_fscx_revolve_v2_ba(&skA_nl, &midA, &KA, I_VALUE);
+        nl_fscx_revolve_v1_ba(&skA_nl, &seedA, &KA, I_VALUE);
         ba_rol_k(&seedB, &KB, KEYBYTES);
-        nl_fscx_revolve_v1_ba(&midB, &seedB, &KB, I_VALUE);
-        nl_fscx_revolve_v2_ba(&skB_nl, &midB, &KB, I_VALUE);
+        nl_fscx_revolve_v1_ba(&skB_nl, &seedB, &KB, I_VALUE);
         ba_print_hex("sk (Alice): ", &skA_nl);
         ba_print_hex("sk (Bob)  : ", &skB_nl);
         if (ba_equal(&KA, &KB)) {

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.9
+/*  Herradura Cryptographic Suite v1.5.10
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,14 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.10: HKEX-RNL two-pass KDF with RotateLeft(K, n/8) seed ---
+
+    HKEX-RNL KDF upgraded to two-pass chain:
+      seed = RotateLeft(K, n/8); mid = NlFscxRevolveV1(seed, K, n/4);
+      sk   = NlFscxRevolveV2(mid, K, n/4)
+    Eliminates step-1 degeneracy (Fscx(K,K)=0) and chains v1 carry-XOR
+    with v2 multiplicative-delta non-linearity.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; NlFscxRevolveV2Inv delta precompute ---
     HSKE-NL-A1 now generates a random per-session nonce N and derives session base
@@ -673,8 +681,12 @@ func main() {
 	sB, CB := rnlKeygen(mBlind, nRnl, rnlQ, rnlP)
 	kRawA := rnlAgree(sA, CB, rnlQ, rnlP, rnlPP, nRnl, n)
 	kRawB := rnlAgree(sB, CA, rnlQ, rnlP, rnlPP, nRnl, n)
-	skRnlA := NlFscxRevolveV1(kRawA, kRawA, n/4)
-	skRnlB := NlFscxRevolveV1(kRawB, kRawB, n/4)
+	seedA  := kRawA.RotateLeft(n / 8)
+	midA   := NlFscxRevolveV1(seedA, kRawA, n/4)
+	skRnlA := NlFscxRevolveV2(midA, kRawA, n/4)
+	seedB  := kRawB.RotateLeft(n / 8)
+	midB   := NlFscxRevolveV1(seedB, kRawB, n/4)
+	skRnlB := NlFscxRevolveV2(midB, kRawB, n/4)
 	fmt.Printf("sk (Alice): %x\n", skRnlA)
 	fmt.Printf("sk (Bob)  : %x\n", skRnlB)
 	if kRawA.Equal(kRawB) {

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -17,13 +17,11 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.10: HKEX-RNL two-pass KDF with RotateLeft(K, n/8) seed ---
+    --- v1.5.10: HKEX-RNL KDF seed fix — RotateLeft(K, n/8) breaks step-1 degeneracy ---
 
-    HKEX-RNL KDF upgraded to two-pass chain:
-      seed = RotateLeft(K, n/8); mid = NlFscxRevolveV1(seed, K, n/4);
-      sk   = NlFscxRevolveV2(mid, K, n/4)
-    Eliminates step-1 degeneracy (Fscx(K,K)=0) and chains v1 carry-XOR
-    with v2 multiplicative-delta non-linearity.
+    HKEX-RNL KDF: seed = K.RotateLeft(n/8); sk = NlFscxRevolveV1(seed, K, n/4).
+    When A0=B=K, Fscx(K,K)=0 so step 1 was a pure rotation (linear in K).
+    RotateLeft(K,n/8) ensures seed!=K, activating full carry non-linearity from step 1.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; NlFscxRevolveV2Inv delta precompute ---
     HSKE-NL-A1 now generates a random per-session nonce N and derives session base
@@ -681,12 +679,8 @@ func main() {
 	sB, CB := rnlKeygen(mBlind, nRnl, rnlQ, rnlP)
 	kRawA := rnlAgree(sA, CB, rnlQ, rnlP, rnlPP, nRnl, n)
 	kRawB := rnlAgree(sB, CA, rnlQ, rnlP, rnlPP, nRnl, n)
-	seedA  := kRawA.RotateLeft(n / 8)
-	midA   := NlFscxRevolveV1(seedA, kRawA, n/4)
-	skRnlA := NlFscxRevolveV2(midA, kRawA, n/4)
-	seedB  := kRawB.RotateLeft(n / 8)
-	midB   := NlFscxRevolveV1(seedB, kRawB, n/4)
-	skRnlB := NlFscxRevolveV2(midB, kRawB, n/4)
+	skRnlA := NlFscxRevolveV1(kRawA.RotateLeft(n/8), kRawA, n/4)
+	skRnlB := NlFscxRevolveV1(kRawB.RotateLeft(n/8), kRawB, n/4)
 	fmt.Printf("sk (Alice): %x\n", skRnlA)
 	fmt.Printf("sk (Bob)  : %x\n", skRnlB)
 	if kRawA.Equal(kRawB) {

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.9 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.10 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32
 
@@ -9,6 +9,7 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
+    v1.5.10: HKEX-RNL two-pass KDF: seed=ROL32(K,4); mid=nl_fscx_revolve_v1(seed,K,I); sk=nl_fscx_revolve_v2(mid,K,I).
     v1.5.9: HSKE-NL-A1 per-session nonce (lcg_next XOR K); nl_fscx_revolve_v2_inv delta precompute.
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=0xFF00FF).
@@ -433,8 +434,12 @@ void loop() {
         rnl_keygen(s_B, C_B, m_blind);
         uint32 KA = rnl_agree(s_A, C_B);
         uint32 KB = rnl_agree(s_B, C_A);
-        uint32 skA = nl_fscx_revolve_v1(KA, KA, I_VALUE);
-        uint32 skB = nl_fscx_revolve_v1(KB, KB, I_VALUE);
+        uint32 seedA = _rol32(KA, 4);  /* ROL(K, n/8) where n=32 */
+        uint32 midA  = nl_fscx_revolve_v1(seedA, KA, I_VALUE);
+        uint32 skA   = nl_fscx_revolve_v2(midA,  KA, I_VALUE);
+        uint32 seedB = _rol32(KB, 4);
+        uint32 midB  = nl_fscx_revolve_v1(seedB, KB, I_VALUE);
+        uint32 skB   = nl_fscx_revolve_v2(midB,  KB, I_VALUE);
         printHexLine("sk (Alice): ", skA);
         printHexLine("sk (Bob)  : ", skB);
         if (KA == KB) {

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -9,7 +9,7 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
-    v1.5.10: HKEX-RNL two-pass KDF: seed=ROL32(K,4); mid=nl_fscx_revolve_v1(seed,K,I); sk=nl_fscx_revolve_v2(mid,K,I).
+    v1.5.10: HKEX-RNL KDF seed fix: seed=ROL32(K,4); sk=nl_fscx_revolve_v1(seed,K,I).
     v1.5.9: HSKE-NL-A1 per-session nonce (lcg_next XOR K); nl_fscx_revolve_v2_inv delta precompute.
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
     v1.5.6: rnl_rand_poly bias fix — 3-byte rejection sampling (threshold=0xFF00FF).
@@ -434,12 +434,8 @@ void loop() {
         rnl_keygen(s_B, C_B, m_blind);
         uint32 KA = rnl_agree(s_A, C_B);
         uint32 KB = rnl_agree(s_B, C_A);
-        uint32 seedA = _rol32(KA, 4);  /* ROL(K, n/8) where n=32 */
-        uint32 midA  = nl_fscx_revolve_v1(seedA, KA, I_VALUE);
-        uint32 skA   = nl_fscx_revolve_v2(midA,  KA, I_VALUE);
-        uint32 seedB = _rol32(KB, 4);
-        uint32 midB  = nl_fscx_revolve_v1(seedB, KB, I_VALUE);
-        uint32 skB   = nl_fscx_revolve_v2(midB,  KB, I_VALUE);
+        uint32 skA = nl_fscx_revolve_v1(_rol32(KA, 4), KA, I_VALUE);
+        uint32 skB = nl_fscx_revolve_v1(_rol32(KB, 4), KB, I_VALUE);
         printHexLine("sk (Alice): ", skA);
         printHexLine("sk (Bob)  : ", skB);
         if (KA == KB) {

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -18,15 +18,15 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-    --- v1.5.10: HKEX-RNL two-pass KDF with ROL(K, n/8) seed ---
+    --- v1.5.10: HKEX-RNL KDF seed fix — ROL(K, n/8) breaks step-1 degeneracy ---
 
-    HKEX-RNL KDF upgraded from a single NL-FSCX v1 pass to a two-pass chain:
+    HKEX-RNL KDF now derives the initial state as seed = ROL(K, n/8) instead of
+    using K directly:
       seed = ROL(K, n/8)
-      mid  = nl_fscx_revolve_v1(seed, K, n/4)
-      sk   = nl_fscx_revolve_v2(mid,  K, n/4)
-    Eliminates the step-1 degeneracy (fscx(K,K)=0 when A0=B=K) and chains
-    two algebraically independent non-linearities (v1 carry-XOR, v2 multiplicative
-    delta) so an attacker must break both structures simultaneously.
+      sk   = nl_fscx_revolve_v1(seed, K, n/4)
+    When A0 = B = K, fscx(K,K) = 0, making step 1 a pure rotation (linear in K).
+    ROL(K, n/8) ensures seed != K, so fscx(seed, K) != 0 and full non-linear carry
+    mixing is active from the very first step.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv delta precompute ---
 
@@ -534,9 +534,7 @@ HKEX-RNL (Ring-LWR key exchange — quantum-resistant):
   Alice:    s_A small private; C_A = round_p(m_blind * s_A)
   Bob:      s_B small private; C_B = round_p(m_blind * s_B)
   Agree:    K_A = round_pp(s_A * lift(C_B));  K_B = round_pp(s_B * lift(C_A))
-  KDF:      seed = ROL(K_raw, n/8)
-            mid  = nl_fscx_revolve_v1(seed, K_raw, n/4)
-            sk   = nl_fscx_revolve_v2(mid,  K_raw, n/4)
+  KDF:      seed = ROL(K_raw, n/8); sk = nl_fscx_revolve_v1(seed, K_raw, n/4)
   Security: Reduces to Ring-LWR on R_q = Z_q[x]/(x^n+1); no known quantum
             polynomial-time attack.  a_rand blinding = standard Ring-LWR hardness.
   Parameters: n=256, q=65537, p=4096, pp=2, eta=1 (CBD(1) secret distribution).
@@ -676,12 +674,8 @@ def main():
     s_B, C_B = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
     K_raw_A  = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, KEYBITS)
     K_raw_B  = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, KEYBITS)
-    seed_A   = K_raw_A.rotated(KEYBITS // 8)
-    mid_A    = nl_fscx_revolve_v1(seed_A, K_raw_A, KEYBITS // 4)
-    sk_rnl_A = nl_fscx_revolve_v2(mid_A,  K_raw_A, KEYBITS // 4)
-    seed_B   = K_raw_B.rotated(KEYBITS // 8)
-    mid_B    = nl_fscx_revolve_v1(seed_B, K_raw_B, KEYBITS // 4)
-    sk_rnl_B = nl_fscx_revolve_v2(mid_B,  K_raw_B, KEYBITS // 4)
+    sk_rnl_A = nl_fscx_revolve_v1(K_raw_A.rotated(KEYBITS // 8), K_raw_A, KEYBITS // 4)
+    sk_rnl_B = nl_fscx_revolve_v1(K_raw_B.rotated(KEYBITS // 8), K_raw_B, KEYBITS // 4)
     print(f"sk (Alice): {sk_rnl_A.hex}")
     print(f"sk (Bob)  : {sk_rnl_B.hex}")
     if K_raw_A == K_raw_B:

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.5.9
+    Herradura Cryptographic Suite v1.5.10
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,6 +17,16 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.10: HKEX-RNL two-pass KDF with ROL(K, n/8) seed ---
+
+    HKEX-RNL KDF upgraded from a single NL-FSCX v1 pass to a two-pass chain:
+      seed = ROL(K, n/8)
+      mid  = nl_fscx_revolve_v1(seed, K, n/4)
+      sk   = nl_fscx_revolve_v2(mid,  K, n/4)
+    Eliminates the step-1 degeneracy (fscx(K,K)=0 when A0=B=K) and chains
+    two algebraically independent non-linearities (v1 carry-XOR, v2 multiplicative
+    delta) so an attacker must break both structures simultaneously.
 
     --- v1.5.9: HSKE-NL-A1 per-session nonce; nl_fscx_revolve_v2_inv delta precompute ---
 
@@ -524,7 +534,9 @@ HKEX-RNL (Ring-LWR key exchange — quantum-resistant):
   Alice:    s_A small private; C_A = round_p(m_blind * s_A)
   Bob:      s_B small private; C_B = round_p(m_blind * s_B)
   Agree:    K_A = round_pp(s_A * lift(C_B));  K_B = round_pp(s_B * lift(C_A))
-  KDF:      sk = nl_fscx_revolve_v1(K_raw, K_raw, n/4)
+  KDF:      seed = ROL(K_raw, n/8)
+            mid  = nl_fscx_revolve_v1(seed, K_raw, n/4)
+            sk   = nl_fscx_revolve_v2(mid,  K_raw, n/4)
   Security: Reduces to Ring-LWR on R_q = Z_q[x]/(x^n+1); no known quantum
             polynomial-time attack.  a_rand blinding = standard Ring-LWR hardness.
   Parameters: n=256, q=65537, p=4096, pp=2, eta=1 (CBD(1) secret distribution).
@@ -664,8 +676,12 @@ def main():
     s_B, C_B = _rnl_keygen(m_blind, n_rnl, RNLQ, RNLP, RNLB)
     K_raw_A  = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n_rnl, KEYBITS)
     K_raw_B  = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n_rnl, KEYBITS)
-    sk_rnl_A = nl_fscx_revolve_v1(K_raw_A, K_raw_A, KEYBITS // 4)
-    sk_rnl_B = nl_fscx_revolve_v1(K_raw_B, K_raw_B, KEYBITS // 4)
+    seed_A   = K_raw_A.rotated(KEYBITS // 8)
+    mid_A    = nl_fscx_revolve_v1(seed_A, K_raw_A, KEYBITS // 4)
+    sk_rnl_A = nl_fscx_revolve_v2(mid_A,  K_raw_A, KEYBITS // 4)
+    seed_B   = K_raw_B.rotated(KEYBITS // 8)
+    mid_B    = nl_fscx_revolve_v1(seed_B, K_raw_B, KEYBITS // 4)
+    sk_rnl_B = nl_fscx_revolve_v2(mid_B,  K_raw_B, KEYBITS // 4)
     print(f"sk (Alice): {sk_rnl_A.hex}")
     print(f"sk (Bob)  : {sk_rnl_B.hex}")
     if K_raw_A == K_raw_B:

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.9
+/*  Herradura Cryptographic Suite v1.5.10
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -42,7 +42,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.9 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.10 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 
@@ -686,10 +686,15 @@ hske_nl2_done:
 
     ldr     r0, =val_KA
     ldr     r0, [r0]
+    ror     r0, r0, #28         @ seed = ROL32(KA, 4)  [n/8 = 32/8 = 4]
     ldr     r1, =val_KA
     ldr     r1, [r1]
     mov     r2, #I_VALUE
-    bl      nl_fscx_revolve_v1
+    bl      nl_fscx_revolve_v1  @ r0 = mid
+    ldr     r1, =val_KA
+    ldr     r1, [r1]            @ reload B = KA
+    mov     r2, #I_VALUE
+    bl      nl_fscx_revolve_v2  @ r0 = sk
     ldr     r3, =val_sk_rnl
     str     r0, [r3]
 

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -688,13 +688,9 @@ hske_nl2_done:
     ldr     r0, [r0]
     ror     r0, r0, #28         @ seed = ROL32(KA, 4)  [n/8 = 32/8 = 4]
     ldr     r1, =val_KA
-    ldr     r1, [r1]
+    ldr     r1, [r1]            @ B = KA
     mov     r2, #I_VALUE
-    bl      nl_fscx_revolve_v1  @ r0 = mid
-    ldr     r1, =val_KA
-    ldr     r1, [r1]            @ reload B = KA
-    mov     r2, #I_VALUE
-    bl      nl_fscx_revolve_v2  @ r0 = sk
+    bl      nl_fscx_revolve_v1  @ r0 = sk
     ldr     r3, =val_sk_rnl
     str     r0, [r3]
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1070,9 +1070,28 @@ $$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{b
 
 Commutativity of $\mathcal R_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
 
-**KDF post-processing.**  The reconciled raw key $K$ is passed through NL-FSCX v1 for final extraction:
+**KDF post-processing.**  The reconciled raw key $K$ is processed through a two-pass chain:
 
-$$sk = \text{NL-FSCX-REVOLVE}(K,\; K,\; n/4)$$
+$$seed = \text{ROL}(K,\; n/8)$$
+$$mid = \text{NL-FSCX-REVOLVE}_{v1}(seed,\; K,\; n/4)$$
+$$sk = \text{NL-FSCX-REVOLVE}_{v2}(mid,\; K,\; n/4)$$
+
+**Rationale for the two-pass design.**  The earlier single-pass KDF ($sk = \text{NL-FSCX-REVOLVE}(K, K, n/4)$) suffered a first-step degeneracy: when $A_0 = B = K$, $\text{FSCX}(K, K) = K \oplus K \oplus \ldots = 0$, so the first revolve step reduces to a pure rotation,
+
+$$A_1 = \text{ROL}((K + K) \bmod 2^n,\; n/4) = \text{ROL}(K \ll 1,\; n/4),$$
+
+which is linear in $K$.  Non-linearity accumulates only from step 2 onward.
+
+Setting $seed = \text{ROL}(K, n/8) \neq K$ ensures $\text{FSCX}(seed, K) = M(seed \oplus K) \neq 0$ immediately, so full non-linear carry mixing is active from the first step of Pass 1.
+
+The two passes provide **algebraically independent non-linearity**:
+
+| Pass | Non-linearity source | Bijective in input? |
+|------|----------------------|---------------------|
+| v1 ($n/4$ steps) | Integer carry in $(A + K) \bmod 2^n$ XOR'd into GF(2) output | No — collisions exist |
+| v2 ($n/4$ steps) | Multiplicative delta $\delta(K) = \text{ROL}(K \cdot \lfloor(K+1)/2\rfloor \bmod 2^n,\; n/4)$ | Yes — bijective with closed-form inverse |
+
+An algebraic attack must break both the carry-based non-linearity of v1 and the multiplicative-delta structure of v2 simultaneously.  Since Pass 2 is bijective in $mid$ for fixed $K$, all one-wayness resides in Pass 1; Pass 2 contributes additional mixing depth and a second independent algebraic obstacle.  Brute-force cost remains $2^n$.
 
 #### 11.4.3 Security
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1070,28 +1070,17 @@ $$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{b
 
 Commutativity of $\mathcal R_q$ gives $s_A \cdot m_\text{blind} \cdot s_B = s_B \cdot m_\text{blind} \cdot s_A$, so $K_A \approx K_B$; reconciliation extracts a shared bit-string.
 
-**KDF post-processing.**  The reconciled raw key $K$ is processed through a two-pass chain:
+**KDF post-processing.**  The reconciled raw key $K$ is passed through NL-FSCX v1 with a rotated seed:
 
-$$seed = \text{ROL}(K,\; n/8)$$
-$$mid = \text{NL-FSCX-REVOLVE}_{v1}(seed,\; K,\; n/4)$$
-$$sk = \text{NL-FSCX-REVOLVE}_{v2}(mid,\; K,\; n/4)$$
+$$seed = \text{ROL}(K,\; n/8), \qquad sk = \text{NL-FSCX-REVOLVE}_{v1}(seed,\; K,\; n/4)$$
 
-**Rationale for the two-pass design.**  The earlier single-pass KDF ($sk = \text{NL-FSCX-REVOLVE}(K, K, n/4)$) suffered a first-step degeneracy: when $A_0 = B = K$, $\text{FSCX}(K, K) = K \oplus K \oplus \ldots = 0$, so the first revolve step reduces to a pure rotation,
+**Rationale.**  The original KDF ($sk = \text{NL-FSCX-REVOLVE}(K, K, n/4)$) suffered a first-step degeneracy: when $A_0 = B = K$, $\text{FSCX}(K, K) = K \oplus K \oplus \ldots = 0$, so the first step reduces to a pure rotation,
 
 $$A_1 = \text{ROL}((K + K) \bmod 2^n,\; n/4) = \text{ROL}(K \ll 1,\; n/4),$$
 
 which is linear in $K$.  Non-linearity accumulates only from step 2 onward.
 
-Setting $seed = \text{ROL}(K, n/8) \neq K$ ensures $\text{FSCX}(seed, K) = M(seed \oplus K) \neq 0$ immediately, so full non-linear carry mixing is active from the first step of Pass 1.
-
-The two passes provide **algebraically independent non-linearity**:
-
-| Pass | Non-linearity source | Bijective in input? |
-|------|----------------------|---------------------|
-| v1 ($n/4$ steps) | Integer carry in $(A + K) \bmod 2^n$ XOR'd into GF(2) output | No — collisions exist |
-| v2 ($n/4$ steps) | Multiplicative delta $\delta(K) = \text{ROL}(K \cdot \lfloor(K+1)/2\rfloor \bmod 2^n,\; n/4)$ | Yes — bijective with closed-form inverse |
-
-An algebraic attack must break both the carry-based non-linearity of v1 and the multiplicative-delta structure of v2 simultaneously.  Since Pass 2 is bijective in $mid$ for fixed $K$, all one-wayness resides in Pass 1; Pass 2 contributes additional mixing depth and a second independent algebraic obstacle.  Brute-force cost remains $2^n$.
+Setting $seed = \text{ROL}(K, n/8) \neq K$ ensures $\text{FSCX}(seed, K) = M(seed \oplus K) \neq 0$ from the very first step, so full integer-carry non-linearity is active throughout all $n/4$ steps.  The single-pass structure is preserved — a second bijective pass (NL-FSCX v2) would not add one-wayness since it is invertible for fixed $K$.
 
 #### 11.4.3 Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -90,7 +90,15 @@ import hashlib
 sk_bytes = hashlib.shake_256(nl_fscx_raw.bytes).digest(KEYBITS // 8)
 ```
 
-Status: **TODO**
+Status: **DONE (v1.5.10)** — Replaced the single-pass KDF with a two-pass chain that
+stays entirely within Herradura primitives (no external hash required):
+  seed = ROL(K, n/8);  mid = nl_fscx_revolve_v1(seed, K, n/4);
+  sk   = nl_fscx_revolve_v2(mid,  K, n/4)
+The ROL(K, n/8) seed breaks the A₀=B=K first-step degeneracy (fscx(K,K)=0) so
+full carry non-linearity is active from step 1.  Pass 2 chains v2's multiplicative-
+delta non-linearity against v1's carry-XOR structure; an attacker must break both
+simultaneously.  Applied to all 6 language targets (suite + test files).
+Note: no formal PRF proof exists for either pass; this is a strengthened heuristic.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -90,15 +90,13 @@ import hashlib
 sk_bytes = hashlib.shake_256(nl_fscx_raw.bytes).digest(KEYBITS // 8)
 ```
 
-Status: **DONE (v1.5.10)** — Replaced the single-pass KDF with a two-pass chain that
-stays entirely within Herradura primitives (no external hash required):
-  seed = ROL(K, n/8);  mid = nl_fscx_revolve_v1(seed, K, n/4);
-  sk   = nl_fscx_revolve_v2(mid,  K, n/4)
-The ROL(K, n/8) seed breaks the A₀=B=K first-step degeneracy (fscx(K,K)=0) so
-full carry non-linearity is active from step 1.  Pass 2 chains v2's multiplicative-
-delta non-linearity against v1's carry-XOR structure; an attacker must break both
-simultaneously.  Applied to all 6 language targets (suite + test files).
-Note: no formal PRF proof exists for either pass; this is a strengthened heuristic.
+Status: **DONE (v1.5.10)** — KDF seed fixed across all 6 language targets (suite + test files):
+  seed = ROL(K, n/8);  sk = nl_fscx_revolve_v1(seed, K, n/4)
+The original A₀=B=K caused fscx(K,K)=0 on step 1, making it a pure rotation (linear).
+ROL(K,n/8) ≠ K ensures fscx(seed,K)≠0 from step 1, activating carry non-linearity
+throughout. A second bijective pass (v2) was considered but rejected — it is invertible
+for fixed K and adds no one-wayness. Note: no formal PRF proof; this is a strengthened
+heuristic.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixed a structural weakness in the HKEX-RNL KDF: when `A₀ = B = K`, `fscx(K,K) = 0`, making step 1 a pure rotation of K (linear). The KDF now derives the initial state as `seed = ROL(K, n/8)`, ensuring `fscx(seed, K) ≠ 0` and full carry non-linearity from step 1.
- A two-pass chain (v1 + v2) was considered and implemented, then simplified: the v2 second pass is bijective for fixed K and adds no one-wayness, so it was removed. The seed fix alone is the complete, minimal solution.
- `SecurityProofs.md` §11.4 updated with algebraic rationale. TODO #4 closed.

Applied across all 6 language targets: Python, C, Go, Arduino, ARM Thumb-2, NASM i386 (suite + test files). Version bumped to v1.5.10.

## Test plan

- [x] C suite builds clean (`gcc -O2`)
- [x] ARM + NASM suite build and run clean
- [x] Python test [14] HKEX-RNL: 50/50 raw agree, 50/50 sk agree — PASS
- [x] C test [14] HKEX-RNL: PASS
- [x] Go test [14] HKEX-RNL: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)