### PR TITLE
v1.5.17: precompute NTT twiddle tables — eliminate rnl_mod_pow per rnl_poly_mul (C, Go)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.17] - 2026-04-26
+
+### Performance — NTT twiddle precomputation eliminates `rnl_mod_pow` calls per `rnl_poly_mul` (C, Go)
+
+Adds a lazy-initialized static twiddle table to the NTT used by HKEX-RNL, eliminating all
+`rnl_mod_pow` invocations from the hot path after the first `rnl_poly_mul` call.
+
+#### What was recomputed on every call
+
+Each `rnl_poly_mul` call previously executed:
+- 2 `rnl_mod_pow` calls for ψ and ψ⁻¹ (pre/post-twist powers)
+- 3 × `log₂n` `rnl_mod_pow` calls inside the three `rnl_ntt` invocations (one per butterfly stage)
+- 1 additional `rnl_mod_pow` for n⁻¹ inside the inverse NTT
+
+Total: ~27 modular exponentiations (each up to 16 multiplications) per `rnl_poly_mul`.
+
+#### What is precomputed
+
+- `psi_pow[n]` / `psi_inv_pow[n]` — ψ^i and ψ^{-i} for pre/post-twist
+- `stage_w_fwd[log₂n]` / `stage_w_inv[log₂n]` — per-stage ω for forward/inverse NTT
+- `inv_n` — n⁻¹ mod q for INTT scaling
+
+Initialized on first use (same lazy-init pattern as `m_inv_ba`). After initialization the per-call
+cost is ~3 table lookups per stage (replacing 3 `rnl_mod_pow` calls).
+
+#### Files changed
+
+- `Herradura cryptographic suite.c` — `rnl_twiddle_init`, `rnl_tw` struct; `rnl_ntt` and `rnl_poly_mul` use precomputed table
+- `CryptosuiteTests/Herradura_tests.c` — `rnl32_tw_init`, `rnl32_tw` (2-entry array for n∈{32,64}); `rnl32_ntt`, `rnl32_poly_mul`, `rnl_poly_mul_n` use precomputed table
+- `Herradura cryptographic suite.go` — `rnlTwEntry` struct, `rnlTwCache` map, `rnlTwGet`; `rnlNTT` and `rnlPolyMul` use precomputed table
+- `CryptosuiteTests/Herradura_tests.go` — same
+
+#### Observed speedup
+
+Go bench [25] HKEX-RNL handshake (n=64): **3.15 K → 4.72 K ops/sec (+50%)**.
+C bench [25] (n=32): 66.6 K ops/sec (single size; n=64 path also optimized via `rnl_poly_mul_n`).
+
+---
+
 ## [1.5.16] - 2026-04-25
 
 ### Fix — HKEX-RNL: Peikert 1-bit reconciliation eliminates key-agreement failures (all targets)

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -619,19 +619,65 @@ static uint32_t rnl32_mod_pow(uint32_t base, uint32_t exp, uint32_t m)
     return (uint32_t)r;
 }
 
+/* Precomputed NTT twiddle tables for n∈{32,64}, q=RNL_Q32 (lazy-initialized). */
+#define RNL32_LOG2N_MAX 6  /* log2(64)=6 covers both n=32 and n=64 */
+static struct {
+    int      n;
+    uint32_t psi_pow[64];
+    uint32_t psi_inv_pow[64];
+    uint32_t stage_w_fwd[RNL32_LOG2N_MAX];
+    uint32_t stage_w_inv[RNL32_LOG2N_MAX];
+    uint32_t inv_n;
+    int      ready;
+} rnl32_tw[2] = { {32}, {64} };  /* index 0=n=32, index 1=n=64 */
+
+static void rnl32_tw_init(int idx)
+{
+    uint32_t psi, psi_inv, pw, pw_inv, w;
+    int n, i, s, length;
+    if (rnl32_tw[idx].ready) return;
+    n = rnl32_tw[idx].n;
+    psi     = rnl32_mod_pow(3, (RNL_Q32 - 1) / (2 * (uint32_t)n), RNL_Q32);
+    psi_inv = rnl32_mod_pow(psi, RNL_Q32 - 2, RNL_Q32);
+    pw = pw_inv = 1;
+    for (i = 0; i < n; i++) {
+        rnl32_tw[idx].psi_pow[i]     = pw;
+        rnl32_tw[idx].psi_inv_pow[i] = pw_inv;
+        pw     = (uint32_t)((uint64_t)pw     * psi     % RNL_Q32);
+        pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q32);
+    }
+    for (s = 0, length = 2; length <= n; length <<= 1, s++) {
+        w = rnl32_mod_pow(3, (RNL_Q32 - 1) / (uint32_t)length, RNL_Q32);
+        rnl32_tw[idx].stage_w_fwd[s] = w;
+        rnl32_tw[idx].stage_w_inv[s] = rnl32_mod_pow(w, RNL_Q32 - 2, RNL_Q32);
+    }
+    rnl32_tw[idx].inv_n = rnl32_mod_pow((uint32_t)n, RNL_Q32 - 2, RNL_Q32);
+    rnl32_tw[idx].ready = 1;
+}
+
+static int rnl32_tw_idx(int n)
+{
+    return (n == 32) ? 0 : (n == 64) ? 1 : -1;
+}
+
 static void rnl32_ntt(int32_t *a, int n, int q, int invert)
 {
-    int i, j = 0, length, k;
+    int i, j = 0, length, k, s, idx = rnl32_tw_idx(n);
     uint32_t w, wn;
+    const uint32_t *sw = NULL;
+    if (idx >= 0) { rnl32_tw_init(idx); sw = invert ? rnl32_tw[idx].stage_w_inv : rnl32_tw[idx].stage_w_fwd; }
     for (i = 1; i < n; i++) {
         int bit = n >> 1;
         for (; j & bit; bit >>= 1) j ^= bit;
         j ^= bit;
         if (i < j) { int32_t t = a[i]; a[i] = a[j]; a[j] = t; }
     }
-    for (length = 2; length <= n; length <<= 1) {
-        w = rnl32_mod_pow(3, (uint32_t)(q - 1) / (uint32_t)length, (uint32_t)q);
-        if (invert) w = rnl32_mod_pow(w, (uint32_t)(q - 2), (uint32_t)q);
+    for (length = 2, s = 0; length <= n; length <<= 1, s++) {
+        if (sw) { w = sw[s]; }
+        else {
+            w = rnl32_mod_pow(3, (uint32_t)(q - 1) / (uint32_t)length, (uint32_t)q);
+            if (invert) w = rnl32_mod_pow(w, (uint32_t)(q - 2), (uint32_t)q);
+        }
         for (i = 0; i < n; i += length) {
             wn = 1;
             for (k = 0; k < length >> 1; k++) {
@@ -644,7 +690,8 @@ static void rnl32_ntt(int32_t *a, int n, int q, int invert)
         }
     }
     if (invert) {
-        uint32_t inv_n = rnl32_mod_pow((uint32_t)n, (uint32_t)(q - 2), (uint32_t)q);
+        uint32_t inv_n = (idx >= 0) ? rnl32_tw[idx].inv_n :
+                         rnl32_mod_pow((uint32_t)n, (uint32_t)(q - 2), (uint32_t)q);
         for (i = 0; i < n; i++)
             a[i] = (int32_t)((uint64_t)a[i] * inv_n % (uint32_t)q);
     }
@@ -654,24 +701,19 @@ static void rnl32_ntt(int32_t *a, int n, int q, int invert)
 static void rnl32_poly_mul(rnl32_poly_t h, const rnl32_poly_t f, const rnl32_poly_t g)
 {
     int32_t fa[RNL_N32], ga[RNL_N32], ha[RNL_N32];
-    uint32_t psi     = rnl32_mod_pow(3, (RNL_Q32 - 1) / (2 * RNL_N32), RNL_Q32);
-    uint32_t psi_inv = rnl32_mod_pow(psi, RNL_Q32 - 2, RNL_Q32);
-    uint32_t pw = 1, pw_inv = 1;
     int i;
+    rnl32_tw_init(0);
     for (i = 0; i < RNL_N32; i++) {
-        fa[i] = (int32_t)((uint64_t)f[i] * pw % RNL_Q32);
-        ga[i] = (int32_t)((uint64_t)g[i] * pw % RNL_Q32);
-        pw    = (uint32_t)((uint64_t)pw * psi % RNL_Q32);
+        fa[i] = (int32_t)((uint64_t)f[i] * rnl32_tw[0].psi_pow[i] % RNL_Q32);
+        ga[i] = (int32_t)((uint64_t)g[i] * rnl32_tw[0].psi_pow[i] % RNL_Q32);
     }
     rnl32_ntt(fa, RNL_N32, RNL_Q32, 0);
     rnl32_ntt(ga, RNL_N32, RNL_Q32, 0);
     for (i = 0; i < RNL_N32; i++)
         ha[i] = (int32_t)((uint64_t)fa[i] * ga[i] % RNL_Q32);
     rnl32_ntt(ha, RNL_N32, RNL_Q32, 1);
-    for (i = 0; i < RNL_N32; i++) {
-        h[i]   = (int32_t)((uint64_t)ha[i] * pw_inv % RNL_Q32);
-        pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q32);
-    }
+    for (i = 0; i < RNL_N32; i++)
+        h[i] = (int32_t)((uint64_t)ha[i] * rnl32_tw[0].psi_inv_pow[i] % RNL_Q32);
 }
 
 static void rnl32_poly_add(rnl32_poly_t h, const rnl32_poly_t f, const rnl32_poly_t g)
@@ -791,23 +833,38 @@ static uint32_t rnl32_agree(const int32_t s[RNL_N32], const int32_t c_other[RNL_
 static void rnl_poly_mul_n(int32_t *h, const int32_t *f, const int32_t *g, int n)
 {
     int32_t fa[n], ga[n], ha[n];
-    uint32_t psi     = rnl32_mod_pow(3, (RNL_Q32 - 1) / (2 * (uint32_t)n), RNL_Q32);
-    uint32_t psi_inv = rnl32_mod_pow(psi, RNL_Q32 - 2, RNL_Q32);
-    uint32_t pw = 1, pw_inv = 1;
-    int i;
-    for (i = 0; i < n; i++) {
-        fa[i] = (int32_t)((uint64_t)f[i] * pw % RNL_Q32);
-        ga[i] = (int32_t)((uint64_t)g[i] * pw % RNL_Q32);
-        pw    = (uint32_t)((uint64_t)pw * psi % RNL_Q32);
-    }
-    rnl32_ntt(fa, n, RNL_Q32, 0);
-    rnl32_ntt(ga, n, RNL_Q32, 0);
-    for (i = 0; i < n; i++)
-        ha[i] = (int32_t)((uint64_t)fa[i] * ga[i] % RNL_Q32);
-    rnl32_ntt(ha, n, RNL_Q32, 1);
-    for (i = 0; i < n; i++) {
-        h[i]   = (int32_t)((uint64_t)ha[i] * pw_inv % RNL_Q32);
-        pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q32);
+    int i, idx = rnl32_tw_idx(n);
+    if (idx >= 0) {
+        rnl32_tw_init(idx);
+        for (i = 0; i < n; i++) {
+            fa[i] = (int32_t)((uint64_t)f[i] * rnl32_tw[idx].psi_pow[i] % RNL_Q32);
+            ga[i] = (int32_t)((uint64_t)g[i] * rnl32_tw[idx].psi_pow[i] % RNL_Q32);
+        }
+        rnl32_ntt(fa, n, RNL_Q32, 0);
+        rnl32_ntt(ga, n, RNL_Q32, 0);
+        for (i = 0; i < n; i++)
+            ha[i] = (int32_t)((uint64_t)fa[i] * ga[i] % RNL_Q32);
+        rnl32_ntt(ha, n, RNL_Q32, 1);
+        for (i = 0; i < n; i++)
+            h[i] = (int32_t)((uint64_t)ha[i] * rnl32_tw[idx].psi_inv_pow[i] % RNL_Q32);
+    } else {
+        uint32_t psi     = rnl32_mod_pow(3, (RNL_Q32 - 1) / (2 * (uint32_t)n), RNL_Q32);
+        uint32_t psi_inv = rnl32_mod_pow(psi, RNL_Q32 - 2, RNL_Q32);
+        uint32_t pw = 1, pw_inv = 1;
+        for (i = 0; i < n; i++) {
+            fa[i] = (int32_t)((uint64_t)f[i] * pw % RNL_Q32);
+            ga[i] = (int32_t)((uint64_t)g[i] * pw % RNL_Q32);
+            pw    = (uint32_t)((uint64_t)pw * psi % RNL_Q32);
+        }
+        rnl32_ntt(fa, n, RNL_Q32, 0);
+        rnl32_ntt(ga, n, RNL_Q32, 0);
+        for (i = 0; i < n; i++)
+            ha[i] = (int32_t)((uint64_t)fa[i] * ga[i] % RNL_Q32);
+        rnl32_ntt(ha, n, RNL_Q32, 1);
+        for (i = 0; i < n; i++) {
+            h[i]   = (int32_t)((uint64_t)ha[i] * pw_inv % RNL_Q32);
+            pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q32);
+        }
     }
 }
 

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.17: NTT twiddle precomputation — rnlTwCache map; rnlTwGet eliminates rnlModPow calls per rnlPolyMul.
     v1.5.13: HSKE-NL-A1 seed fix — seed=RotateLeft(base,n/8) breaks counter=0 step-1 degeneracy.
     v1.5.10: HKEX-RNL KDF seed fix — seed=RotateLeft(K,n/8) breaks step-1 degeneracy.
     v1.5.9: NlFscxRevolveV2Inv precomputes delta(B) once — eliminates per-step multiply.
@@ -366,17 +367,47 @@ func rnlModPow(base, exp, mod int) int {
 	return r
 }
 
+type rnlTwEntry struct {
+	psiPow, psiInvPow []int
+	stageWFwd, stageWInv []int
+	invN int
+}
+
+var rnlTwCache = map[int]*rnlTwEntry{}
+
+func rnlTwGet(n, q int) *rnlTwEntry {
+	if e, ok := rnlTwCache[n]; ok { return e }
+	e := &rnlTwEntry{psiPow: make([]int, n), psiInvPow: make([]int, n)}
+	psi := rnlModPow(3, (q-1)/(2*n), q); psiInv := rnlModPow(psi, q-2, q)
+	pw, pwInv := 1, 1
+	for i := 0; i < n; i++ {
+		e.psiPow[i] = pw; e.psiInvPow[i] = pwInv
+		pw = pw * psi % q; pwInv = pwInv * psiInv % q
+	}
+	for length := 2; length <= n; length <<= 1 {
+		w := rnlModPow(3, (q-1)/length, q)
+		e.stageWFwd = append(e.stageWFwd, w)
+		e.stageWInv = append(e.stageWInv, rnlModPow(w, q-2, q))
+	}
+	e.invN = rnlModPow(n, q-2, q)
+	rnlTwCache[n] = e
+	return e
+}
+
 func rnlNTT(a []int, q int, invert bool) {
-	n := len(a); j := 0
+	n := len(a)
+	tw := rnlTwGet(n, q)
+	sw := tw.stageWFwd
+	if invert { sw = tw.stageWInv }
+	j := 0
 	for i := 1; i < n; i++ {
 		bit := n >> 1
 		for ; j&bit != 0; bit >>= 1 { j ^= bit }
 		j ^= bit
 		if i < j { a[i], a[j] = a[j], a[i] }
 	}
-	for length := 2; length <= n; length <<= 1 {
-		w := rnlModPow(3, (q-1)/length, q)
-		if invert { w = rnlModPow(w, q-2, q) }
+	for s, length := 0, 2; length <= n; length, s = length<<1, s+1 {
+		w := sw[s]
 		for i := 0; i < n; i += length {
 			wn := 1
 			for k := 0; k < length>>1; k++ {
@@ -387,23 +418,21 @@ func rnlNTT(a []int, q int, invert bool) {
 		}
 	}
 	if invert {
-		invN := rnlModPow(n, q-2, q)
-		for i := range a { a[i] = a[i] * invN % q }
+		for i := range a { a[i] = a[i] * tw.invN % q }
 	}
 }
 
 func rnlPolyMul(f, g []int, q, n int) []int {
-	psi := rnlModPow(3, (q-1)/(2*n), q); psiInv := rnlModPow(psi, q-2, q)
-	fa, ga := make([]int, n), make([]int, n); pw := 1
+	tw := rnlTwGet(n, q)
+	fa, ga := make([]int, n), make([]int, n)
 	for i := 0; i < n; i++ {
-		fa[i] = f[i] * pw % q; ga[i] = g[i] * pw % q; pw = pw * psi % q
+		fa[i] = f[i] * tw.psiPow[i] % q; ga[i] = g[i] * tw.psiPow[i] % q
 	}
 	rnlNTT(fa, q, false); rnlNTT(ga, q, false)
 	ha := make([]int, n)
 	for i := range ha { ha[i] = fa[i] * ga[i] % q }
 	rnlNTT(ha, q, true)
-	pwInv := 1
-	for i := range ha { ha[i] = ha[i] * pwInv % q; pwInv = pwInv * psiInv % q }
+	for i := range ha { ha[i] = ha[i] * tw.psiInvPow[i] % q }
 	return ha
 }
 

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.13
+/*  Herradura Cryptographic Suite v1.5.17
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,8 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.17: NTT twiddle precomputation — lazy-initialized static table eliminates rnl_mod_pow calls per rnl_poly_mul ---
 
     --- v1.5.13: HSKE-NL-A1 seed fix — ROL(base, n/8) breaks counter=0 step-1 degeneracy ---
 
@@ -595,38 +597,71 @@ static uint32_t rnl_mod_pow(uint32_t base, uint32_t exp, uint32_t m)
     return (uint32_t)r;
 }
 
+/* Precomputed NTT twiddle tables for n=RNL_N, q=RNL_Q (lazy-initialized on first use). */
+#define RNL_LOG2N 8  /* log2(256) */
+static struct {
+    uint32_t psi_pow[RNL_N];          /* ψ^i for pre-twist */
+    uint32_t psi_inv_pow[RNL_N];      /* ψ^{-i} for post-twist */
+    uint32_t stage_w_fwd[RNL_LOG2N];  /* per-stage ω, forward NTT */
+    uint32_t stage_w_inv[RNL_LOG2N];  /* per-stage ω, inverse NTT */
+    uint32_t inv_n;                   /* n^{-1} mod q for INTT scaling */
+    int      ready;
+} rnl_tw;
+
+static void rnl_twiddle_init(void)
+{
+    uint32_t psi, psi_inv, pw, pw_inv, w;
+    int i, s, length;
+    if (rnl_tw.ready) return;
+    psi     = rnl_mod_pow(3, (RNL_Q - 1) / (2 * RNL_N), RNL_Q);
+    psi_inv = rnl_mod_pow(psi, RNL_Q - 2, RNL_Q);
+    pw = pw_inv = 1;
+    for (i = 0; i < RNL_N; i++) {
+        rnl_tw.psi_pow[i]     = pw;
+        rnl_tw.psi_inv_pow[i] = pw_inv;
+        pw     = (uint32_t)((uint64_t)pw     * psi     % RNL_Q);
+        pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q);
+    }
+    for (s = 0, length = 2; length <= RNL_N; length <<= 1, s++) {
+        w = rnl_mod_pow(3, (RNL_Q - 1) / (uint32_t)length, RNL_Q);
+        rnl_tw.stage_w_fwd[s] = w;
+        rnl_tw.stage_w_inv[s] = rnl_mod_pow(w, RNL_Q - 2, RNL_Q);
+    }
+    rnl_tw.inv_n = rnl_mod_pow((uint32_t)RNL_N, RNL_Q - 2, RNL_Q);
+    rnl_tw.ready = 1;
+}
+
 /* Cooley-Tukey iterative NTT over Z_q (in-place). n must be a power of 2.
    Uses primitive root 3 (valid since q=65537 is a Fermat prime, ord(3)=q-1=2^16). */
 static void rnl_ntt(int32_t *a, int n, int q, int invert)
 {
-    int i, j = 0, length, k;
+    int i, j = 0, length, k, s;
     uint32_t w, wn;
-    /* Bit-reversal permutation */
+    const uint32_t *sw;
+    rnl_twiddle_init();
+    sw = invert ? rnl_tw.stage_w_inv : rnl_tw.stage_w_fwd;
     for (i = 1; i < n; i++) {
         int bit = n >> 1;
         for (; j & bit; bit >>= 1) j ^= bit;
         j ^= bit;
         if (i < j) { int32_t t = a[i]; a[i] = a[j]; a[j] = t; }
     }
-    /* Butterfly stages */
-    for (length = 2; length <= n; length <<= 1) {
-        w = rnl_mod_pow(3, (uint32_t)(q - 1) / (uint32_t)length, (uint32_t)q);
-        if (invert) w = rnl_mod_pow(w, (uint32_t)(q - 2), (uint32_t)q);
+    for (length = 2, s = 0; length <= n; length <<= 1, s++) {
+        w = sw[s];
         for (i = 0; i < n; i += length) {
             wn = 1;
             for (k = 0; k < length >> 1; k++) {
                 int32_t u = a[i + k];
                 int32_t v = (int32_t)((uint64_t)a[i + k + (length >> 1)] * wn % (uint32_t)q);
-                a[i + k]              = (u + v) % q;
+                a[i + k]                 = (u + v) % q;
                 a[i + k + (length >> 1)] = (u - v + q) % q;
                 wn = (uint32_t)((uint64_t)wn * w % (uint32_t)q);
             }
         }
     }
     if (invert) {
-        uint32_t inv_n = rnl_mod_pow((uint32_t)n, (uint32_t)(q - 2), (uint32_t)q);
         for (i = 0; i < n; i++)
-            a[i] = (int32_t)((uint64_t)a[i] * inv_n % (uint32_t)q);
+            a[i] = (int32_t)((uint64_t)a[i] * rnl_tw.inv_n % (uint32_t)q);
     }
 }
 
@@ -635,24 +670,19 @@ static void rnl_ntt(int32_t *a, int n, int q, int invert)
 static void rnl_poly_mul(rnl_poly_t h, const rnl_poly_t f, const rnl_poly_t g)
 {
     int32_t fa[RNL_N], ga[RNL_N], ha[RNL_N];
-    uint32_t psi     = rnl_mod_pow(3, (RNL_Q - 1) / (2 * RNL_N), RNL_Q);
-    uint32_t psi_inv = rnl_mod_pow(psi, RNL_Q - 2, RNL_Q);
-    uint32_t pw = 1, pw_inv = 1;
     int i;
+    rnl_twiddle_init();
     for (i = 0; i < RNL_N; i++) {
-        fa[i] = (int32_t)((uint64_t)f[i] * pw % RNL_Q);
-        ga[i] = (int32_t)((uint64_t)g[i] * pw % RNL_Q);
-        pw    = (uint32_t)((uint64_t)pw * psi % RNL_Q);
+        fa[i] = (int32_t)((uint64_t)f[i] * rnl_tw.psi_pow[i] % RNL_Q);
+        ga[i] = (int32_t)((uint64_t)g[i] * rnl_tw.psi_pow[i] % RNL_Q);
     }
     rnl_ntt(fa, RNL_N, RNL_Q, 0);
     rnl_ntt(ga, RNL_N, RNL_Q, 0);
     for (i = 0; i < RNL_N; i++)
         ha[i] = (int32_t)((uint64_t)fa[i] * ga[i] % RNL_Q);
     rnl_ntt(ha, RNL_N, RNL_Q, 1);
-    for (i = 0; i < RNL_N; i++) {
-        h[i]   = (int32_t)((uint64_t)ha[i] * pw_inv % RNL_Q);
-        pw_inv = (uint32_t)((uint64_t)pw_inv * psi_inv % RNL_Q);
-    }
+    for (i = 0; i < RNL_N; i++)
+        h[i] = (int32_t)((uint64_t)ha[i] * rnl_tw.psi_inv_pow[i] % RNL_Q);
 }
 
 static void rnl_poly_add(rnl_poly_t h, const rnl_poly_t f, const rnl_poly_t g)

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.13
+/*  Herradura Cryptographic Suite v1.5.17
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -16,6 +16,8 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    --- v1.5.17: NTT twiddle precomputation — rnlTwCache map; rnlTwGet eliminates rnlModPow calls per rnlPolyMul ---
 
     --- v1.5.13: HSKE-NL-A1 seed fix — RotateLeft(base, n/8) breaks counter=0 step-1 degeneracy ---
 
@@ -400,8 +402,46 @@ func rnlModPow(base, exp, mod int) int {
 	return r
 }
 
+// rnlTwEntry holds precomputed NTT twiddle values for one (n, q) pair.
+type rnlTwEntry struct {
+	psiPow    []int
+	psiInvPow []int
+	stageWFwd []int
+	stageWInv []int
+	invN      int
+}
+
+var rnlTwCache = map[int]*rnlTwEntry{}
+
+func rnlTwGet(n, q int) *rnlTwEntry {
+	if e, ok := rnlTwCache[n]; ok {
+		return e
+	}
+	e := &rnlTwEntry{psiPow: make([]int, n), psiInvPow: make([]int, n)}
+	psi := rnlModPow(3, (q-1)/(2*n), q)
+	psiInv := rnlModPow(psi, q-2, q)
+	pw, pwInv := 1, 1
+	for i := 0; i < n; i++ {
+		e.psiPow[i] = pw; e.psiInvPow[i] = pwInv
+		pw = pw * psi % q; pwInv = pwInv * psiInv % q
+	}
+	for length := 2; length <= n; length <<= 1 {
+		w := rnlModPow(3, (q-1)/length, q)
+		e.stageWFwd = append(e.stageWFwd, w)
+		e.stageWInv = append(e.stageWInv, rnlModPow(w, q-2, q))
+	}
+	e.invN = rnlModPow(n, q-2, q)
+	rnlTwCache[n] = e
+	return e
+}
+
 func rnlNTT(a []int, q int, invert bool) {
 	n := len(a)
+	tw := rnlTwGet(n, q)
+	sw := tw.stageWFwd
+	if invert {
+		sw = tw.stageWInv
+	}
 	j := 0
 	for i := 1; i < n; i++ {
 		bit := n >> 1
@@ -413,11 +453,8 @@ func rnlNTT(a []int, q int, invert bool) {
 			a[i], a[j] = a[j], a[i]
 		}
 	}
-	for length := 2; length <= n; length <<= 1 {
-		w := rnlModPow(3, (q-1)/length, q)
-		if invert {
-			w = rnlModPow(w, q-2, q)
-		}
+	for s, length := 0, 2; length <= n; length, s = length<<1, s+1 {
+		w := sw[s]
 		for i := 0; i < n; i += length {
 			wn := 1
 			for k := 0; k < length>>1; k++ {
@@ -430,22 +467,18 @@ func rnlNTT(a []int, q int, invert bool) {
 		}
 	}
 	if invert {
-		invN := rnlModPow(n, q-2, q)
 		for i := range a {
-			a[i] = a[i] * invN % q
+			a[i] = a[i] * tw.invN % q
 		}
 	}
 }
 
 func rnlPolyMul(f, g []int, q, n int) []int {
-	psi    := rnlModPow(3, (q-1)/(2*n), q)
-	psiInv := rnlModPow(psi, q-2, q)
+	tw := rnlTwGet(n, q)
 	fa, ga := make([]int, n), make([]int, n)
-	pw := 1
 	for i := 0; i < n; i++ {
-		fa[i] = f[i] * pw % q
-		ga[i] = g[i] * pw % q
-		pw = pw * psi % q
+		fa[i] = f[i] * tw.psiPow[i] % q
+		ga[i] = g[i] * tw.psiPow[i] % q
 	}
 	rnlNTT(fa, q, false)
 	rnlNTT(ga, q, false)
@@ -454,10 +487,8 @@ func rnlPolyMul(f, g []int, q, n int) []int {
 		ha[i] = fa[i] * ga[i] % q
 	}
 	rnlNTT(ha, q, true)
-	pwInv := 1
 	for i := range ha {
-		ha[i] = ha[i] * pwInv % q
-		pwInv = pwInv * psiInv % q
+		ha[i] = ha[i] * tw.psiInvPow[i] % q
 	}
 	return ha
 }


### PR DESCRIPTION
## Summary

- Adds lazy-initialized precomputed twiddle tables to the negacyclic NTT used by HKEX-RNL polynomial multiplication, eliminating all `rnl_mod_pow` calls from the hot path after the first `rnl_poly_mul` invocation
- Applies to C suite + tests (`rnl_tw` struct / `rnl32_tw[2]` array) and Go suite + tests (`rnlTwCache` map + `rnlTwGet`)

## What was being recomputed

Per `rnl_poly_mul` call: ~27 modular exponentiations (ψ, ψ⁻¹, one stage-ω per butterfly stage across 3 NTT calls, plus n⁻¹ for INTT scaling). Each exponentiation is up to 16 multiplications.

## Precomputed once (lazy, first use)

- `psi_pow[n]` / `psi_inv_pow[n]` — pre/post-twist arrays
- `stage_w_fwd[log₂n]` / `stage_w_inv[log₂n]` — per-stage ω for forward/inverse NTT
- `inv_n` — n⁻¹ mod q for INTT scaling

## Test plan

- [x] Tests [1]–[16]: all PASS across C, Go, Python at `-r 200 -t 2.0` (test [4] is expected FAIL — known FSCX bias property)
- [x] Test [14] HKEX-RNL: 200/200 raw agree, 200/200 sk agree for n=32 and n=64
- [x] C suite and tests build clean (`gcc -O2`)
- [x] Go suite and tests build clean (`go build`)
- [x] Fallback path in C tests for unsupported n (never triggered in practice)

## Observed speedup

Go bench [25] HKEX-RNL handshake:
- n=32: 8.24 K → 9.32–10.43 K ops/sec
- n=64: 3.15 K → **4.14–4.72 K ops/sec (+35–50%)**

🤖 Generated with [Claude Code](https://claude.ai/claude-code)