### PR TITLE
v1.5.21: ARM HSKE-NL-A2 R_VALUE fix; Python q=65537 label; banner sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.21] - 2026-04-30
+
+### Fix — ARM HSKE-NL-A2 used wrong step count (TODO #22)
+
+**Root cause:** `Herradura cryptographic suite.s` called `nl_fscx_revolve_v2` and
+`nl_fscx_revolve_v2_inv` with `#I_VALUE` (= n/4 = 8 steps) for HSKE-NL-A2, while
+the protocol specifies `r = 3n/4 = R_VALUE = 24 steps`. NASM i386 and C were correct.
+HPKE-NL was unaffected — it legitimately uses `I_VALUE` (n/4).
+
+**Impact:** ARM and NASM i386 HSKE-NL-A2 ciphertexts were cross-incompatible; both
+self-decrypted correctly (symmetric use of the wrong step count) so the bug was silent.
+
+**Fix:** Changed both HSKE-NL-A2 call sites in `Herradura cryptographic suite.s`
+(encrypt and decrypt) from `mov r2, #I_VALUE` to `mov r2, #R_VALUE`. Updated the
+inline comments to match.
+
+### Fix — Python HKEX-RNL demo banner printed q=3329 (TODO #20)
+
+`Herradura cryptographic suite.py` line 953 printed `q=3329` (Kyber's modulus),
+but `RNLQ = 65537` since v1.5.4. The same banner was fixed in C at v1.5.13 but the
+Python file was missed. Changed to `q=65537`.
+
+### Maintenance — Version-banner sync (TODO #19)
+
+Nine files still carried `v1.5.18` in header comments and/or runtime-printed banner
+strings; the project was at v1.5.20. Updated all header comments and printed banners
+to v1.5.21 across:
+
+- `Herradura cryptographic suite.go` (header comment)
+- `CryptosuiteTests/Herradura_tests.go` (header changelog + printed banner)
+- `CryptosuiteTests/Herradura_tests.py` (argparse description + printed banner)
+- `Herradura cryptographic suite.s` / `CryptosuiteTests/Herradura_tests.s` (header + `.asciz` string)
+- `Herradura cryptographic suite.asm` / `CryptosuiteTests/Herradura_tests.asm` (header + `db` string)
+- `Herradura cryptographic suite.ino` / `CryptosuiteTests/Herradura_tests.ino` (header + `Serial.println`)
+
+Historical changelog entries inside file headers (e.g. `v1.5.18: HPKS-Stern-F...`)
+were left unchanged.
+
+---
+
 ## [1.5.20] - 2026-04-30
 
 ### Performance — Fermat prime fast modulo for NTT inner loops (Batch 8 / TODO #15)

--- a/CryptosuiteTests/Herradura_tests.asm
+++ b/CryptosuiteTests/Herradura_tests.asm
@@ -1,4 +1,4 @@
-;  Herradura KEx -- Correctness Tests v1.5.18
+;  Herradura KEx -- Correctness Tests v1.5.21
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS Schnorr, HPKE El Gamal,
 ;                        NL-FSCX v2 inv, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL,
 ;                        HPKS-Stern-F, HPKE-Stern-F
@@ -58,7 +58,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura KEx v1.5.18 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr         db "=== Herradura KEx v1.5.21 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
     hdr_l       equ $-hdr
 
     t1_hdr      db "[1] HKEX-GF key exchange correctness: sk_alice == sk_bob (20 iterations)", 10

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.21: version-banner sync; ARM HSKE-NL-A2 R_VALUE fix.
     v1.5.18: HPKS-Stern-F + HPKE-Stern-F code-based PQC tests [17][18]; benchmarks renumbered [19-28].
     v1.5.17: NTT twiddle precomputation — rnlTwCache map; rnlTwGet eliminates rnlModPow calls per rnlPolyMul.
     v1.5.13: HSKE-NL-A1 seed fix — seed=RotateLeft(base,n/8) breaks counter=0 step-1 degeneracy.
@@ -1629,7 +1630,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.18 — Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.21 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -1,4 +1,4 @@
-/*  Herradura KEx — Security Tests v1.5.18 (Arduino, 32-bit)
+/*  Herradura KEx — Security Tests v1.5.21 (Arduino, 32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, NL-FSCX, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL,
     HPKS-Stern-F, HPKE-Stern-F
 
@@ -661,7 +661,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura KEx v1.5.18 - Security Tests (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura KEx v1.5.21 - Security Tests (Arduino, 32-bit) ===");
     Serial.println();
 
     test_hkex_gf();

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1125,7 +1125,7 @@ def bench_hpks_stern_f():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.18 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.5.21 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -1153,7 +1153,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.18 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.21 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/CryptosuiteTests/Herradura_tests.s
+++ b/CryptosuiteTests/Herradura_tests.s
@@ -1,4 +1,4 @@
-/*  Herradura KEx -- Correctness Tests v1.5.18
+/*  Herradura KEx -- Correctness Tests v1.5.21
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        NL-FSCX v2 inv, HSKE-NL-A2,
                                        HKEX-RNL, HPKS-NL, HPKE-NL,
@@ -36,7 +36,7 @@
     .data
     .balign 4
 
-fmt_hdr:  .asciz "=== Herradura KEx v1.5.18 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
+fmt_hdr:  .asciz "=== Herradura KEx v1.5.21 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
 fmt_t1:   .asciz "[1] HKEX-GF key exchange: sk_alice == sk_bob (20 iterations)\n"
 fmt_t2:   .asciz "[2] HSKE encrypt+decrypt round-trip: D == plaintext (100 iterations)\n"
 fmt_t3:   .asciz "[3] HPKS Schnorr: g^s * C^e == R (20 iterations)\n"

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.18
+;  Herradura Cryptographic Suite v1.5.21
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
 ;                        HPKS-Stern-F, HPKE-Stern-F
@@ -103,7 +103,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.5.18 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.5.21 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.18
+/*  Herradura Cryptographic Suite v1.5.21
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.18
+/*  Herradura Cryptographic Suite v1.5.21
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.18 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.21 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
     HPKS-Stern-F, HPKE-Stern-F
     KEYBITS = 32
@@ -504,7 +504,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura Cryptographic Suite v1.5.18 (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura Cryptographic Suite v1.5.21 (Arduino, 32-bit) ===");
     Serial.println();
 
     printHexLine("a_priv : ", A_PRIV);

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -950,7 +950,7 @@ def main():
         print("- decryption failed!")
 
     print("\n--- HKEX-RNL [PQC — Ring-LWR key exchange; conjectured quantum-resistant]")
-    print("    (Ring-LWR, m(x)=1+x+x^{n-1}, n=256, q=3329 — may be slow)")
+    print("    (Ring-LWR, m(x)=1+x+x^{n-1}, n=256, q=65537 — may be slow)")
     n_rnl    = KEYBITS
     m_base   = _rnl_m_poly(n_rnl)
     a_rand   = _rnl_rand_poly(n_rnl, RNLQ)         # session random, public

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.18
+/*  Herradura Cryptographic Suite v1.5.21
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
                                        HPKS-Stern-F, HPKE-Stern-F
@@ -49,7 +49,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.18 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.21 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 
@@ -632,8 +632,8 @@ hske_nl1_done:
 
     /* ================================================================
        HSKE-NL-A2  (revolve-mode with NL-FSCX v2)
-       E = nl_fscx_revolve_v2(plain, key, I_VALUE)
-       D = nl_fscx_revolve_v2_inv(E, key, I_VALUE)  must == plain
+       E = nl_fscx_revolve_v2(plain, key, R_VALUE)
+       D = nl_fscx_revolve_v2_inv(E, key, R_VALUE)  must == plain
        CAUTION: deterministic — same (plain, key) always yields same E.
        ================================================================ */
     ldr     r0, =fmt_hske_nl2_hdr
@@ -643,7 +643,7 @@ hske_nl1_done:
     ldr     r0, [r0]
     ldr     r1, =val_key
     ldr     r1, [r1]
-    mov     r2, #I_VALUE
+    mov     r2, #R_VALUE
     bl      nl_fscx_revolve_v2
     ldr     r3, =val_E_nl2
     str     r0, [r3]
@@ -652,7 +652,7 @@ hske_nl1_done:
     ldr     r0, [r0]
     ldr     r1, =val_key
     ldr     r1, [r1]
-    mov     r2, #I_VALUE
+    mov     r2, #R_VALUE
     bl      nl_fscx_revolve_v2_inv
     ldr     r3, =val_D_nl2
     str     r0, [r3]


### PR DESCRIPTION
## Summary

- **TODO #22 — ARM HSKE-NL-A2 cross-compatibility fix (Correctness, Medium):** `Herradura cryptographic suite.s` called `nl_fscx_revolve_v2`/`_inv` with `#I_VALUE` (8 steps, n/4) instead of `#R_VALUE` (24 steps, 3n/4) for HSKE-NL-A2. The protocol specifies `r = 3n/4`; NASM i386 and C were already correct. Both targets now produce `E = 0x633a13c8` for the same inputs. HPKE-NL was unaffected (it legitimately uses I_VALUE).

- **TODO #20 — Python HKEX-RNL demo label (Correctness, Trivial):** `Herradura cryptographic suite.py:953` printed `q=3329` (Kyber's modulus) since the Python file was missed when C got the same fix at v1.5.13. Fixed to `q=65537`.

- **TODO #19 — Version-banner sync (Maintenance, Trivial):** Nine files still carried `v1.5.18` in header comments and/or runtime-printed banners. Updated to v1.5.21 across Go, Python, ARM Thumb-2, NASM i386, Arduino, and C suite files. Historical changelog entries left unchanged.

## Test plan

- [x] ARM suite rebuilt (`arm-linux-gnueabi-gcc`) — no errors
- [x] `qemu-arm ./Herradura\ cryptographic\ suite_arm` — HSKE-NL-A2 `E = 0x633a13c8`, `D = 0xdeadc0de ✓` (matches NASM i386)
- [x] `qemu-i386 ./Herradura\ cryptographic\ suite_i386` — HSKE-NL-A2 `E = 0x633a13c8`, `D = 0xdeadc0de ✓`
- [x] Python suite — HKEX-RNL banner now shows `q=65537`
- [x] All banners verified `v1.5.21` via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)