### PR TITLE
v1.5.13: fix HSKE-NL-A1 counter=0 step-1 degeneracy (all targets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.13] - 2026-04-24
+
+### Fixed — HSKE-NL-A1 counter=0 step-1 degeneracy (security, all targets)
+
+**Root cause.** The HSKE-NL-A1 keystream call `nl_fscx_revolve_v1(base, base XOR ctr, n/4)`
+passes `A = B = base` when `ctr = 0`.  With `A = B`, `FSCX(A, B) = M(A ⊕ B) = M(0) = 0`, so
+step 1 contributes only the linear term `ROL(2·base, n/4)`.  Non-linearity accumulates only
+from step 2 onward — the same degeneracy fixed for the HKEX-RNL KDF in v1.5.10.
+
+**Fix.** Replace the A (seed) argument with `ROL(base, n/8)` across all language targets:
+
+```
+ks[i] = nl_fscx_revolve_v1(ROL(base, n/8), base XOR i, n/4)
+```
+
+For n=256 (C/Go/Python): `ROL(base, 32)`.
+For n=32 (ARM Thumb-2, NASM i386, Arduino): `ROL(base, 4)` — implemented as `ROR(base, 28)` on ARM.
+
+**Files changed (9):**
+- `Herradura cryptographic suite.c` — seed via `ba_rol_k(&seed_a1, &base_a1, KEYBYTES)` (n/8=32)
+- `Herradura cryptographic suite.go` — `baseA1.RotateLeft(n/8)`
+- `Herradura cryptographic suite.py` — `base_a1.rotated(KEYBITS // 8)`
+- `Herradura cryptographic suite.s` — `ror r0, r0, #28` before `bl nl_fscx_revolve_v1`
+- `Herradura cryptographic suite.asm` — `rol eax, 4` before `call nl_fscx_revolve_v1`
+- `Herradura cryptographic suite.ino` — `_rol32(base, 4)`
+- `CryptosuiteTests/Herradura_tests.c` — inline ROL in test [12] for n=64 and n=128
+- `CryptosuiteTests/Herradura_tests.go` — `base.RotateLeft(size/8)` in test [12]
+- `CryptosuiteTests/Herradura_tests.py` — `base.rotated(size // 8)` in test [12] and bench [23]
+
+**Documentation updated:**
+- `SecurityProofs.md §11.3.1` — updated keystream formula and added seed-rotation rationale
+- `SecurityProofs.md §11.6` — updated KDF table entry to reflect v1.5.10 seed fix (was stale)
+- `Herradura cryptographic suite.c:933` — fixed stale `q=3329` comment (should be `q=65537` since v1.5.4)
+
+**TODO.md items closed:** #9 (degeneracy fix), #10 (stale q comment), #11 (stale §11.6 KDF formula).
+
+---
+
 ## [1.5.2] - 2026-04-18
 
 ### Fixed — KaTeX rendering in `SecurityProofs.md` (`^*` and `\mathcal{R}_q` cross-span emphasis)

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+    v1.5.13: HSKE-NL-A1 seed fix — seed=ROL(base,n/8) breaks counter=0 step-1 degeneracy.
     v1.5.10: HKEX-RNL KDF seed fix — seed=ROL(K,n/8) breaks step-1 degeneracy.
     v1.5.9: nl_fscx_revolve_v2_inv_{32,64,128} precompute delta(B) once — eliminates per-step multiply.
     v1.5.7: m_inv_32/64/128 use precomputed rotation tables (0x6DB6DB6D / constants).
@@ -1495,14 +1496,16 @@ static void test_hske_nl_a1_correctness(void)
             if (size == 128) {
                 __uint128_t K = rand128(), nonce = rand128(), P = rand128();
                 __uint128_t base = K ^ nonce;
+                __uint128_t seed = (base << 16) | (base >> 112); /* ROL(base, n/8=16) */
                 __uint128_t ctr = (uint32_t)i & 0xFFFF;
-                __uint128_t ks = nl_fscx_revolve_v1_128(base, base ^ ctr, iv);
+                __uint128_t ks = nl_fscx_revolve_v1_128(seed, base ^ ctr, iv);
                 if ((P ^ ks ^ ks) == P) ok++;
             } else {
                 uint64_t K = rand64(), nonce = rand64(), P = rand64();
                 uint64_t base = K ^ nonce;
+                uint64_t seed = (base << 8) | (base >> 56); /* ROL(base, n/8=8) */
                 uint64_t ctr = (uint32_t)i & 0xFFFF;
-                uint64_t ks = nl_fscx_revolve_v1_64(base, base ^ ctr, iv);
+                uint64_t ks = nl_fscx_revolve_v1_64(seed, base ^ ctr, iv);
                 if ((P ^ ks ^ ks) == P) ok++;
             }
             if ((i & 63) == 63 && time_exceeded(&t0)) { N = i + 1; break; }

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.13: HSKE-NL-A1 seed fix — seed=RotateLeft(base,n/8) breaks counter=0 step-1 degeneracy.
     v1.5.10: HKEX-RNL KDF seed fix — seed=RotateLeft(K,n/8) breaks step-1 degeneracy.
     v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: MInv uses precomputed rotation table (sync.Map cache per bit-size).
@@ -900,7 +901,7 @@ func testNlFscxV2BijectiveInverse() {
 }
 
 func testHskeNlA1Correctness() {
-	// HSKE-NL-A1 with per-session nonce: base = K XOR N; ks = NlFscxRevolveV1(base, base XOR ctr, n/4).
+	// HSKE-NL-A1 with per-session nonce: base = K XOR N; ks = NlFscxRevolveV1(ROL(base,n/8), base XOR ctr, n/4).
 	fmt.Println("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
@@ -911,7 +912,7 @@ func testHskeNlA1Correctness() {
 			base := newBA(size, new(big.Int).Xor(&K.val, &nonce.val))
 			ctr := int64(trial % (1 << 16))
 			bCtr := newBA(size, new(big.Int).Xor(&base.val, big.NewInt(ctr)))
-			ks := NlFscxRevolveV1(base, bCtr, iv)
+			ks := NlFscxRevolveV1(base.RotateLeft(size/8), bCtr, iv) // seed=ROL(base,n/8)
 			C := newBA(size, new(big.Int).Xor(&P.val, &ks.val))
 			D := newBA(size, new(big.Int).Xor(&C.val, &ks.val))
 			if D.Equal(P) { ok++ }

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.13: HSKE-NL-A1 seed fix — seed=ROL(base,n/8) breaks counter=0 step-1 degeneracy.
     v1.5.10: HKEX-RNL KDF seed fix — seed=ROL(K,n/8) breaks step-1 degeneracy.
     v1.5.9: nl_fscx_revolve_v2_inv precomputes delta(B) once — eliminates per-step multiply.
     v1.5.7: _m_inv uses precomputed rotation table (lazy init, cached per bit-size).
@@ -623,7 +624,7 @@ def test_nl_fscx_v2_bijective_inverse():
 
 def test_hske_nl_a1_correctness():
     # HSKE-NL-A1 counter-mode with per-session nonce: N random; base = K XOR N.
-    # keystream[i] = nl_fscx_revolve_v1(base, base XOR i, n/4).
+    # keystream[i] = nl_fscx_revolve_v1(ROL(base, n/8), base XOR i, n/4).
     print("[12] HSKE-NL-A1 counter-mode correctness: D == P  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); ok = 0; n_run = 0
@@ -635,7 +636,7 @@ def test_hske_nl_a1_correctness():
             base = BitArray(size, K.uint ^ N.uint)       # session key base
             ctr  = trial % (1 << min(size, 16))
             B    = BitArray(size, base.uint ^ ctr)
-            ks   = nl_fscx_revolve_v1(base, B, iv)
+            ks   = nl_fscx_revolve_v1(base.rotated(size // 8), B, iv)  # seed=ROL(base,n/8)
             C    = BitArray(size, P.uint ^ ks.uint)
             D    = BitArray(size, C.uint ^ ks.uint)
             if D == P: ok += 1
@@ -850,7 +851,7 @@ def bench_hske_nl_a1_roundtrip():
             N    = BitArray.random(size)
             base = BitArray(size, K.uint ^ N.uint)
             B    = BitArray(size, base.uint ^ 0)  # counter=0
-            ks   = nl_fscx_revolve_v1(base, B, iv)
+            ks   = nl_fscx_revolve_v1(base.rotated(size // 8), B, iv)  # seed=ROL(base,n/8)
             sink ^= BitArray(size, P.uint ^ ks.uint)
         _bench(f"bits={size:3d}", fn)
     print()

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.10
+;  Herradura Cryptographic Suite v1.5.13
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
 ;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -9,6 +9,8 @@
 ;              delta(B) = ROL32(B*((B+1)>>1), 8)
 ;              inv: B XOR M^{-1}((Y - delta(B)) mod 2^32)
 ;  HKEX-RNL: Ring-LWR, N=32, q=65537, p=4096, pp=2, B=1
+;
+;  v1.5.13: HSKE-NL-A1 seed=ROL(base,4) [n/8=4] fixes counter=0 step-1 degeneracy.
 ;
 ;  Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 ;  MIT License / GPL v3.0 -- choose either.
@@ -523,13 +525,14 @@ _start:
     mov  ecx, hske_nl1_hdr_l
     call print_str
 
-    ; N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(base, base, I_VALUE)
+    ; N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(ROL(base,4), base, I_VALUE)
     call prng_next              ; eax = nonce N
     mov  [val_nonce_nl1], eax
     xor  eax, [val_key]         ; eax = base = N XOR key
-    mov  ebx, eax               ; ebx = base (counter=0: B = base)
+    mov  ebx, eax               ; ebx = B = base (counter=0)
+    rol  eax, 4                 ; eax = ROL(base, 4) = seed  [n=32, n/8=4]
     mov  ecx, I_VALUE
-    call nl_fscx_revolve_v1     ; eax = ks
+    call nl_fscx_revolve_v1     ; eax = ks  (A=seed, B=base)
     mov  [val_ks_nl1], eax
 
     ; E = plain XOR ks

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.10
+/*  Herradura Cryptographic Suite v1.5.13
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,14 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.13: HSKE-NL-A1 seed fix — ROL(base, n/8) breaks counter=0 step-1 degeneracy ---
+
+    HSKE-NL-A1 keystream: seed = ba_rol_k(base, n/8); ks = nl_fscx_revolve_v1(seed, base^ctr, n/4).
+    When A=B=base (counter=0), fscx(base,base)=0 so step 1 was a pure rotation (linear).
+    ROL(base,n/8) ensures seed!=base, activating full carry non-linearity from step 1.
+    Same degeneracy pattern fixed for HKEX-RNL KDF in v1.5.10; now applied consistently.
+    Also fixes stale q=3329 comment (was 65537 since v1.5.4).
 
     --- v1.5.10: HKEX-RNL KDF seed fix — ROL(K, n/8) breaks step-1 degeneracy ---
 
@@ -762,7 +770,7 @@ HPKE (El Gamal public key encryption, 256-bit):
 
 HSKE-NL-A1 (counter-mode with NL-FSCX v1, 256-bit):
     N = random(256 bits); base = K XOR N  [per-session nonce; N transmitted with ciphertext]
-    ks = nl_fscx_revolve_v1(base, base XOR counter, I_VALUE)
+    ks = nl_fscx_revolve_v1(ROL(base, n/8), base XOR counter, I_VALUE)
     E = P XOR ks;  D = E XOR ks = P
 
 HSKE-NL-A2 (revolve-mode with NL-FSCX v2, 256-bit):
@@ -900,7 +908,9 @@ int main(void)
         BitArray N_a1, base_a1, ks_nl1, E_nl1, D_nl1;
         ba_rand(&N_a1, urnd);                         /* per-session nonce          */
         ba_xor(&base_a1, &preshared, &N_a1);          /* base = K XOR N             */
-        nl_fscx_revolve_v1_ba(&ks_nl1, &base_a1, &base_a1, I_VALUE); /* counter=0  */
+        BitArray seed_a1;
+        ba_rol_k(&seed_a1, &base_a1, KEYBYTES);       /* seed = ROL(base, n/8)      */
+        nl_fscx_revolve_v1_ba(&ks_nl1, &seed_a1, &base_a1, I_VALUE); /* counter=0  */
         ba_xor(&E_nl1, &plaintext, &ks_nl1);
         ba_xor(&D_nl1, &E_nl1,    &ks_nl1);
         ba_print_hex("N (nonce) : ", &N_a1);
@@ -930,7 +940,7 @@ int main(void)
 
     /* --- HKEX-RNL [PQC -- Ring-LWR key exchange; conjectured quantum-resistant] */
     printf("\n--- HKEX-RNL [PQC \xe2\x80\x94 Ring-LWR key exchange; conjectured quantum-resistant]\n");
-    puts("    (Ring-LWR, m(x)=1+x+x^{n-1}, n=256, q=3329 \xe2\x80\x94 may be slow)");
+    puts("    (Ring-LWR, m(x)=1+x+x^{n-1}, n=256, q=65537)");
     {
         rnl_poly_t m_base, a_rand_poly, m_blind;
         rnl_poly_t s_A_poly, s_B_poly;

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.10
+/*  Herradura Cryptographic Suite v1.5.13
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,13 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.13: HSKE-NL-A1 seed fix — RotateLeft(base, n/8) breaks counter=0 step-1 degeneracy ---
+
+    HSKE-NL-A1 keystream: seed = base.RotateLeft(n/8); ks = NlFscxRevolveV1(seed, base^ctr, n/4).
+    When A=B=base (counter=0), Fscx(base,base)=0 so step 1 was a pure rotation (linear in base).
+    RotateLeft(base,n/8) ensures seed!=base, activating full carry non-linearity from step 1.
+    Same degeneracy pattern fixed for HKEX-RNL KDF in v1.5.10; now applied consistently.
 
     --- v1.5.10: HKEX-RNL KDF seed fix — RotateLeft(K, n/8) breaks step-1 degeneracy ---
 
@@ -640,11 +647,11 @@ func main() {
 
 	// ── PQC-HARDENED protocols ───────────────────────────────────────────────
 	fmt.Println("\n--- HSKE-NL-A1 [PQC-HARDENED — counter-mode with NL-FSCX v1]")
-	nA1    := randBA(n)                                                    // per-session nonce
+	nA1    := NewRandBitArray(n)                                           // per-session nonce
 	baseA1 := NewBitArray(n, new(big.Int).Xor(&preshared.val, &nA1.val)) // base = K XOR N
 	counter := 0
 	bA1 := NewBitArray(n, new(big.Int).Xor(&baseA1.val, big.NewInt(int64(counter))))
-	ksA1 := NlFscxRevolveV1(baseA1, bA1, n/4)
+	ksA1 := NlFscxRevolveV1(baseA1.RotateLeft(n/8), bA1, n/4) // seed=ROL(base,n/8) avoids step-1 degeneracy
 	eA1 := NewBitArray(n, new(big.Int).Xor(&plaintext.val, &ksA1.val))
 	dA1 := NewBitArray(n, new(big.Int).Xor(&eA1.val, &ksA1.val))
 	fmt.Printf("N (nonce) : %x\n", nA1)

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.10 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.13 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32
 
@@ -9,6 +9,8 @@
     Upload via Arduino IDE or: arduino --upload --board arduino:avr:uno ...
     Monitor: 9600 baud serial monitor.
 
+    v1.5.13: HSKE-NL-A1 seed fix: seed=_rol32(base,4); ks=nl_fscx_revolve_v1(seed,base,I).
+             When A=B=base, fscx(base,base)=0; ROL by n/8=4 activates non-linearity from step 1.
     v1.5.10: HKEX-RNL KDF seed fix: seed=ROL32(K,4); sk=nl_fscx_revolve_v1(seed,K,I).
     v1.5.9: HSKE-NL-A1 per-session nonce (lcg_next XOR K); nl_fscx_revolve_v2_inv delta precompute.
     v1.5.7: m_inv_32 uses precomputed rotation table (0x6DB6DB6D) — replaces 15-step loop.
@@ -396,7 +398,7 @@ void loop() {
     {
         uint32 N    = lcg_next();              /* per-session nonce            */
         uint32 base = K ^ N;                   /* session key base = K XOR N   */
-        uint32 ks   = nl_fscx_revolve_v1(base, base, I_VALUE);  /* counter=0  */
+        uint32 ks   = nl_fscx_revolve_v1(_rol32(base, 4), base, I_VALUE);  /* seed=ROL(base,n/8=4) */
         uint32 E    = PLAIN ^ ks;
         uint32 D    = E ^ ks;
         printHexLine("N (nonce) : ", N);

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.5.10
+    Herradura Cryptographic Suite v1.5.13
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -17,6 +17,13 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.13: HSKE-NL-A1 seed fix — ROL(base, n/8) breaks counter=0 step-1 degeneracy ---
+
+    HSKE-NL-A1 keystream: seed = base.rotated(n/8); ks = nl_fscx_revolve_v1(seed, base^ctr, n/4).
+    When A=B=base (counter=0), fscx(base,base)=0 so step 1 was a pure rotation (linear).
+    ROL(base,n/8) ensures seed!=base, activating full carry non-linearity from step 1.
+    Same degeneracy pattern fixed for HKEX-RNL KDF in v1.5.10; now applied consistently.
 
     --- v1.5.10: HKEX-RNL KDF seed fix — ROL(K, n/8) breaks step-1 degeneracy ---
 
@@ -517,7 +524,7 @@ PQC-HARDENED PROTOCOLS (v1.5.0, C3 hybrid — see SecurityProofs.md §11)
 HSKE-NL-A1 (counter-mode HSKE with NL-FSCX v1):
   Nonce:    N = random(n bits)   [per-session; transmitted alongside ciphertext]
   base      = K XOR N            [session key base]
-  keystream[i] = nl_fscx_revolve_v1(base, base XOR i, n/4)
+  keystream[i] = nl_fscx_revolve_v1(ROL(base, n/8), base XOR i, n/4)
   Encrypt:  C = (N, P XOR keystream[0])
   Decrypt:  base = K XOR N; P = C XOR keystream[0]
   Security: per-session nonce ensures distinct keystreams across sessions;
@@ -639,7 +646,7 @@ def main():
     counter    = 0
     N_a1       = BitArray.random(KEYBITS)                         # per-session nonce
     base_a1    = BitArray(KEYBITS, preshared.uint ^ N_a1.uint)   # K XOR N
-    ks_a1      = nl_fscx_revolve_v1(base_a1,
+    ks_a1      = nl_fscx_revolve_v1(base_a1.rotated(KEYBITS // 8),  # seed=ROL(base,n/8)
                                     BitArray(KEYBITS, base_a1.uint ^ counter),
                                     KEYBITS // 4)
     E_a1 = BitArray(KEYBITS, plaintext.uint ^ ks_a1.uint)

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.10
+/*  Herradura Cryptographic Suite v1.5.13
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL
     KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
@@ -8,6 +8,8 @@
     NL-FSCX v2: nl_v2(A,B) = fscx(A,B) + ROL32(B*((B+1)>>1), 8)  mod 2^32
                 inv: B XOR M^{-1}((Y-delta(B)) mod 2^32)
     HKEX-RNL:  Ring-LWR; N=32, q=65537, p=4096, pp=2
+
+    v1.5.13: HSKE-NL-A1 seed=ROR(base,28) [=ROL(base,4)=ROL(base,n/8)] fixes counter=0 degeneracy.
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
     MIT License / GPL v3.0 — choose either.
@@ -525,7 +527,7 @@ hpke_done:
 
     /* ================================================================
        HSKE-NL-A1  (counter-mode with NL-FSCX v1)
-       N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(base, base, I_VALUE)
+       N = prng_next(); base = key XOR N; ks = nl_fscx_revolve_v1(ROL(base,4), base, I_VALUE)
        E = plain XOR ks;  D = E XOR ks  (must == plain)
        ================================================================ */
     ldr     r0, =fmt_hske_nl1_hdr
@@ -537,9 +539,10 @@ hpke_done:
     ldr     r1, =val_key
     ldr     r1, [r1]
     eor     r0, r0, r1              @ r0 = base = N XOR key
-    mov     r1, r0                  @ r1 = base (counter=0: B = base)
+    mov     r1, r0                  @ r1 = B = base (counter=0)
+    ror     r0, r0, #28             @ r0 = ROL(base, 4) = seed  [n=32, n/8=4]
     mov     r2, #I_VALUE
-    bl      nl_fscx_revolve_v1      @ r0 = ks
+    bl      nl_fscx_revolve_v1      @ r0 = ks  (A=seed, B=base)
     ldr     r3, =val_ks_nl1
     str     r0, [r3]
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1226,17 +1226,26 @@ Two secure HSKE constructions are defined; both are chosen depending on API requ
 
 #### 11.3.1 HSKE-A1: Counter Mode with NL-FSCX v1
 
-$$\text{keystream}[i] = \text{NL-FSCX-REVOLVE}(K,\; K \oplus i,\; n/4)$$
+Let $\text{base} = K \oplus N$ where $N$ is a random per-session nonce (transmitted with ciphertext).
+
+$$\text{keystream}[i] = \text{NL-FSCX-REVOLVE}\!\left(\text{ROL}(\text{base},\; n/8),\; \text{base} \oplus i,\; n/4\right)$$
 $$C[i] = P[i] \oplus \text{keystream}[i]$$
 $$D[i] = C[i] \oplus \text{keystream}[i] = P[i]$$
 
 No inverse is required.  The counter $i$ ensures keystream uniqueness per block.
 Decryption is identical to encryption (XOR-symmetric).
 
+**Seed rotation rationale.**  Without the ROL, counter $i = 0$ passes $A = B = \text{base}$, giving
+$\text{FSCX}(\text{base}, \text{base}) = M(\text{base} \oplus \text{base}) = 0$ on step 1 — making the first
+output purely a rotation of $2 \cdot \text{base}$, linear in $\text{base}$.  Setting the seed to
+$\text{ROL}(\text{base}, n/8) \neq \text{base}$ ensures $\text{FSCX}(\text{seed}, \text{base}) \neq 0$ and
+integer-carry non-linearity is active from step 1 across all counter values.
+This mirrors the HKEX-RNL KDF fix in v1.5.10.  (v1.5.13)
+
 **Security argument.**  $\text{keystream}[i]$ is the output of $n/4$ rounds of NL-FSCX v1 starting
-from seed $K$ with parameter $K \oplus i$.  Non-linearity prevents GF(2) linear recovery of $K$
-from any set of (plaintext, ciphertext) pairs.  Assuming NL-FSCX v1 acts as a
-pseudorandom function (PRF), CPA security follows from standard stream cipher arguments.
+from seed $\text{ROL}(\text{base}, n/8)$ with parameter $\text{base} \oplus i$.  Non-linearity prevents
+GF(2) linear recovery of $K$ from any set of (plaintext, ciphertext) pairs.  Assuming NL-FSCX v1
+acts as a pseudorandom function (PRF), CPA security follows from standard stream cipher arguments.
 
 #### 11.3.2 HSKE-A2: Revolve Mode with NL-FSCX v2
 
@@ -1411,7 +1420,7 @@ The C3 hybrid assigns each primitive to the role that matches its properties:
 - $p = 4096$, $p' = 2$ (1 bit extracted per ring coefficient)
 - **Secret distribution:** $\mathrm{CBD}(\eta=1)$, coefficients in $\{-1, 0, 1\}$ with zero mean (upgraded from uniform $\{0,1\}$ in v1.5.3)
 - $a_\text{rand}$: $n$-coefficient polynomial, coefficients uniform in $\mathbb{Z}/q\mathbb{Z}$, transmitted per session
-- KDF: $sk = \text{NL-FSCX}\textunderscore\text{REVOLVE}\textunderscore\text{v1}(K_\text{raw}, K_\text{raw}, n/4)$
+- KDF: $\text{seed} = \text{ROL}(K_\text{raw},\; n/8)$; $sk = \text{NL-FSCX}\textunderscore\text{REVOLVE}\textunderscore\text{v1}(\text{seed},\; K_\text{raw},\; n/4)$
 
 *Verification.* The invertibility of $m(x)$ in $\mathbb{Z}_q[x]/(x^n+1)$ is confirmed for
 the deployed parameters $(q=65537, n=32)$ and $(q=65537, n=256)$ by `hkex_nl_verification.py` §2.1.

--- a/TODO.md
+++ b/TODO.md
@@ -300,3 +300,158 @@ loop `{64, 128}`. 256-bit NL-FSCX deferred (requires 256-bit integer multiply).
 Status: **DONE (v1.5.5)** — [5] fixed in Phase 3 (criterion changed to `mean >= n/4`).
 [11] upgraded to `BIJ_SAMPLES=256` random A values per B with O(n²) pairwise output
 collision scan, matching Python/Go 256-sample hash-map methodology.
+
+---
+
+## v1.5.x Review — Findings (2026-04-24)
+
+### 9. HSKE-NL-A1 counter=0 step-1 degeneracy (Security, High)
+
+**Files:** C:903, Go:647, Python:642–643; all assembly targets
+
+When `counter = 0` both arguments to `nl_fscx_revolve_v1` equal `base`, so
+`FSCX(base, base) = M(base ⊕ base) = M(0) = 0`. Step 1 contributes only the
+linear term `ROL(2·base, n/4)`; non-linearity accumulates from step 2 of n/4
+only — the same degeneracy fixed for the HKEX-RNL KDF in v1.5.10.
+
+Fix: use `ROL(base, n/8)` as the A (seed) argument across all languages:
+```
+ks[i] = nl_fscx_revolve_v1(ROL(base, n/8), base XOR i, n/4)
+```
+Also update SecurityProofs.md §11.3.1 formula and §11.6 table.
+
+Status: **DONE (v1.5.13)** — `ROL(base, n/8)` seed applied across all 6 suite targets
+(C, Go, Python, ARM Thumb-2, NASM i386, Arduino) and 3 test targets (C, Go, Python).
+SecurityProofs.md §11.3.1 updated with new formula and seed-rotation rationale.
+
+---
+
+### 10. Stale `q=3329` comment in C main() (Correctness, Trivial)
+
+**File:** `Herradura cryptographic suite.c:933`
+
+`puts("    (Ring-LWR, ..., q=3329 ...")` but `RNL_Q = 65537` since v1.5.4.
+
+Fix: update the string literal to `q=65537`.
+
+Status: **DONE (v1.5.13)**
+
+---
+
+### 11. §11.6 KDF formula stale — missing v1.5.10 seed fix (Documentation, Trivial)
+
+**File:** `SecurityProofs.md:1414`
+
+Table entry still shows `KDF: sk = NL-FSCX-REVOLVE-v1(K_raw, K_raw, n/4)`.
+The §11.4.2 body has the correct v1.5.10 formula but §11.6 was not updated.
+
+Fix: replace the table entry with:
+```
+seed = ROL(K_raw, n/8);  sk = NL-FSCX-REVOLVE-v1(seed, K_raw, n/4)
+```
+
+Status: **DONE (v1.5.13)**
+
+---
+
+### 12. HSKE-NL-A2 deterministic encryption undocumented (Security/Docs, Medium)
+
+**Files:** `SecurityProofs.md §11.3.2`; code comments in all language targets
+
+HSKE-NL-A2 (`NlFscxRevolveV2(P, K, r)`) has no nonce — same (key, plaintext)
+always produces identical ciphertext. This is not a correctness bug but must be
+documented as a usage constraint: HSKE-NL-A2 must not encrypt multiple distinct
+messages under the same key without external message differentiation.
+
+Fix: add a note to §11.3.2 and to the in-code protocol comment blocks.
+
+Status: **OPEN**
+
+---
+
+### 13. HKEX-RNL failure rate uncharacterized at deployed parameters (Analysis, Medium)
+
+**Files:** `SecurityProofs.md §11.5 Q2`; new `SecurityProofsCode/hkex_rnl_failure_rate.py`
+
+§11.5 Q2 marks `(q=65537, n=256, p=4096)` as `⚠ pending verification`. No
+empirical P(K_A ≠ K_B) row exists for the deployed parameter set.
+
+Fix: add a script that samples (s_A, s_B, a_rand) uniformly and measures the
+empirical key-disagreement rate over ≥ 10,000 trials at n=256. Record the result
+in §11.5 Q2. If failure rate > 1%, a reconciliation hint mechanism is needed.
+
+Status: **OPEN**
+
+---
+
+### 14. NTT twiddle recomputation per poly-multiply call (Performance, Medium)
+
+**Files:** C `rnl_ntt` / `rnl_poly_mul`; Go `rnlNTT` / `rnlPolyMul`
+
+`rnl_poly_mul` recomputes ψ and ψ⁻¹ via `rnl_mod_pow` on every call. Inside
+`rnl_ntt`, each of the 8 butterfly stages calls `rnl_mod_pow` once for the stage
+twiddle `w`. For ≈4 poly-mul calls per HKEX-RNL exchange, this is ≈40
+`rnl_mod_pow` invocations (each up to 16 modular multiplications) on top of the
+butterfly work.
+
+Fix: precompute a lazy-initialized static table (same pattern as `m_inv_ba`):
+- `psi_powers[n]` — twist/untwist values for pre/post-NTT phase
+- `stage_w[log₂n]` — per-stage ω values for forward and inverse NTT
+
+Expected gain: ~5–10% reduction in HKEX-RNL exchange time.
+
+Status: **OPEN**
+
+---
+
+### 15. Fermat prime fast modulo for NTT inner loops (Performance, Medium)
+
+**Files:** C `rnl_ntt` inner loop; Go `rnlNTT` inner loop
+
+q = 65537 = 2^16 + 1 is a Fermat prime. The NTT butterfly loops execute
+`(uint64_t)a * b % RNL_Q` which issues a 64-bit division. The reduction is
+divisionless for this prime:
+
+```c
+static inline uint32_t rnl_mod_q(uint64_t x) {
+    uint32_t lo = x & 0xFFFF, hi = (x >> 16) & 0xFFFF, top = (x >> 32) & 1;
+    int32_t r = (int32_t)(lo - hi + top);
+    if (r < 0)      r += RNL_Q;
+    if (r >= RNL_Q) r -= RNL_Q;
+    return (uint32_t)r;
+}
+```
+
+Each NTT call performs n/2 × log₂n = 1024 butterfly steps with 1–2 modular
+reductions each. Replacing `% RNL_Q` in the hot path eliminates all divides.
+Expected speedup: ~2× for the NTT, ~1.3–1.5× for a full HKEX-RNL exchange.
+
+Status: **OPEN**
+
+---
+
+### 16. `rnl_cbd_poly` bit-per-byte inefficiency (Performance, Low)
+
+**Files:** C `rnl_cbd_poly`; Go `rnlCBDPoly`; Python `_rnl_cbd_poly`
+
+With η=1 each coefficient needs 2 bits (one `a` bit, one `b` bit). Current code
+reads 1 byte per coefficient and uses only bits 0–1 → 75% of urandom entropy
+discarded. For n=256 that is 256 bytes drawn when 64 would suffice.
+
+Fix: process 4 coefficients per byte (bit-pairs at positions 0-1, 2-3, 4-5, 6-7).
+Apply to C, Go, Python. Note: byte-for-byte output changes — update affected tests.
+
+Status: **OPEN**
+
+---
+
+## Updated priority order
+
+1. #9  — HSKE-NL-A1 counter=0 degeneracy (security regression matching KDF fix)
+2. #13 — HKEX-RNL failure rate (close pending-verification gap)
+3. #12 — HSKE-NL-A2 deterministic encryption caveat (documentation)
+4. #15 — Fermat prime fast modulo (largest performance win)
+5. #14 — NTT twiddle precomputation (moderate performance win)
+6. #10 — Stale q=3329 comment (trivial)
+7. #11 — Stale §11.6 KDF formula (trivial)
+8. #16 — CBD bit efficiency (low effort, minor gain)


### PR DESCRIPTION
## Summary

- **Security fix (TODO #9):** HSKE-NL-A1 keystream passed `A = B = base` when `counter = 0`, causing `FSCX(base, base) = M(0) = 0` on step 1. Only the linear term `ROL(2·base, n/4)` contributed; non-linearity accumulated from step 2 of n/4 only. Same degeneracy was fixed for HKEX-RNL KDF in v1.5.10. Fix: use `ROL(base, n/8)` as the seed (A argument) across all targets.
- **Trivial fixes (TODO #10, #11):** Stale `q=3329` comment in C main() corrected to `q=65537`; SecurityProofs.md §11.6 KDF table entry updated to reflect v1.5.10 seed formula.
- **Pre-existing build fix:** `randBA` → `NewRandBitArray` typo in Go suite that prevented `go run` from compiling.

## Files changed (12)

| Target | Change |
|--------|--------|
| `Herradura cryptographic suite.c` | `ba_rol_k(&seed_a1, &base_a1, KEYBYTES)` + stale comment fix |
| `Herradura cryptographic suite.go` | `baseA1.RotateLeft(n/8)` + `randBA`→`NewRandBitArray` |
| `Herradura cryptographic suite.py` | `base_a1.rotated(KEYBITS // 8)` |
| `Herradura cryptographic suite.s` | `ror r0, r0, #28` (= ROL by 4) |
| `Herradura cryptographic suite.asm` | `rol eax, 4` |
| `Herradura cryptographic suite.ino` | `_rol32(base, 4)` |
| `CryptosuiteTests/Herradura_tests.c` | inline ROL in test [12] for n=64 (`<<8\|>>56`) and n=128 (`<<16\|>>112`) |
| `CryptosuiteTests/Herradura_tests.go` | `base.RotateLeft(size/8)` in test [12] |
| `CryptosuiteTests/Herradura_tests.py` | `base.rotated(size // 8)` in test [12] and bench [23] |
| `SecurityProofs.md` | §11.3.1 formula + seed-rotation rationale; §11.6 KDF entry |
| `CHANGELOG.md` | v1.5.13 entry |
| `TODO.md` | items #9, #10, #11 marked DONE |

## Test plan

- [x] `gcc -O2` C suite builds cleanly
- [x] `go run` Go suite: all protocols `+ correct` / `+ agree` / `+ verified`
- [x] `python3` Python suite: all protocols pass
- [x] `./CryptosuiteTests/Herradura_tests -r 200 -t 2.0`: tests [12]–[16] all PASS
- [x] `go run CryptosuiteTests/Herradura_tests.go -r 200 -t 2.0`: tests [12]–[16] all PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)