### PR TITLE
v1.5.14–15: HSKE-NL-A2 caveat, CHANGELOG backfill, HKEX-RNL failure-rate analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,292 @@ For n=32 (ARM Thumb-2, NASM i386, Arduino): `ROL(base, 4)` — implemented as `R
 
 ---
 
+## [1.5.12] - 2026-04-24
+
+### Changed — `SecurityProofs.md`: §12 integrated into earlier sections
+
+`§12 (Classical and Quantum Security Analysis)` was a late appendix holding
+analysis that logically belonged alongside the earlier protocol-development sections.
+Content redistributed to match the development timeline:
+
+- **§9.2.4** — expanded with full DLP attack taxonomy (BSGS, Pohlig–Hellman, index
+  calculus, quasi-polynomial), n=32 BSGS experimental verification, and cross-reference
+  to §10.9.
+- **§6** — added cross-reference to §10.8 for post-fix quantum analysis.
+- **§10.6** — classical security analysis of v1.4.0 protocols (HSKE known-plaintext,
+  HPKS forgery resistance, HPKE CDH attack path).
+- **§10.7** — HPKS challenge function algebraic properties (affine bijection,
+  predictable delta identity, ROM gap for EUF-CMA).
+- **§10.8** — quantum algorithm analysis for v1.4.0 (Grover, Simon, Bernstein–Vazirani,
+  Shor, HHL).
+- **§10.9** — root-cause analysis of GF(2^n)* as DLP group; comparison table across
+  GF(2^n)*, Z_p*, ECDLP, Ring-LWR; motivation for HKEX-RNL.
+- **§11.7** — protocol-level quantum security summary table (all protocols).
+- **§12 removed** — no content lost; every subsection relocated.
+
+**Files changed (1):** `SecurityProofs.md`.
+
+---
+
+## [1.5.11] - 2026-04-23
+
+### Fixed — KaTeX rendering errors in `SecurityProofs.md` §11
+
+Four incremental fixes resolving three distinct parse failures in §11.4:
+
+1. **`\$` inside inline math** (§11.4.2, line 1065): GitHub's Markdown parser treats
+   `\$` as closing the `$...$` span, leaving `\overset{` with an unclosed brace.
+   Fix: `\overset{\$}` → `\overset{\textdollar}`.
+
+2. **`\{`/`\}` inside italic span** (§11.4.1, line 1039): `\{`/`\}` inside `*...*`
+   italic markup are Markdown-escaped to bare `{`/`}` before KaTeX sees them, making
+   set braces invisible.
+   Fix: `\{` → `\lbrace`, `\}` → `\rbrace` (letter-prefixed; not a Markdown escape).
+
+3. **Italic span blocking math** (§11.4.1): the `*Verified for ...*` span prevented
+   GitHub's math extension from parsing `$...$` delimiters inside it.
+   Fix: removed the `*...*` italic markers; `\{`/`\}` reverted from `\lbrace`/`\rbrace`
+   (not needed outside italic context).
+
+4. **Nested parentheses breaking math span** (§11.4.2, KDF formula): formula
+   `($sk = \text{NL-FSCX-REVOLVE}(K, K, n/4)$)` — the inner `(K, K, n/4)` parens
+   satisfy GitHub's link-paren-depth tracker before the `$` math span closes.
+   Fix: outer `(` `$...$` `)` rewritten as `, where $sk = ...,$` (no wrapping parens).
+
+**Files changed (1):** `SecurityProofs.md`.
+
+---
+
+## [1.5.10] - 2026-04-22
+
+### Changed — HKEX-RNL KDF simplified to single-pass with ROL(K, n/8) seed
+
+The KDF seed degeneracy (`fscx(K, K) = 0` on step 1 when A₀ = B = K`) was the root
+cause.  Two-pass chain (v1.5.10-initial) was simplified to a single pass once the v2
+second pass was shown to be bijective for fixed K — adding no one-wayness.
+
+**Final KDF (all targets):**
+```
+seed = ROL(K, n/8);  sk = nl_fscx_revolve_v1(seed, K, n/4)
+```
+
+For n=256 (C/Go/Python): `ROL(K, 32)`.
+For n=32 (assembly/Arduino/C-tests): `ROL(K, 4)`.
+
+`SecurityProofs.md §11.4` updated with algebraic rationale and revised table.
+
+**Files changed (12):** all language targets (suite + tests) and `SecurityProofs.md`.
+
+**TODO.md item closed:** #4 (HKEX-RNL KDF degeneracy fix).
+
+---
+
+## [1.5.9] - 2026-04-22
+
+### Changed — `nl_fscx_revolve_v2_inv`: precompute δ(B) once; HSKE-NL-A1 per-session nonce
+
+Two independent improvements across all language targets:
+
+#### Performance — precompute δ(B) in `nl_fscx_revolve_v2_inv`
+
+`delta(B)` was recomputed on every iteration even though B is constant throughout the
+loop.  Now computed once before the loop; inner body becomes `z = y − delta; y = B ⊕ m_inv(z)`.
+Eliminates one multiply-and-rotate (or big-integer multiply for n=256) per step in
+Python, C (32/64/128-bit), Go, Arduino, ARM Thumb-2, and NASM i386.
+
+**Files changed (12):** all language targets (suite + tests). Closes TODO #8.
+
+#### Security — HSKE-NL-A1 per-session nonce
+
+Added random nonce N to HSKE-NL-A1 counter-mode so the keystream changes each session
+even when K is reused.  Session base becomes `K ⊕ N`; N is generated fresh per run and
+displayed alongside ciphertext.  Applied to Python, C, Go, Arduino, ARM Thumb-2, and
+NASM i386 suite + test files.
+
+**Files changed (9):** suite and test files for all targets. Closes TODO #3.
+
+---
+
+## [1.5.8] - 2026-04-21
+
+### Added — build and run scripts for all language targets
+
+Eight shell scripts added to the repository root:
+
+| Script | Purpose |
+|---|---|
+| `build_c.sh` | Build C suite and tests; checks for `gcc` |
+| `build_go.sh` | Build Go suite and tests; checks for `go` |
+| `build_arm.sh` | Build ARM Thumb-2 binaries; checks for `arm-linux-gnueabi-gcc` |
+| `build_asm_i386.sh` | Build NASM i386 binaries; checks for `nasm` + linker |
+| `build_arduino.sh` | Build Arduino firmware; checks for `arduino-cli` |
+| `run_arm.sh` | Run ARM binaries via `qemu-arm`; usage instructions |
+| `run_asm_i386.sh` | Run i386 binaries via `qemu-i386`; usage instructions |
+| `run_arduino.sh` | Run Arduino firmware via `simavr`; usage instructions |
+
+Each build script prints `apt-get install` instructions for any missing tool.
+
+**Files changed (8):** new scripts only.
+
+---
+
+## [1.5.7] - 2026-04-21
+
+### Changed — precomputed M⁻¹ rotation table for `nl_fscx_v2_inv`; Arduino banner fix
+
+#### Performance — precomputed M⁻¹ rotation table
+
+`M⁻¹(X) = M^{n/2−1}(X)` is now applied via a precomputed rotation table: XOR of
+`ROL(X, k)` for each `k` where bit `k` of `M⁻¹(1)` is set.
+
+- **n=256 (C/Go/Python):** table bootstrapped once on first call via the old
+  `fscx_revolve` path (lazy init, cached per bit-size).
+- **n=32 (assembly/Arduino/C-tests):** constant `0x6DB6DB6D` hardcoded
+  (21 rotations, analytically verified).
+- **n=64/128 (C test file):** 64-bit constants hardcoded.
+
+Reduces each `nl_fscx_v2_inv` step from 127 FSCX iterations (n=256) to ~170
+XOR-rotation pairs (~2n/3 density). All language targets updated: C, Go, Python,
+Arduino (unrolled helper), ARM Thumb-2 (ROR+EOR pairs), NASM i386 (ROL+XOR pairs).
+
+**Files changed (12):** all language targets (suite + tests).
+
+#### Fixed — stale v1.5.3 version banner in Arduino `loop()`
+
+`loop()` in both `.ino` files still printed `v1.5.3`; corrected to `v1.5.7`.
+
+**Files changed (2):** `Herradura cryptographic suite.ino`, `CryptosuiteTests/Herradura_tests.ino`.
+
+---
+
+## [1.5.6] - 2026-04-20
+
+### Fixed — modular bias in `rnl_rand_poly` — 3-byte rejection sampling
+
+The previous 4-byte draw followed by naive `% Q` had ~1/2³² per-coefficient bias
+(value 0 appeared once more than all others over the full 32-bit cycle).
+
+**Fix (all targets):** 24-bit rejection-sampling loop with threshold
+`(1<<24) − (1<<24)%65537 = 16711935`. Rejection probability ≈ 0.39%.
+
+Added `rnl_rand_coeff()` helper to C tests (replaces `rand32()%Q` in
+`rnl32_rand_poly` and `rnl_rand_poly_n`).
+
+Applied to: Python, C, Go, ARM Thumb-2, NASM i386, Arduino.
+
+**Files changed (9):** `Herradura cryptographic suite.{c,go,py,s,asm,ino}`,
+`CryptosuiteTests/Herradura_tests.{c,go,py}`.
+
+---
+
+## [1.5.5] - 2026-04-20
+
+### Changed — C test suite: multi-size loops, PQC benchmarks, output alignment (Phases 1–5)
+
+Five-phase expansion bringing `Herradura_tests.c` to full parity with Python and Go:
+
+#### Phase 1–2 (earlier) — infrastructure
+
+Generalized `BitArray` with `int nbits`/`int nbytes` fields; added `ba_add` (mod 2ⁿ
+addition) required by NL-FSCX at non-32-bit widths. Added `gf_mul_64`/`gf_pow_64`
+(GF(2⁶⁴), poly `0x1B`) and corresponding 64-bit FSCX/NL-FSCX primitives.
+
+#### Phase 3 — GF/NL multi-size loops (tests [1],[5]–[9],[14]–[16])
+
+- Tests [1],[5],[6]: loop over `{32, 64, 256}`.
+- Tests [7]–[9],[14]–[16]: loop over `{32, 64}`.
+- Key-sensitivity PASS criterion aligned to `mean ≥ n/4` (matching Python/Go).
+- 64-bit Schnorr uses `__uint128_t` for `(a·e) mod (2⁶⁴−1)` overflow safety.
+
+#### Phase 4 — FSCX/NL-FSCX multi-size loops (tests [2]–[4],[10]–[13])
+
+Added 128-bit FSCX primitives (`fscx128`/`fscx_revolve128` via `__uint128_t`) and full
+128-bit NL-FSCX v1/v2/inv suite; `rol128_32` for n/4=32-bit shift; `rand128()` helper.
+
+- Tests [2]–[4]: loop `{64, 128, 256}` using `fscx64`/`fscx128`/`ba_fscx` dispatch.
+- Tests [10]–[13]: loop `{64, 128}` using 64/128-bit NL-FSCX scalar functions.
+  (256-bit NL-FSCX deferred — requires 256-bit integer multiply.)
+- `popcount128()` helper for 128-bit Hamming distance in test [2].
+
+#### Phase 5 — test [11] bijectivity methodology alignment
+
+Upgraded test [11] bijectivity sub-test to match Python/Go: sample
+`BIJ_SAMPLES=256` random A values per B and detect output collisions via O(n²)
+pairwise scan (vs. prior single-pair draw).
+
+#### Output and benchmarks alignment
+
+- Version banner bumped to v1.5.5 in `Herradura_tests.c`, `.py`, `.go`.
+- C test labels: added `[CLASSICAL]` tag to tests [1]–[9] and `[PQC-EXT]` to
+  [10]–[16], matching existing Python/Go output.
+- C section headers renamed to match Python/Go.
+- PQC benchmarks [22]–[25] ported from Python/Go to C:
+  - [22] NL-FSCX v1 revolve throughput (32-bit, n/4=8 steps)
+  - [22b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val=24 steps)
+  - [23] HSKE-NL-A1 counter-mode throughput (32-bit, ctr=0)
+  - [24] HSKE-NL-A2 revolve-mode round-trip (32-bit, r_val=24 steps)
+  - [25] HKEX-RNL full handshake throughput (n=32)
+
+**Files changed (3):** `CryptosuiteTests/Herradura_tests.{c,go,py}`.
+
+---
+
+## [1.5.4] - 2026-04-20
+
+### Changed — replace O(n²) polynomial multiplication with negacyclic NTT in all implementations
+
+Cooley-Tukey NTT over Z₆₅₅₃₇ (Fermat prime) with negacyclic twist
+`ψ = 3^{(q−1)/(2n)} mod q` replaces the naive O(n²) `_rnl_poly_mul` in every
+language implementation and test suite. ~32× speedup at n=256; ~6× at n=32.
+
+| Target | Change |
+|---|---|
+| C, Go, Python | `rnl_ntt`/`rnlNTT`/`_ntt_inplace` + NTT-based `poly_mul` |
+| ARM Thumb-2 (.s) | Precomputed tables + `rnl_ntt` subroutine (`umull` + fast Fermat mod) |
+| NASM i386 (.asm) | Precomputed tables + `rnl_ntt` (stack-frame cdecl) + NTT `poly_mul` |
+| Arduino (.ino) | Same NTT using `uint64_t` multiply |
+
+`SecurityProofs.md` status line updated with v1.5.4 NTT note.
+
+**Files changed (13):** all language targets (suite + tests) and `SecurityProofs.md`.
+
+---
+
+## [1.5.3] - 2026-04-19
+
+### Changed — HKEX-RNL secret sampler upgraded to CBD(η=1); assembly bug fixes
+
+#### Security — CBD(η=1) secret polynomial sampler
+
+Replaced the uniform `{0,1}` secret polynomial sampler (`rnl_small_poly` /
+`rnlSmallPoly` / `_rnl_small_poly`) with centered binomial distribution CBD(η=1)
+across all language targets.
+
+CBD(1) samples each coefficient as `(a − b) mod q` where `a, b` are independent
+uniform bits, producing values in `{−1, 0, 1}` with zero mean and `P(±1) = 1/4`.
+This matches the Kyber/NIST PQC baseline secret distribution and eliminates the
+positive mean bias of the previous `{0,1}` sampler — a prerequisite for standard
+Ring-LWR hardness arguments. The max coefficient magnitude (1) is unchanged, so
+the noise budget and parameter set `(n, q, p, p', η)` are unaffected.
+
+`SecurityProofs.md §11.4.2` and `§11.6` updated to document CBD(η=1) and its rationale.
+
+**Files changed (13):** all language targets (suite + tests) and `SecurityProofs.md`.
+
+#### Fixed — ARM `cbz` hi-register and NASM `poly_mul` stack offset
+
+- **ARM Thumb-2:** `cbz` only accepts lo-registers r0–r7; replaced `cbz r9`/`cbz r10`
+  with `cmp`+`beq` pairs in both `.s` files.
+- **NASM i386:** after `pop ebx` in `rnl_poly_mul`, `[esp]` = k and `[esp+4]` = i;
+  the code was reading `[esp+4]` (= i) to get k, writing every partial product to
+  `rnl_tmp[i]` instead of `rnl_tmp[k]`. Fixed to `[esp]` in both `.rpm_add_no_sub`
+  and `.rpm_neg_no_sub` branches in both `.asm` files.
+
+**Files changed (4):** `Herradura cryptographic suite.{asm,s}`,
+`CryptosuiteTests/Herradura_tests.{asm,s}`.
+
+---
+
 ## [1.5.2] - 2026-04-18
 
 ### Fixed — KaTeX rendering in `SecurityProofs.md` (`^*` and `\mathcal{R}_q` cross-span emphasis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.14] - 2026-04-25
+
+### Documentation — HSKE-NL-A2 deterministic encryption caveat (all targets)
+
+HSKE-NL-A2 carries no nonce: the same (plaintext, key) pair always produces the
+same ciphertext.  It does not achieve IND-CPA security in the multi-message sense
+unless an external session differentiator is embedded in the plaintext before
+encryption.  This usage constraint was undocumented; added in all seven locations:
+
+- **`SecurityProofs.md §11.3.2`** — new paragraph after the cost analysis:
+  explains the IND-CPA gap, contrasts with HSKE-NL-A1's per-session nonce, and
+  gives concrete guidance (embed sequence number / nonce / session ID in plaintext).
+- **`Herradura cryptographic suite.py`** — `CAUTION:` line added to the HSKE-NL-A2
+  protocol comment block.
+- **`Herradura cryptographic suite.c`** — same `CAUTION:` added to the block comment.
+- **`Herradura cryptographic suite.go`** — one-liner in the protocol list expanded to
+  note determinism and multi-message constraint.
+- **`Herradura cryptographic suite.s`** (ARM Thumb-2) — `CAUTION:` line added inside
+  the block comment preceding the HSKE-NL-A2 section.
+- **`Herradura cryptographic suite.asm`** (NASM i386) — `CAUTION:` comment added
+  above the `mov eax, hske_nl2_hdr` instruction.
+- **`Herradura cryptographic suite.ino`** (Arduino) — `CAUTION:` comment added inside
+  the banner block.
+
+**No functional code changes.**
+
+---
+
 ## [1.5.13] - 2026-04-24
 
 ### Fixed — HSKE-NL-A1 counter=0 step-1 degeneracy (security, all targets)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.15] - 2026-04-25
+
+### Analysis — HKEX-RNL key-agreement failure rate characterized (all deployed parameters)
+
+New script `SecurityProofsCode/hkex_rnl_failure_rate.py` measures the empirical
+key-disagreement rate P(K_A ≠ K_B) at deployed parameters across four sections.
+
+#### Results
+
+| Parameters | Failures | Rate | 95% CI |
+|---|---|---|---|
+| n=32, p=4096, η=1, 10 000 trials | 204/10 000 | **2.04%** | 1.78–2.34% |
+| n=256, p=4096, η=1, 5 000 trials | 1 862/5 000 | **37.24%** | 35.9–38.6% |
+
+Single-bit errors dominate (201/204 at n=32; 1456/1862 at n=256). Maximum bit-error
+count: 2 at n=32, 5 at n=256.
+
+#### Root-cause analysis (§2)
+
+Per-coefficient error (`max|eA−eB| = 134`) is tiny relative to the extraction threshold
+(16 384 = q/4), yet failures occur at extraction boundaries.  Root cause: ring convolution
+over n coefficients accumulates error as O(√n), so at n=256 boundary crossings are frequent.
+A p-sensitivity sweep (§4) confirms no p value below q fixes the problem (0.80% at p=8192).
+
+#### Verdict
+
+**Reconciliation hints required.** The single-polynomial structure of HKEX-RNL (vs. the
+k×k matrix in Kyber) gives insufficient noise averaging at n=256.  NewHope-style 1-bit
+reconciliation hints are needed; they add n/8 bytes of public data per party and reduce the
+failure rate to effectively zero.  Architectural fix planned (TODO.md item #13).
+
+#### Files changed
+
+- `SecurityProofsCode/hkex_rnl_failure_rate.py` — new; four-section analysis script
+- `SecurityProofs.md §11.5 Q2` — four new rows; removed ⚠ pending-verification note;
+  added p-sensitivity table
+- `SecurityProofs.md §11.6` — replaced stale "reliable without reconciliation" claim with
+  correctness-warning block; added failure-rate table and reconciliation-hint requirement
+
+---
+
 ## [1.5.14] - 2026-04-25
 
 ### Documentation — HSKE-NL-A2 deterministic encryption caveat (all targets)

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -577,6 +577,7 @@ _start:
 .nl1_done:
 
     ; ================================================================== HSKE-NL-A2
+    ; CAUTION: deterministic — same (plain, key) always yields same E.
     mov  eax, hske_nl2_hdr
     mov  ecx, hske_nl2_hdr_l
     call print_str

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -776,6 +776,8 @@ HSKE-NL-A1 (counter-mode with NL-FSCX v1, 256-bit):
 HSKE-NL-A2 (revolve-mode with NL-FSCX v2, 256-bit):
     E = nl_fscx_revolve_v2(P, K, R_VALUE)
     D = nl_fscx_revolve_v2_inv(E, K, R_VALUE) = P
+    CAUTION: Deterministic — same (P, K) always yields the same E. Embed a nonce
+    in P when multiple messages may be encrypted under the same key.
 
 HKEX-RNL (Ring-LWR key exchange, n=256):
     Shared m_blind = m(x) + a_rand in Z_q[x]/(x^n+1)

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -72,7 +72,8 @@
 
     PQC protocol variants (C3 hybrid assignment):
       HSKE-NL-A1  — counter-mode HSKE with NL-FSCX v1 keystream
-      HSKE-NL-A2  — revolve-mode HSKE with NL-FSCX v2 (invertible)
+      HSKE-NL-A2  — revolve-mode HSKE with NL-FSCX v2 (invertible); deterministic
+                    (no nonce — embed one in plaintext for multi-message use)
       HKEX-RNL    — Ring-LWR key exchange (quantum-resistant; replaces HKEX-GF)
       HPKS-NL     — Schnorr with NL-FSCX v1 challenge (linear preimage hardened)
       HPKE-NL     — El Gamal with NL-FSCX v2 encryption/decryption

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -410,6 +410,7 @@ void loop() {
 
     /* ---------------------------------------------------------------- */
     /* HSKE-NL-A2 [PQC-HARDENED -- revolve-mode with NL-FSCX v2]      */
+    /* CAUTION: deterministic -- same (P, K) always yields the same E. */
     /* ---------------------------------------------------------------- */
     Serial.println("--- HSKE-NL-A2 [PQC-HARDENED -- revolve-mode with NL-FSCX v2]");
     {

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -535,6 +535,9 @@ HSKE-NL-A2 (revolve-mode HSKE with NL-FSCX v2):
   Decrypt:  D = nl_fscx_revolve_v2_inv(E, K, r)  [closed-form inverse]
   Security: B-channel non-linearity defeats linear key-recovery on K.
             API-compatible with classical HSKE (same encrypt/decrypt shape).
+  CAUTION:  Deterministic — same (P, K) always yields the same E. Not IND-CPA
+            in the multi-message sense without a nonce in P. Prefer HSKE-NL-A1
+            when multiple messages may be encrypted under the same key.
 
 HKEX-RNL (Ring-LWR key exchange — quantum-resistant):
   Setup:    a_rand random; m_blind = m(x) + a_rand  [m(x)=1+x+x^{n-1}]

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -593,6 +593,7 @@ hske_nl1_done:
        HSKE-NL-A2  (revolve-mode with NL-FSCX v2)
        E = nl_fscx_revolve_v2(plain, key, I_VALUE)
        D = nl_fscx_revolve_v2_inv(E, key, I_VALUE)  must == plain
+       CAUTION: deterministic — same (plain, key) always yields same E.
        ================================================================ */
     ldr     r0, =fmt_hske_nl2_hdr
     bl      printf

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1378,10 +1378,9 @@ All results are from `SecurityProofsCode/hkex_nl_verification.py` (n=32 unless n
 | NL-FSCX v1 period (n=32, 500 samples) | 500/500 find no period in 256 steps | Period property completely destroyed |
 | HSKE-A1 counter mode encrypt→decrypt | 200/200 correct | Counter mode is viable |
 
-#### Q2 — FSCX-LWR algebraic attack
+#### Q2 — FSCX-LWR algebraic attack and key-agreement correctness
 
-All rows below use $n = 16$ unless noted.  The deployed implementation uses $q = 65537$,
-$n \in \{32, 256\}$; those parameter pairs are marked ⚠ pending verification.
+All rows below use $n = 16$ unless noted.
 
 | Test | Result | Conclusion |
 |------|--------|------------|
@@ -1392,6 +1391,10 @@ $n \in \{32, 256\}$; those parameter pairs are marked ⚠ pending verification.
 | Naive attack: exact $s$ recovery (fixed $m$, $q=769$, $n=16$, $p \in \{4…256\}$) | 0/200 for every $p$ value | Rounding noise too large for naive inversion |
 | Noise amplification $\|m^{-1}\|_1 \cdot q/(2p)$ vs. $q$ | Exceeds $q$ for all tested $(q,p)$ | Structural protection against naive inversion |
 | Blinded $m$ vs. fixed $m$ (naive attack) | Both 0/200 | Blinding adds standard Ring-LWR hardness beyond structural noise protection |
+| **Key-agreement failure rate** ($q=65537$, $n=32$, $p=4096$, $\eta=1$), 10 000 trials | **204 / 10 000 = 2.04%** (95% CI: 1.78–2.34%) | Fails the <1% threshold; reconciliation hints required. Single-bit errors dominate (201/204). `hkex_rnl_failure_rate.py` §1 |
+| **Key-agreement failure rate** ($q=65537$, $n=256$, $p=4096$, $\eta=1$), 5 000 trials | **1 862 / 5 000 = 37.24%** (95% CI: 35.9–38.6%) | Completely unusable without reconciliation. Per-coeff error accumulates as $O(\sqrt{n})$ via ring convolution. `hkex_rnl_failure_rate.py` §3 |
+| Max per-coeff error $\|e_A - e_B\|_\infty$ ($n=32$, 10 000 trials) | 134 (0.82% of extraction threshold 16 384) | Individual errors are tiny; failures occur only near extraction boundaries. §2 |
+| $p$-sensitivity at $n=32$: failure rate vs. $p \in \{512,\ldots,8192\}$ | 14.7% → 8.45% → 4.4% → 2.2% → 0.80% | No tested $p$ achieves <1%; architectural fix (reconciliation hints) required. §4 |
 
 #### Q3 — NL-FSCX injectivity and inverse
 
@@ -1420,26 +1423,42 @@ The C3 hybrid assigns each primitive to the role that matches its properties:
 | HPKS commitment hash | **NL-FSCX v1** revolve | One-way; hardened against linear preimage |
 | HPKE encryption | **NL-FSCX v2** revolve | Invertible; bijective |
 
-**Parameters for HKEX-RNL** (deployed in v1.5.0; secret sampler upgraded to CBD in v1.5.3; requires further analysis before production use):
+**Parameters for HKEX-RNL** (deployed in v1.5.0; CBD sampler in v1.5.3; correctness verified in v1.5.15):
 - $n = 256$ (suite C/Go/Python), $n = 32$ (assembly, Arduino, C/Go/Python tests)
-- $q = 65537$ ($= 2^{16}+1$, Fermat prime); chosen over $q = 3329$ (Kyber) for lower
-  noise-to-margin ratio at small $n$, ensuring reliable single-block agreement without
-  reconciliation hints
+- $q = 65537$ ($= 2^{16}+1$, Fermat prime)
 - $p = 4096$, $p' = 2$ (1 bit extracted per ring coefficient)
-- **Secret distribution:** $\mathrm{CBD}(\eta=1)$, coefficients in $\{-1, 0, 1\}$ with zero mean (upgraded from uniform $\{0,1\}$ in v1.5.3)
+- **Secret distribution:** $\mathrm{CBD}(\eta=1)$, coefficients in $\{-1, 0, 1\}$ with zero mean
 - $a_\text{rand}$: $n$-coefficient polynomial, coefficients uniform in $\mathbb{Z}/q\mathbb{Z}$, transmitted per session
 - KDF: $\text{seed} = \text{ROL}(K_\text{raw},\; n/8)$; $sk = \text{NL-FSCX}\textunderscore\text{REVOLVE}\textunderscore\text{v1}(\text{seed},\; K_\text{raw},\; n/4)$
 
-*Verification.* The invertibility of $m(x)$ in $\mathbb{Z}_q[x]/(x^n+1)$ is confirmed for
-the deployed parameters $(q=65537, n=32)$ and $(q=65537, n=256)$ by `hkex_nl_verification.py` §2.1.
-Noise amplification at $p=4096$ gives $\|m^{-1}\|_1 \cdot q/(2p) \approx 4.3\times10^6 \gg q$,
-confirming structural protection against naive inversion (§11.4.3, §11.5 Q2).
-The max coefficient magnitude of $\mathrm{CBD}(1)$ equals that of the previous $\{0,1\}$ sampler,
-so the noise budget is unchanged.
+*Algebraic verification.* Invertibility of $m(x)$ in $\mathbb{Z}_q[x]/(x^n+1)$ confirmed for
+$(q=65537, n \in \{32, 256\})$ by `hkex_nl_verification.py` §2.1.  Noise amplification
+$\|m^{-1}\|_1 \cdot q/(2p) \approx 4.3\times10^6 \gg q$ confirms structural protection against
+naive algebraic inversion (§11.4.3, §11.5 Q2).
+
+**⚠ Correctness warning — reconciliation hints required.**
+Empirical failure-rate measurement (`hkex_rnl_failure_rate.py`, v1.5.15) shows:
+
+| Parameters | Failure rate | 95% CI |
+|---|---|---|
+| $n=32$, $p=4096$, $\eta=1$, 10 000 trials | **2.04%** | 1.78–2.34% |
+| $n=256$, $p=4096$, $\eta=1$, 5 000 trials | **37.24%** | 35.9–38.6% |
+
+Root cause: the per-coefficient error in $K_\text{poly}$ accumulates as $O(\sqrt{n})$ via ring
+convolution over $n$ terms (each CBD(1) coefficient × rounding noise $\leq q/(2p) = 8$).
+Although individual errors are tiny ($\leq 134$ out of extraction threshold 16 384), extraction
+boundaries at $q/4$ and $3q/4$ are crossed frequently when 256 error terms accumulate.
+Increasing $p$ alone does not fix the problem: a p-sensitivity sweep at $n=32$ shows 0.80%
+failure rate even at $p=8192$.  The $n=256$ case requires architectural correction.
+
+**Required fix:** NewHope-style 1-bit reconciliation hints.  Each party transmits one hint bit per
+ring coefficient indicating which side of the nearest extraction boundary their value lies on;
+the other party uses the hint to resolve near-boundary cases.  This reduces the failure rate to
+effectively zero without changing the security assumptions.  Planned in TODO.md item #13.
 
 **Status.** The NL-FSCX primitives and HKEX-RNL were implemented across all languages in v1.5.0.
-The CBD(eta=1) secret sampler was deployed across all language implementations in v1.5.3.
-The C3 hybrid assignment (table above) governs the current implementation.
+The CBD(η=1) secret sampler was deployed in v1.5.3.  Correctness failure characterised in v1.5.15.
+Reconciliation hints are required before production use.
 
 ---
 

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1259,6 +1259,14 @@ The explicit inverse from §11.2.2 is applied $r$ times, each costing one intege
 one ROL, and one application of $M^{-1} = M^{n/2-1}$, so total decrypt cost is
 $O(r \cdot n/2)$ FSCX steps — same asymptotic order as standard HSKE.
 
+**Usage constraint — deterministic encryption.** HSKE-NL-A2 carries no nonce:
+the same (plaintext, key) pair always produces the same ciphertext.  It does not
+achieve IND-CPA security in the multi-message sense unless an external session
+differentiator (sequence number, nonce, or session ID) is embedded in the
+plaintext before encryption.  HSKE-NL-A1 (§11.3.1) provides a per-session nonce
+as part of the protocol; prefer A1 when multiple messages may be encrypted under
+the same key.
+
 ---
 
 ### 11.4 HKEX-RNL: PQC Key Exchange (B2)

--- a/SecurityProofsCode/hkex_rnl_failure_rate.py
+++ b/SecurityProofsCode/hkex_rnl_failure_rate.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+hkex_rnl_failure_rate.py — Empirical HKEX-RNL key-agreement failure-rate analysis
+
+  §1  Empirical failure rate (n=32,  10 000 trials) — fast baseline
+  §2  Per-coefficient noise analysis (n=32, 10 000 trials)
+  §3  Empirical failure rate (n=256,  up to 5 000 trials) — deployed parameters
+  §4  p-sensitivity sweep (n=32, 2 000 trials per p value)
+
+Deployed parameters: q=65537, p=4096, pp=2, η=1
+SecurityProofs.md §11.5 Q2 marks (q=65537, n=256, p=4096) as ⚠ pending verification.
+"""
+
+import os
+import time
+import math
+from collections import Counter
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────────
+Q   = 65537   # Fermat prime modulus (deployed)
+PP  = 2       # extraction modulus: 1 bit per coefficient
+ETA = 1       # CBD(η=1): secret coefficients in {-1, 0, 1}
+
+SEP  = "═" * 70
+SEP2 = "─" * 70
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ring-arithmetic primitives (copied verbatim from Herradura cryptographic suite.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _ntt_inplace(a, q, invert):
+    n = len(a)
+    j = 0
+    for i in range(1, n):
+        bit = n >> 1
+        while j & bit:
+            j ^= bit
+            bit >>= 1
+        j ^= bit
+        if i < j:
+            a[i], a[j] = a[j], a[i]
+    length = 2
+    while length <= n:
+        w = pow(3, (q - 1) // length, q)
+        if invert:
+            w = pow(w, q - 2, q)
+        for i in range(0, n, length):
+            wn = 1
+            for k in range(length >> 1):
+                u = a[i + k]
+                v = a[i + k + (length >> 1)] * wn % q
+                a[i + k]                     = (u + v) % q
+                a[i + k + (length >> 1)]     = (u - v) % q
+                wn = wn * w % q
+        length <<= 1
+    if invert:
+        inv_n = pow(n, q - 2, q)
+        for i in range(n):
+            a[i] = a[i] * inv_n % q
+
+
+def _poly_mul(f, g, q, n):
+    """Multiply f*g in Z_q[x]/(x^n+1) via negacyclic NTT."""
+    psi     = pow(3, (q - 1) // (2 * n), q)
+    psi_inv = pow(psi, q - 2, q)
+    fa, ga  = list(f), list(g)
+    pw = 1
+    for i in range(n):
+        fa[i] = fa[i] * pw % q
+        ga[i] = ga[i] * pw % q
+        pw = pw * psi % q
+    _ntt_inplace(fa, q, False)
+    _ntt_inplace(ga, q, False)
+    ha = [fa[i] * ga[i] % q for i in range(n)]
+    _ntt_inplace(ha, q, True)
+    pw_inv = 1
+    for i in range(n):
+        ha[i]  = ha[i] * pw_inv % q
+        pw_inv = pw_inv * psi_inv % q
+    return ha
+
+
+def _poly_add(f, g, q):
+    return [(a + b) % q for a, b in zip(f, g)]
+
+
+def _round_poly(poly, from_q, to_p):
+    return [(c * to_p + from_q // 2) // from_q % to_p for c in poly]
+
+
+def _lift_poly(poly, from_p, to_q):
+    return [c * to_q // from_p % to_q for c in poly]
+
+
+def _m_poly(n):
+    """FSCX polynomial m(x) = 1 + x + x^{n-1}."""
+    p = [0] * n
+    p[0] = p[1] = p[n - 1] = 1
+    return p
+
+
+def _rand_poly(n, q):
+    """Uniform random polynomial over Z_q (bias-free 3-byte rejection sampling)."""
+    threshold = (1 << 24) - (1 << 24) % q
+    out = []
+    while len(out) < n:
+        v = int.from_bytes(os.urandom(3), 'big')
+        if v < threshold:
+            out.append(v % q)
+    return out
+
+
+def _cbd_poly(n, eta, q):
+    """CBD(η): each coeff = (popcount of η bits) − (popcount of next η bits) mod q."""
+    mask       = (1 << eta) - 1
+    byte_count = (2 * eta + 7) // 8
+    out = []
+    for _ in range(n):
+        raw = int.from_bytes(os.urandom(byte_count), 'big')
+        a   = bin(raw & mask).count('1')
+        b   = bin((raw >> eta) & mask).count('1')
+        out.append((a - b) % q)
+    return out
+
+
+def _extract_bits(poly, pp, n_bits):
+    """Extract 1 bit per coefficient (c >= pp//2 → 1). Returns int."""
+    threshold = pp // 2
+    val = 0
+    for i, c in enumerate(poly[:n_bits]):
+        if c >= threshold:
+            val |= (1 << i)
+    return val
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# One HKEX-RNL exchange
+# ─────────────────────────────────────────────────────────────────────────────
+
+def rnl_exchange(n, q, p, pp, eta):
+    """Run one full HKEX-RNL exchange. Returns (K_raw_A, K_raw_B, K_poly_A, K_poly_B, s_A, s_B, m_blind)."""
+    m_base  = _m_poly(n)
+    a_rand  = _rand_poly(n, q)
+    m_blind = _poly_add(m_base, a_rand, q)
+
+    s_A  = _cbd_poly(n, eta, q)
+    C_A  = _round_poly(_poly_mul(m_blind, s_A, q, n), q, p)
+
+    s_B  = _cbd_poly(n, eta, q)
+    C_B  = _round_poly(_poly_mul(m_blind, s_B, q, n), q, p)
+
+    K_poly_A = _poly_mul(s_A, _lift_poly(C_B, p, q), q, n)
+    K_poly_B = _poly_mul(s_B, _lift_poly(C_A, p, q), q, n)
+
+    K_raw_A = _extract_bits(_round_poly(K_poly_A, q, pp), pp, n)
+    K_raw_B = _extract_bits(_round_poly(K_poly_B, q, pp), pp, n)
+
+    return K_raw_A, K_raw_B, K_poly_A, K_poly_B, s_A, s_B, m_blind
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Statistics helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def wilson_ci(k, n, z=1.96):
+    """Wilson score 95% confidence interval for proportion k/n."""
+    if n == 0:
+        return (0.0, 1.0)
+    p_hat = k / n
+    denom  = 1 + z * z / n
+    centre = (p_hat + z * z / (2 * n)) / denom
+    margin = z * math.sqrt(p_hat * (1 - p_hat) / n + z * z / (4 * n * n)) / denom
+    return (max(0.0, centre - margin), centre + margin)
+
+
+def popcount(x):
+    return bin(x).count('1')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §1 — Empirical failure rate (n=32, 10 000 trials)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def section1():
+    print(SEP)
+    print("§1  Empirical failure rate  (q=65537, n=32, p=4096, pp=2, η=1)")
+    print(f"    10 000 trials")
+    print(SEP)
+    N, P, TRIALS = 32, 4096, 10_000
+
+    failures     = 0
+    bit_err_dist = Counter()
+    max_bit_err  = 0
+    fail_examples = []
+
+    t0 = time.monotonic()
+    for trial in range(TRIALS):
+        K_A, K_B, *_ = rnl_exchange(N, Q, P, PP, ETA)
+        if K_A != K_B:
+            err = popcount(K_A ^ K_B)
+            failures += 1
+            bit_err_dist[err] += 1
+            max_bit_err = max(max_bit_err, err)
+            if len(fail_examples) < 5:
+                fail_examples.append((trial, err, K_A, K_B))
+    elapsed = time.monotonic() - t0
+
+    lo, hi = wilson_ci(failures, TRIALS)
+    print(f"  Trials        : {TRIALS}")
+    print(f"  Failures      : {failures}  ({failures/TRIALS*100:.4f}%)")
+    print(f"  95% Wilson CI : [{lo*100:.4f}%, {hi*100:.4f}%]")
+    print(f"  Max bit-errors: {max_bit_err}")
+    if failures:
+        print(f"  Bit-error dist: {dict(sorted(bit_err_dist.items()))}")
+        for t, err, ka, kb in fail_examples:
+            print(f"    trial {t:5d}: {err} bit(s) wrong  K_A={ka:#010x}  K_B={kb:#010x}")
+    else:
+        print("  No failures.")
+    print(f"  Time          : {elapsed:.1f}s  ({TRIALS/elapsed:.0f} trials/s)")
+    print()
+    return failures, TRIALS
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §2 — Per-coefficient noise analysis (n=32, 10 000 trials)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def section2():
+    print(SEP2)
+    print("§2  Per-coefficient noise analysis  (q=65537, n=32, p=4096, 10 000 trials)")
+    print(SEP2)
+    N, P, TRIALS = 32, 4096, 10_000
+    threshold = Q // (2 * PP)   # = 16384: |error| must be < this for agreement
+
+    max_err_A    = 0
+    max_err_B    = 0
+    max_err_diff = 0
+    near_boundary_events = 0   # coeff-trials where the boundary q/4 or 3q/4 lies
+                                # within the error band [min(vA,vB), max(vA,vB)]
+
+    t0 = time.monotonic()
+    for _ in range(TRIALS):
+        _, _, kp_A, kp_B, s_A, s_B, m_blind = rnl_exchange(N, Q, P, PP, ETA)
+        # exact shared polynomial (ring commutativity: s_A·m·s_B == s_B·m·s_A)
+        exact = _poly_mul(s_A, _poly_mul(m_blind, s_B, Q, N), Q, N)
+
+        for i in range(N):
+            # signed error: map to (-q/2, q/2]
+            eA = (kp_A[i] - exact[i]) % Q
+            eB = (kp_B[i] - exact[i]) % Q
+            if eA > Q // 2: eA -= Q
+            if eB > Q // 2: eB -= Q
+            max_err_A    = max(max_err_A,    abs(eA))
+            max_err_B    = max(max_err_B,    abs(eB))
+            max_err_diff = max(max_err_diff, abs(eA - eB))
+            # check if either extraction boundary (q/4 or 3q/4) lies in [min,max]
+            lo_v = min(kp_A[i], kp_B[i])
+            hi_v = max(kp_A[i], kp_B[i])
+            for bdry in (Q // 4, 3 * Q // 4):
+                if lo_v <= bdry <= hi_v:
+                    near_boundary_events += 1
+                    break
+    elapsed = time.monotonic() - t0
+
+    theory_max = N * (Q // (2 * P))   # n × q/(2p)
+    print(f"  Extraction threshold q/(2·pp) : {threshold}")
+    print(f"  Theoretical max |error|       : n × q/(2p) = {N} × {Q//(2*P)} = {theory_max}")
+    print(f"  Measured max |error_A|        : {max_err_A}  ({max_err_A/threshold*100:.2f}% of threshold)")
+    print(f"  Measured max |error_B|        : {max_err_B}  ({max_err_B/threshold*100:.2f}% of threshold)")
+    print(f"  Measured max |error_A−error_B|: {max_err_diff}  ({max_err_diff/threshold*100:.2f}% of threshold)")
+    print(f"  Near-boundary events          : {near_boundary_events} / {TRIALS*N} coeff-trials  "
+          f"({near_boundary_events/(TRIALS*N)*100:.4f}%)")
+    print(f"  Time                          : {elapsed:.1f}s")
+    print()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §3 — Empirical failure rate (n=256, deployed)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def section3():
+    print(SEP)
+    print("§3  Empirical failure rate  (q=65537, n=256, p=4096, pp=2, η=1)")
+    print(SEP)
+    N, P = 256, 4096
+
+    # Time one trial to set TRIALS within a 120s budget
+    t0 = time.monotonic()
+    rnl_exchange(N, Q, P, PP, ETA)
+    t_one = time.monotonic() - t0
+    TARGET_SEC = 120
+    TRIALS = min(5000, max(500, int(TARGET_SEC / t_one)))
+    print(f"  Single trial  : {t_one*1000:.1f}ms  →  running {TRIALS} trials (≤{TARGET_SEC}s cap)")
+    print()
+
+    failures     = 0
+    bit_err_dist = Counter()
+    max_bit_err  = 0
+    fail_examples = []
+
+    t0 = time.monotonic()
+    for trial in range(TRIALS):
+        K_A, K_B, *_ = rnl_exchange(N, Q, P, PP, ETA)
+        if K_A != K_B:
+            err = popcount(K_A ^ K_B)
+            failures += 1
+            bit_err_dist[err] += 1
+            max_bit_err = max(max_bit_err, err)
+            if len(fail_examples) < 5:
+                fail_examples.append((trial, err))
+        if (trial + 1) % 500 == 0:
+            print(f"  ... {trial+1:>5}/{TRIALS}  failures so far: {failures}"
+                  f"  ({time.monotonic()-t0:.0f}s)")
+    elapsed = time.monotonic() - t0
+
+    lo, hi = wilson_ci(failures, TRIALS)
+    print(f"  Trials        : {TRIALS}")
+    print(f"  Failures      : {failures}  ({failures/TRIALS*100:.4f}%)")
+    print(f"  95% Wilson CI : [{lo*100:.4f}%, {hi*100:.4f}%]")
+    print(f"  Max bit-errors: {max_bit_err}")
+    if failures:
+        print(f"  Bit-error dist: {dict(sorted(bit_err_dist.items()))}")
+        for t, err in fail_examples:
+            print(f"    trial {t:5d}: {err} bit(s) wrong")
+    else:
+        print("  No failures.")
+    print(f"  Time          : {elapsed:.1f}s  ({TRIALS/elapsed:.2f} trials/s)")
+    print()
+    return failures, TRIALS
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §4 — p-sensitivity sweep (n=32, 2 000 trials per p value)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def section4():
+    print(SEP2)
+    print("§4  p-sensitivity sweep  (q=65537, n=32, pp=2, η=1, 2 000 trials per p)")
+    print(SEP2)
+    N, TRIALS = 32, 2_000
+    P_VALUES  = [512, 1024, 2048, 4096, 8192]
+
+    print(f"  {'p':>6}  {'failures':>10}  {'rate%':>8}  {'95% CI (lo%..hi%)':>26}  {'q/(2p)':>8}")
+    print(f"  {'─'*6}  {'─'*10}  {'─'*8}  {'─'*26}  {'─'*8}")
+    for p in P_VALUES:
+        fails = 0
+        for _ in range(TRIALS):
+            K_A, K_B, *_ = rnl_exchange(N, Q, p, PP, ETA)
+            if K_A != K_B:
+                fails += 1
+        lo, hi = wilson_ci(fails, TRIALS)
+        margin = Q // (2 * p)
+        print(f"  {p:>6}  {fails:>10}  {fails/TRIALS*100:>8.4f}  "
+              f"[{lo*100:>8.4f}%..{hi*100:>8.4f}%]  {margin:>8}")
+    print()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main():
+    print()
+    print("hkex_rnl_failure_rate.py — HKEX-RNL key-agreement failure-rate analysis")
+    print(f"  q={Q}, η={ETA}, pp={PP} (deployed parameters)")
+    print()
+
+    f1, t1 = section1()
+    section2()
+    f3, t3 = section3()
+    section4()
+
+    print(SEP)
+    print("SUMMARY")
+    print(SEP)
+    print(f"  n=32  (baseline) : {f1}/{t1} failures  ({f1/t1*100:.4f}%)")
+    print(f"  n=256 (deployed) : {f3}/{t3} failures  ({f3/t3*100:.4f}%)")
+    print()
+
+    # Decision
+    rate32  = f1 / t1
+    rate256 = f3 / t3
+    worst   = max(rate32, rate256)
+    if worst == 0.0:
+        verdict = "PASS — zero failures observed; current parameters have adequate noise margin."
+    elif worst <= 0.001:
+        verdict = "ACCEPTABLE — low failure rate; no reconciliation needed for most uses."
+    elif worst <= 0.01:
+        verdict = "MARGINAL — consider NewHope-style 1-bit reconciliation hints."
+    else:
+        verdict = "FAIL — failure rate > 1%; reconciliation hints required before production use."
+    print(f"  Verdict: {verdict}")
+    print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- **CHANGELOG.md backfill** — add missing entries v1.5.3 through v1.5.12 (were absent between [1.5.13] and [1.5.2])
- **v1.5.14: HSKE-NL-A2 deterministic encryption caveat** — document that same (P, K) always yields the same ciphertext (no IND-CPA in multi-message sense without a nonce in P); added to `SecurityProofs.md §11.3.2` and protocol comment blocks in all 6 language targets (C, Go, Python, ARM, NASM, Arduino). No functional code changes.
- **v1.5.15: HKEX-RNL failure-rate characterization** — new `SecurityProofsCode/hkex_rnl_failure_rate.py` measures empirical P(K_A ≠ K_B); results: **2.04% at n=32** and **37.24% at n=256** at deployed parameters; root cause is O(√n) error accumulation via ring convolution; NewHope-style reconciliation hints identified as required fix; `SecurityProofs.md §11.5 Q2` and §11.6 updated with results and correctness warning.

## Commits

| Commit | Change |
|---|---|
| `0ca5f84` | CHANGELOG.md: add missing entries v1.5.3–v1.5.12 |
| `917396f` | v1.5.14: document HSKE-NL-A2 deterministic encryption constraint (all targets) |
| `e03c161` | v1.5.15: characterize HKEX-RNL failure rate — reconciliation hints required |

## Test plan
- [ ] Verify CHANGELOG.md covers v1.5.3 through v1.5.15 without gaps
- [x] Run `python3 SecurityProofsCode/hkex_rnl_failure_rate.py` — confirm ~2% failure at n=32, ~37% at n=256
- [x] Verify `SecurityProofs.md §11.5 Q2` no longer contains ⚠ pending-verification note
- [x] Verify HSKE-NL-A2 CAUTION comment present in each suite file

🤖 Generated with [Claude Code](https://claude.com/claude-code)