### PR TITLE
v1.5.23 TODO #25: HerraduraCli OpenSSL-style CLI + CliTest suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,65 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.5.23] - 2026-05-03
+
+### New Feature — HerraduraCli: OpenSSL-style command-line tool (TODO #25)
+
+A Python CLI in a new `HerraduraCli/` subdirectory exposing all non-broken Herradura
+protocols through an interface analogous to OpenSSL's `genpkey`, `pkey`, `enc`, `dec`,
+`sign`, `verify`, and `kex` subcommands. No external Python dependencies; uses only stdlib.
+
+**File layout:**
+- `HerraduraCli/herradura.py` — argparse dispatcher; all protocol subcommands
+- `HerraduraCli/codec.py` — pure-Python PEM and minimal DER INTEGER/SEQUENCE codec;
+  polynomial pack/unpack helpers for Ring-LWR polynomials
+- `HerraduraCli/primitives.py` — loads `"Herradura cryptographic suite.py"` via
+  `importlib.util` (space-in-filename workaround); re-exports all primitive symbols
+
+**Supported subcommands:**
+- `genpkey --algo <a>` — generate private key PEM for all 8 supported algorithms
+- `pkey --pubout / --text` — extract public key or print key fields as hex
+- `kex --algo hkex-gf/hkex-rnl --our … --their …` — HKEX-GF one-round or HKEX-RNL
+  two-round key exchange; writes SESSION KEY PEM or RESPONSE PEM
+- `enc / dec --algo hske/hske-nla1/hske-nla2/hpke/hpke-nl/hpke-stern` — encrypt and
+  decrypt using symmetric session keys or asymmetric public/private keys
+- `sign / verify --algo hpks/hpks-nl/hpks-stern` — Schnorr or Stern-F signatures;
+  `verify` exits 0/1 and prints `Signature OK` / `Verification FAILED`
+
+**HKEX-RNL 2-round protocol:** Alice publishes a fresh random `m_blind` polynomial in
+her public key PEM; Bob re-derives `C_B = round_p(m_A * s_B)` on his side and writes a
+RESPONSE PEM encoding `(K_B, C_B, Peikert-hint, n)`; Alice reads the response and
+completes with `K_A = reconcile(s_A * C_B, hint)`. The RESPONSE PEM doubles as a session
+key file (Bob's `K_B` is stored as the first field) so Bob can pass it directly to
+`enc`/`dec` without a separate kex step.
+
+**Key format summary (DER SEQUENCE):**
+- Classical/NL private: `{priv_int, pub_int, nbits}` (nbits//8 bytes each)
+- Classical/NL public: `{pub_int, nbits}`
+- HKEX-RNL private: `{s_packed(4n bytes), m_packed(4n bytes), n}`
+- HKEX-RNL public: `{C_packed(2n bytes), m_packed(4n bytes), n}`
+- Stern private/public: `{e_int / syn_int, seed_uint, n}` (n//8 bytes each)
+
+### New Feature — CliTest shell test suite (TODO #25)
+
+Four bash scripts in `CliTest/` exercising the full CLI:
+- `test_keygen.sh` — 16 cases: `genpkey` + `pkey --pubout` for all 8 algorithms; asserts
+  PEM headers and non-empty output
+- `test_encrypt.sh` — 7 cases: full enc/dec round-trips for hske, hske-nla1, hske-nla2
+  (via HKEX-GF session key), HKEX-RNL cross-party, hpke, hpke-nl, hpke-stern
+- `test_sign.sh` — 7 cases: sign/verify with correct and tampered messages for hpks,
+  hpks-nl (including wrong-key rejection), and hpks-stern
+- `test_vectors.sh` — 3 cases: HKEX-GF key-agreement (both parties produce identical
+  SESSION KEY PEM) and HKEX-RNL bidirectional cross-party enc/dec (validates Peikert
+  reconciliation)
+
+### Maintenance — Version-banner sync
+
+All 12 implementation files advanced from v1.5.22 (or v1.5.20 for Python suite/tests and
+C tests, which had missed earlier bumps) to v1.5.23.
+
+---
+
 ## [1.5.22] - 2026-05-01
 
 ### Fix — NASM i386 HKEX-RNL produced all-zero session keys (TODO #21)

--- a/CliTest/test_encrypt.sh
+++ b/CliTest/test_encrypt.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# CliTest/test_encrypt.sh — enc/dec round-trips for all Herradura encryption algorithms
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_roundtrip() {
+    local label="$1" orig="$2" plain="$3"
+    if cmp -s "$orig" "$plain"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: decrypted output does not match original"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# Reference plaintexts sized to match each block width
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg32.bin"  # 32 bytes (256-bit block)
+printf 'TESTMSG!' > "$TMP/msg8.bin"                            # 8 bytes (64-bit block)
+printf 'Test' > "$TMP/msg4.bin"                                # 4 bytes (32-bit block)
+
+# ---------------------------------------------------------------------------
+# HKEX-GF key exchange → symmetric enc/dec (hske, hske-nla1, hske-nla2)
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hkex-gf --out "$TMP/alice_gf.pem"
+$CLI pkey    --in "$TMP/alice_gf.pem" --pubout --out "$TMP/alice_gf_pub.pem"
+$CLI genpkey --algo hkex-gf --out "$TMP/bob_gf.pem"
+$CLI pkey    --in "$TMP/bob_gf.pem"   --pubout --out "$TMP/bob_gf_pub.pem"
+$CLI kex     --algo hkex-gf --our "$TMP/alice_gf.pem" --their "$TMP/bob_gf_pub.pem" \
+             --out "$TMP/sk_gf.pem"
+
+for algo in hske hske-nla1 hske-nla2; do
+    $CLI enc --algo "$algo" --key "$TMP/sk_gf.pem" \
+             --in "$TMP/msg32.bin" --out "$TMP/${algo}_ct.pem"
+    $CLI dec --algo "$algo" --key "$TMP/sk_gf.pem" \
+             --in "$TMP/${algo}_ct.pem" --out "$TMP/${algo}_plain.bin"
+    check_roundtrip "$algo enc/dec" "$TMP/msg32.bin" "$TMP/${algo}_plain.bin"
+done
+
+# ---------------------------------------------------------------------------
+# HKEX-RNL 2-round kex (n=64) — Bob responds, Alice completes; cross-party enc/dec
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hkex-rnl --bits 64 --out "$TMP/alice_rnl.pem"
+$CLI pkey    --in "$TMP/alice_rnl.pem" --pubout --out "$TMP/alice_rnl_pub.pem"
+$CLI genpkey --algo hkex-rnl --bits 64 --out "$TMP/bob_rnl.pem"
+
+# Step 1: Bob responds to Alice's public key (writes RESPONSE PEM containing K_B)
+$CLI kex --algo hkex-rnl --our "$TMP/bob_rnl.pem" --their "$TMP/alice_rnl_pub.pem" \
+         --out "$TMP/bob_rnl_resp.pem"
+# Step 2: Alice completes (writes SESSION KEY PEM containing K_A)
+$CLI kex --algo hkex-rnl --our "$TMP/alice_rnl.pem" --their "$TMP/bob_rnl_resp.pem" \
+         --out "$TMP/alice_rnl_sk.pem"
+
+# Bob encrypts with K_B (RESPONSE PEM); Alice decrypts with K_A (SESSION KEY PEM).
+# If K_A = K_B the round-trip succeeds, validating the reconciliation property.
+$CLI enc --algo hske --key "$TMP/bob_rnl_resp.pem" \
+         --in "$TMP/msg8.bin" --out "$TMP/hkex_rnl_ct.pem"
+$CLI dec --algo hske --key "$TMP/alice_rnl_sk.pem" \
+         --in "$TMP/hkex_rnl_ct.pem" --out "$TMP/hkex_rnl_plain.bin"
+check_roundtrip "hkex-rnl kex + hske enc/dec (cross-party)" "$TMP/msg8.bin" "$TMP/hkex_rnl_plain.bin"
+
+# ---------------------------------------------------------------------------
+# Asymmetric HPKE / HPKE-NL
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hpke    --out "$TMP/alice_hpke.pem"
+$CLI pkey    --in "$TMP/alice_hpke.pem" --pubout --out "$TMP/alice_hpke_pub.pem"
+$CLI enc --algo hpke --pubkey "$TMP/alice_hpke_pub.pem" \
+         --in "$TMP/msg32.bin" --out "$TMP/hpke_ct.pem"
+$CLI dec --algo hpke --key "$TMP/alice_hpke.pem" \
+         --in "$TMP/hpke_ct.pem" --out "$TMP/hpke_plain.bin"
+check_roundtrip "hpke enc/dec" "$TMP/msg32.bin" "$TMP/hpke_plain.bin"
+
+$CLI genpkey --algo hpke-nl --out "$TMP/alice_hpke_nl.pem"
+$CLI pkey    --in "$TMP/alice_hpke_nl.pem" --pubout --out "$TMP/alice_hpke_nl_pub.pem"
+$CLI enc --algo hpke-nl --pubkey "$TMP/alice_hpke_nl_pub.pem" \
+         --in "$TMP/msg32.bin" --out "$TMP/hpke_nl_ct.pem"
+$CLI dec --algo hpke-nl --key "$TMP/alice_hpke_nl.pem" \
+         --in "$TMP/hpke_nl_ct.pem" --out "$TMP/hpke_nl_plain.bin"
+check_roundtrip "hpke-nl enc/dec" "$TMP/msg32.bin" "$TMP/hpke_nl_plain.bin"
+
+# ---------------------------------------------------------------------------
+# HPKE-Stern-F KEM demo (n=32; block = 4 bytes)
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hpke-stern --bits 32 --out "$TMP/stern_hpke.pem"
+$CLI pkey    --in "$TMP/stern_hpke.pem" --pubout --out "$TMP/stern_hpke_pub.pem"
+$CLI enc --algo hpke-stern --pubkey "$TMP/stern_hpke_pub.pem" \
+         --in "$TMP/msg4.bin" --out "$TMP/hpke_stern_ct.pem"
+$CLI dec --algo hpke-stern --key "$TMP/stern_hpke.pem" \
+         --in "$TMP/hpke_stern_ct.pem" --out "$TMP/hpke_stern_plain.bin"
+check_roundtrip "hpke-stern enc/dec n=32" "$TMP/msg4.bin" "$TMP/hpke_stern_plain.bin"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_keygen.sh
+++ b/CliTest/test_keygen.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# CliTest/test_keygen.sh — generate every key type; assert PEM headers and non-empty output
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check() {
+    local label="$1" file="$2" expected_header="$3"
+    if [ ! -s "$file" ]; then
+        echo "FAIL $label: output file is empty"
+        FAIL=$((FAIL+1)); return
+    fi
+    if ! grep -qF "$expected_header" "$file"; then
+        echo "FAIL $label: expected header '$expected_header' not found"
+        FAIL=$((FAIL+1)); return
+    fi
+    echo "PASS $label"
+    PASS=$((PASS+1))
+}
+
+# Classical and NL algorithms (default 256 bits)
+for algo in hkex-gf hpks hpks-nl hpke hpke-nl; do
+    $CLI genpkey --algo "$algo" --out "$TMP/${algo}.pem"
+    check "genpkey $algo" "$TMP/${algo}.pem" "BEGIN HERRADURA"
+    $CLI pkey --in "$TMP/${algo}.pem" --pubout --out "$TMP/${algo}_pub.pem"
+    check "pkey pubout $algo" "$TMP/${algo}_pub.pem" "PUBLIC KEY"
+done
+
+# HKEX-RNL (smaller n=64 for speed)
+$CLI genpkey --algo hkex-rnl --bits 64 --out "$TMP/hkex-rnl.pem"
+check "genpkey hkex-rnl n=64" "$TMP/hkex-rnl.pem" "BEGIN HERRADURA"
+$CLI pkey --in "$TMP/hkex-rnl.pem" --pubout --out "$TMP/hkex-rnl_pub.pem"
+check "pkey pubout hkex-rnl" "$TMP/hkex-rnl_pub.pem" "PUBLIC KEY"
+
+# Stern algorithms (n=32 for speed)
+for algo in hpks-stern hpke-stern; do
+    $CLI genpkey --algo "$algo" --bits 32 --out "$TMP/${algo}.pem"
+    check "genpkey $algo n=32" "$TMP/${algo}.pem" "BEGIN HERRADURA"
+    $CLI pkey --in "$TMP/${algo}.pem" --pubout --out "$TMP/${algo}_pub.pem"
+    check "pkey pubout $algo" "$TMP/${algo}_pub.pem" "PUBLIC KEY"
+done
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_sign.sh
+++ b/CliTest/test_sign.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# CliTest/test_sign.sh — sign/verify for HPKS, HPKS-NL, HPKS-Stern-F (pass and reject cases)
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+# Run a verify command; expect "Signature OK" and exit 0.
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# Run a verify command; expect "Verification FAILED" and non-zero exit.
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# Reference messages
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg32.bin"   # 32 bytes (256-bit block)
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg32b.bin"  # differs in last byte
+printf 'Test' > "$TMP/msg4.bin"                                 # 4 bytes (32-bit block)
+printf 'Fail' > "$TMP/msg4b.bin"                                # different 4 bytes
+
+# ---------------------------------------------------------------------------
+# HPKS and HPKS-NL (Schnorr over GF(2^256)*)
+# ---------------------------------------------------------------------------
+
+for algo in hpks hpks-nl; do
+    $CLI genpkey --algo "$algo" --out "$TMP/${algo}.pem"
+    $CLI pkey    --in "$TMP/${algo}.pem" --pubout --out "$TMP/${algo}_pub.pem"
+    $CLI sign    --algo "$algo" --key "$TMP/${algo}.pem" \
+                 --in "$TMP/msg32.bin" --out "$TMP/${algo}_sig.pem"
+
+    check_verify "verify $algo correct msg" \
+        $CLI verify --algo "$algo" --pubkey "$TMP/${algo}_pub.pem" \
+        --in "$TMP/msg32.bin" --sig "$TMP/${algo}_sig.pem"
+
+    check_reject "verify $algo wrong msg" \
+        $CLI verify --algo "$algo" --pubkey "$TMP/${algo}_pub.pem" \
+        --in "$TMP/msg32b.bin" --sig "$TMP/${algo}_sig.pem"
+done
+
+# Cross-key rejection: signature made with hpks key must not verify under a different hpks key
+$CLI genpkey --algo hpks --out "$TMP/hpks_other.pem"
+$CLI pkey    --in "$TMP/hpks_other.pem" --pubout --out "$TMP/hpks_other_pub.pem"
+check_reject "verify hpks wrong key" \
+    $CLI verify --algo hpks --pubkey "$TMP/hpks_other_pub.pem" \
+    --in "$TMP/msg32.bin" --sig "$TMP/hpks_sig.pem"
+
+# ---------------------------------------------------------------------------
+# HPKS-Stern-F (Fiat-Shamir over code-based ZKP; n=32 for speed)
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hpks-stern --bits 32 --out "$TMP/hpks_stern.pem"
+$CLI pkey    --in "$TMP/hpks_stern.pem" --pubout --out "$TMP/hpks_stern_pub.pem"
+$CLI sign    --algo hpks-stern --key "$TMP/hpks_stern.pem" \
+             --in "$TMP/msg4.bin" --out "$TMP/hpks_stern_sig.pem"
+
+check_verify "verify hpks-stern correct msg n=32" \
+    $CLI verify --algo hpks-stern --pubkey "$TMP/hpks_stern_pub.pem" \
+    --in "$TMP/msg4.bin" --sig "$TMP/hpks_stern_sig.pem"
+
+check_reject "verify hpks-stern wrong msg n=32" \
+    $CLI verify --algo hpks-stern --pubkey "$TMP/hpks_stern_pub.pem" \
+    --in "$TMP/msg4b.bin" --sig "$TMP/hpks_stern_sig.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_vectors.sh
+++ b/CliTest/test_vectors.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# CliTest/test_vectors.sh — key-agreement correctness: both parties must derive matching secrets
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check() {
+    local label="$1" result="$2"
+    if [ "$result" = "ok" ]; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: $result"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# HKEX-GF — both parties must produce an identical SESSION KEY PEM
+#
+# g^{ab} = g^{ba} in GF(2^n)*, so both DER-encoded outputs must be equal.
+# ---------------------------------------------------------------------------
+
+$CLI genpkey --algo hkex-gf --out "$TMP/alice_gf.pem"
+$CLI pkey    --in "$TMP/alice_gf.pem" --pubout --out "$TMP/alice_gf_pub.pem"
+$CLI genpkey --algo hkex-gf --out "$TMP/bob_gf.pem"
+$CLI pkey    --in "$TMP/bob_gf.pem"   --pubout --out "$TMP/bob_gf_pub.pem"
+
+$CLI kex --algo hkex-gf --our "$TMP/alice_gf.pem" --their "$TMP/bob_gf_pub.pem" \
+         --out "$TMP/alice_sk.pem"
+$CLI kex --algo hkex-gf --our "$TMP/bob_gf.pem"   --their "$TMP/alice_gf_pub.pem" \
+         --out "$TMP/bob_sk.pem"
+
+if cmp -s "$TMP/alice_sk.pem" "$TMP/bob_sk.pem"; then
+    check "hkex-gf key agreement" "ok"
+else
+    check "hkex-gf key agreement" "session key PEMs differ"
+fi
+
+# ---------------------------------------------------------------------------
+# HKEX-RNL (n=64) — cross-party encryption must round-trip
+#
+# Bob encrypts with K_B (RESPONSE PEM); Alice decrypts with K_A (SESSION KEY PEM).
+# Success proves K_A = K_B, validating the Peikert reconciliation property.
+# ---------------------------------------------------------------------------
+
+printf 'KEXTEST!' > "$TMP/msg8.bin"   # 8 bytes matches the n=64 block size
+
+$CLI genpkey --algo hkex-rnl --bits 64 --out "$TMP/alice_rnl.pem"
+$CLI pkey    --in "$TMP/alice_rnl.pem" --pubout --out "$TMP/alice_rnl_pub.pem"
+$CLI genpkey --algo hkex-rnl --bits 64 --out "$TMP/bob_rnl.pem"
+
+# Step 1 — Bob responds; RESPONSE PEM holds K_B, C_B, hint
+$CLI kex --algo hkex-rnl --our "$TMP/bob_rnl.pem" --their "$TMP/alice_rnl_pub.pem" \
+         --out "$TMP/bob_rnl_resp.pem"
+# Step 2 — Alice completes; SESSION KEY PEM holds K_A
+$CLI kex --algo hkex-rnl --our "$TMP/alice_rnl.pem" --their "$TMP/bob_rnl_resp.pem" \
+         --out "$TMP/alice_rnl_sk.pem"
+
+# Bob-side encrypt (K_B), Alice-side decrypt (K_A)
+$CLI enc --algo hske --key "$TMP/bob_rnl_resp.pem" \
+         --in "$TMP/msg8.bin" --out "$TMP/rnl_ct_bob.pem"
+$CLI dec --algo hske --key "$TMP/alice_rnl_sk.pem" \
+         --in "$TMP/rnl_ct_bob.pem" --out "$TMP/rnl_plain_alice.bin"
+
+if cmp -s "$TMP/msg8.bin" "$TMP/rnl_plain_alice.bin"; then
+    check "hkex-rnl key agreement (Bob enc / Alice dec)" "ok"
+else
+    check "hkex-rnl key agreement (Bob enc / Alice dec)" "plaintext mismatch — K_A ≠ K_B"
+fi
+
+# Alice-side encrypt (K_A), Bob-side decrypt (K_B)
+$CLI enc --algo hske --key "$TMP/alice_rnl_sk.pem" \
+         --in "$TMP/msg8.bin" --out "$TMP/rnl_ct_alice.pem"
+$CLI dec --algo hske --key "$TMP/bob_rnl_resp.pem" \
+         --in "$TMP/rnl_ct_alice.pem" --out "$TMP/rnl_plain_bob.bin"
+
+if cmp -s "$TMP/msg8.bin" "$TMP/rnl_plain_bob.bin"; then
+    check "hkex-rnl key agreement (Alice enc / Bob dec)" "ok"
+else
+    check "hkex-rnl key agreement (Alice enc / Bob dec)" "plaintext mismatch — K_A ≠ K_B"
+fi
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CryptosuiteTests/Herradura_tests.asm
+++ b/CryptosuiteTests/Herradura_tests.asm
@@ -1,4 +1,4 @@
-;  Herradura KEx -- Correctness Tests v1.5.22
+;  Herradura KEx -- Correctness Tests v1.5.23
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS Schnorr, HPKE El Gamal,
 ;                        NL-FSCX v2 inv, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL,
 ;                        HPKS-Stern-F, HPKE-Stern-F
@@ -58,7 +58,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura KEx v1.5.22 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
+    hdr         db "=== Herradura KEx v1.5.23 -- Correctness Tests (NASM i386, KEYBITS=32) ===", 10, 10
     hdr_l       equ $-hdr
 
     t1_hdr      db "[1] HKEX-GF key exchange correctness: sk_alice == sk_bob (20 iterations)", 10

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -5,6 +5,7 @@
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
 /*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+    v1.5.23: HerraduraCli OpenSSL-style CLI (TODO #25); CliTest shell test suite.
     v1.5.20: 256-bit NL-FSCX v2 BitArray functions; tests expanded to full multi-size:
             Batch 2 — tests [10]–[13] loop {64,128,256}; adds ba_sub256, ba_mul256,
             m_inv_ba, nl_fscx_v2_ba/inv_ba, nl_fscx_revolve_v2_ba/inv_ba.
@@ -3859,7 +3860,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.5.20 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.5.23 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
 /*  Herradura KEx -- Security & Performance Tests (Go)
+    v1.5.23: HerraduraCli OpenSSL-style CLI (TODO #25); CliTest shell test suite.
     v1.5.22: CBD(eta=1) 4-coeffs/byte (#16); test[14] n∈{32,64,128,256} (#23); NASM rnl_round fix (#21).
     v1.5.21: version-banner sync; ARM HSKE-NL-A2 R_VALUE fix; Python HKEX-RNL q-label.
     v1.5.18: HPKS-Stern-F + HPKE-Stern-F code-based PQC tests [17][18]; benchmarks renumbered [19-28].
@@ -1632,7 +1633,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.5.22 — Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.5.23 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -1,4 +1,4 @@
-/*  Herradura KEx — Security Tests v1.5.22 (Arduino, 32-bit)
+/*  Herradura KEx — Security Tests v1.5.23 (Arduino, 32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, NL-FSCX, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL,
     HPKS-Stern-F, HPKE-Stern-F
 
@@ -661,7 +661,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura KEx v1.5.22 - Security Tests (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura KEx v1.5.23 - Security Tests (Arduino, 32-bit) ===");
     Serial.println();
 
     test_hkex_gf();

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
     Herradura KEx — Security & Performance Tests (Python)
+    v1.5.23: HerraduraCli OpenSSL-style CLI (TODO #25); CliTest shell test suite.
     v1.5.20: multi-size standardization — GF/RNL/Stern-F tests at 32,64,128,256 bits.
     v1.5.18: HPKS-Stern-F [17] + HPKE-Stern-F [18] + bench [26] (code-based PQC).
     v1.5.13: HSKE-NL-A1 seed fix — seed=ROL(base,n/8) breaks counter=0 step-1 degeneracy.
@@ -1151,7 +1152,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.5.22 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.5.23 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/CryptosuiteTests/Herradura_tests.s
+++ b/CryptosuiteTests/Herradura_tests.s
@@ -1,4 +1,4 @@
-/*  Herradura KEx -- Correctness Tests v1.5.22
+/*  Herradura KEx -- Correctness Tests v1.5.23
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        NL-FSCX v2 inv, HSKE-NL-A2,
                                        HKEX-RNL, HPKS-NL, HPKE-NL,
@@ -36,7 +36,7 @@
     .data
     .balign 4
 
-fmt_hdr:  .asciz "=== Herradura KEx v1.5.22 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
+fmt_hdr:  .asciz "=== Herradura KEx v1.5.23 -- Correctness Tests (ARM Thumb, KEYBITS=32) ===\n\n"
 fmt_t1:   .asciz "[1] HKEX-GF key exchange: sk_alice == sk_bob (20 iterations)\n"
 fmt_t2:   .asciz "[2] HSKE encrypt+decrypt round-trip: D == plaintext (100 iterations)\n"
 fmt_t3:   .asciz "[3] HPKS Schnorr: g^s * C^e == R (20 iterations)\n"

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,4 +1,4 @@
-;  Herradura Cryptographic Suite v1.5.22
+;  Herradura Cryptographic Suite v1.5.23
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
 ;                        HPKS-Stern-F, HPKE-Stern-F
@@ -103,7 +103,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.5.22 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.5.23 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.22
+/*  Herradura Cryptographic Suite v1.5.23
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.22
+/*  Herradura Cryptographic Suite v1.5.23
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.22 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.5.23 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
     HPKS-Stern-F, HPKE-Stern-F
     KEYBITS = 32
@@ -504,7 +504,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura Cryptographic Suite v1.5.22 (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura Cryptographic Suite v1.5.23 (Arduino, 32-bit) ===");
     Serial.println();
 
     printHexLine("a_priv : ", A_PRIV);

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.5.20
+    Herradura Cryptographic Suite v1.5.23
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -18,6 +18,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+    --- v1.5.23: HerraduraCli — OpenSSL-style Python CLI (TODO #25); CliTest shell test suite ---
     --- v1.5.20: HPKE-Stern-F N=256 known-e' demo; multi-size standardization ---
     --- v1.5.18: HPKS-Stern-F / HPKE-Stern-F — code-based PQC (SD + NL-FSCX v1 PRF) ---
 

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.5.22
+/*  Herradura Cryptographic Suite v1.5.23
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
                                        HPKS-Stern-F, HPKE-Stern-F
@@ -49,7 +49,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.22 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.5.23 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 

--- a/HerraduraCli/codec.py
+++ b/HerraduraCli/codec.py
@@ -1,0 +1,143 @@
+# HerraduraCli/codec.py — PEM and minimal DER codec (v1.5.23)
+# No external dependencies; uses only base64 from stdlib.
+import base64
+
+
+# ---------------------------------------------------------------------------
+# DER helpers
+# ---------------------------------------------------------------------------
+
+def _encode_length(n: int) -> bytes:
+    if n < 0x80:
+        return bytes([n])
+    elif n < 0x100:
+        return bytes([0x81, n])
+    elif n < 0x10000:
+        return bytes([0x82, n >> 8, n & 0xff])
+    else:
+        raise ValueError(f"Length too large for DER: {n}")
+
+
+def _read_length(data: bytes, offset: int):
+    b = data[offset]
+    if b < 0x80:
+        return b, offset + 1
+    n_bytes = b & 0x7f
+    val = int.from_bytes(data[offset + 1:offset + 1 + n_bytes], 'big')
+    return val, offset + 1 + n_bytes
+
+
+def der_int(value: int, nbytes: int = None) -> bytes:
+    """Encode a non-negative integer as DER INTEGER (tag 0x02).
+
+    nbytes: byte width of the value before adding any sign byte.
+    If None, the minimal non-zero byte count is used.
+    """
+    if value < 0:
+        raise ValueError("Negative integers not supported")
+    if nbytes is None:
+        nbytes = max(1, (value.bit_length() + 7) // 8)
+    data = value.to_bytes(nbytes, 'big')
+    if data[0] & 0x80:          # high bit set → add leading zero (positive sign)
+        data = b'\x00' + data
+    return b'\x02' + _encode_length(len(data)) + data
+
+
+def der_seq(*items: bytes) -> bytes:
+    """Wrap DER-encoded items in a SEQUENCE (tag 0x30)."""
+    body = b''.join(items)
+    return b'\x30' + _encode_length(len(body)) + body
+
+
+def der_parse_seq(data: bytes) -> list:
+    """Decode a DER SEQUENCE of INTEGERs; return list of Python ints."""
+    if data[0] != 0x30:
+        raise ValueError(f"Expected SEQUENCE tag 0x30, got 0x{data[0]:02x}")
+    offset = 1
+    length, offset = _read_length(data, offset)
+    end = offset + length
+    results = []
+    while offset < end:
+        if data[offset] != 0x02:
+            raise ValueError(f"Expected INTEGER tag 0x02, got 0x{data[offset]:02x}")
+        offset += 1
+        vlen, offset = _read_length(data, offset)
+        val_bytes = data[offset:offset + vlen]
+        offset += vlen
+        # Strip optional leading zero byte used as positive sign indicator
+        if val_bytes and val_bytes[0] == 0x00 and len(val_bytes) > 1:
+            val_bytes = val_bytes[1:]
+        results.append(int.from_bytes(val_bytes, 'big'))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Polynomial packing helpers
+# ---------------------------------------------------------------------------
+
+def pack_poly(coeffs: list, bytes_per_coeff: int) -> tuple:
+    """Pack a list of integer coefficients into a big integer and byte count.
+
+    Returns (packed_int, total_bytes) so that der_int(packed_int, total_bytes)
+    round-trips correctly even when leading coefficients are zero.
+    """
+    n = len(coeffs)
+    total = n * bytes_per_coeff
+    raw = bytearray(total)
+    for i, c in enumerate(coeffs):
+        raw[i * bytes_per_coeff:(i + 1) * bytes_per_coeff] = c.to_bytes(bytes_per_coeff, 'big')
+    return int.from_bytes(raw, 'big'), total
+
+
+def unpack_poly(packed_int: int, n: int, bytes_per_coeff: int) -> list:
+    """Unpack a big integer back to a coefficient list (inverse of pack_poly)."""
+    total = n * bytes_per_coeff
+    raw = packed_int.to_bytes(total, 'big')
+    return [int.from_bytes(raw[i * bytes_per_coeff:(i + 1) * bytes_per_coeff], 'big')
+            for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# PEM helpers
+# ---------------------------------------------------------------------------
+
+def pem_wrap(label: str, data: bytes) -> str:
+    """Wrap binary data as a PEM block with the given label."""
+    b64 = base64.encodebytes(data).decode('ascii').strip()
+    return f"-----BEGIN {label}-----\n{b64}\n-----END {label}-----\n"
+
+
+def pem_unwrap(pem_text: str) -> tuple:
+    """Unwrap a PEM block; return (label, binary_data)."""
+    lines = pem_text.strip().splitlines()
+    if not (lines[0].startswith('-----BEGIN ') and lines[-1].startswith('-----END ')):
+        raise ValueError("Not a valid PEM block")
+    label = lines[0][11:-5]
+    b64 = ''.join(lines[1:-1])
+    return label, base64.b64decode(b64)
+
+
+# ---------------------------------------------------------------------------
+# Self-test (runs when imported as __main__ only)
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    # Round-trip DER INTEGER
+    for v in [0, 1, 127, 128, 255, 256, 0xdeadbeef, 2**256 - 1]:
+        enc = der_int(v)
+        dec = der_parse_seq(der_seq(enc))
+        assert dec == [v], f"der_int round-trip failed for {v}: {dec}"
+    # Round-trip DER SEQUENCE
+    items = [0, 42, 2**64, 2**256 - 1]
+    seq = der_seq(*[der_int(x) for x in items])
+    assert der_parse_seq(seq) == items
+    # Round-trip polynomial packing
+    poly = [0, 65537 - 1, 1, 0, 42, 0]
+    packed, nb = pack_poly(poly, 4)
+    assert unpack_poly(packed, len(poly), 4) == poly
+    # Round-trip PEM
+    data = bytes(range(64))
+    label = "HERRADURA TEST"
+    pem = pem_wrap(label, der_seq(der_int(42)))
+    lbl, raw = pem_unwrap(pem)
+    assert lbl == label
+    print("codec.py self-test OK")

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+# HerraduraCli/herradura.py — OpenSSL-style CLI for the Herradura Cryptographic Suite (v1.5.23)
+#
+# Usage examples:
+#   python3 herradura.py genpkey --algo hkex-gf  --bits 256 --out alice.pem
+#   python3 herradura.py pkey    --in alice.pem --pubout --out alice_pub.pem
+#   python3 herradura.py kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --out sk.pem
+#   python3 herradura.py enc     --algo hske      --key sk.pem --in msg.bin --out cipher.pem
+#   python3 herradura.py dec     --algo hske      --key sk.pem --in cipher.pem --out plain.bin
+#   python3 herradura.py sign    --algo hpks      --key sig.pem --in msg.bin --out s.pem
+#   python3 herradura.py verify  --algo hpks      --pubkey sig.pem --in msg.bin --sig s.pem
+#
+# HKEX-RNL key exchange (2-round — Bob responds first, then Alice completes):
+#   # Step 1: Bob responds to Alice's public key
+#   python3 herradura.py kex --algo hkex-rnl --our bob.pem --their alice_pub.pem \
+#                            --out bob_session.pem
+#   # Step 2: Alice completes using Bob's response
+#   python3 herradura.py kex --algo hkex-rnl --our alice.pem --their bob_session.pem \
+#                            --out alice_session.pem
+#
+# HPKE-Stern-F is a KEM demo: e' is embedded in ciphertext (brute-force decap).
+# Production use requires a QC-MDPC decoder (N=256, t=16).
+
+import argparse
+import sys
+import os
+
+# Add parent directory to path so relative imports work when run directly
+sys.path.insert(0, os.path.dirname(__file__))
+
+from codec import (der_int, der_seq, der_parse_seq, pem_wrap, pem_unwrap,
+                   pack_poly, unpack_poly)
+from primitives import (
+    BitArray, fscx_revolve, nl_fscx_revolve_v1, nl_fscx_revolve_v2,
+    nl_fscx_revolve_v2_inv, gf_mul, gf_pow,
+    _rnl_keygen, _rnl_agree, _rnl_m_poly, _rnl_rand_poly, _rnl_poly_add,
+    _rnl_lift, _rnl_poly_mul,
+    stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
+    hpke_stern_f_encap_with_e, hpke_stern_f_decap,
+    KEYBITS, GF_POLY, GF_GEN, ORD,
+    RNLQ, RNLP, RNLPP, RNLB,
+    I_VALUE, R_VALUE, SDFT, SDFNR, SDFR,
+)
+from primitives import _s as _suite_mod
+
+# ---------------------------------------------------------------------------
+# Label constants
+# ---------------------------------------------------------------------------
+
+_PRIV_ALGOS = {
+    'hkex-gf':     'HERRADURA HKEX-GF PRIVATE KEY',
+    'hkex-rnl':    'HERRADURA HKEX-RNL PRIVATE KEY',
+    'hpks':        'HERRADURA HPKS PRIVATE KEY',
+    'hpks-nl':     'HERRADURA HPKS-NL PRIVATE KEY',
+    'hpke':        'HERRADURA HPKE PRIVATE KEY',
+    'hpke-nl':     'HERRADURA HPKE-NL PRIVATE KEY',
+    'hpks-stern':  'HERRADURA HPKS-STERN PRIVATE KEY',
+    'hpke-stern':  'HERRADURA HPKE-STERN PRIVATE KEY',
+}
+
+_PUB_ALGOS = {k: v.replace('PRIVATE', 'PUBLIC') for k, v in _PRIV_ALGOS.items()}
+
+_LABEL_TO_ALGO = {v: k for k, v in _PRIV_ALGOS.items()}
+_LABEL_TO_ALGO.update({v: k for k, v in _PUB_ALGOS.items()})
+
+_LABEL_SESSION     = 'HERRADURA SESSION KEY'
+_LABEL_RNL_RESP    = 'HERRADURA HKEX-RNL RESPONSE'
+_LABEL_SIG         = 'HERRADURA SIGNATURE'
+_LABEL_CT          = 'HERRADURA CIPHERTEXT'
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+def _read_file(path):
+    if path == '-':
+        return sys.stdin.buffer.read()
+    with open(path, 'rb') as f:
+        return f.read()
+
+
+def _write_file(path, data):
+    if path == '-':
+        if isinstance(data, str):
+            sys.stdout.write(data)
+        else:
+            sys.stdout.buffer.write(data)
+        return
+    mode = 'w' if isinstance(data, str) else 'wb'
+    with open(path, mode) as f:
+        f.write(data)
+
+
+def _read_pem(path):
+    raw = _read_file(path)
+    return pem_unwrap(raw.decode('ascii') if isinstance(raw, bytes) else raw)
+
+
+def _read_pem_ints(path):
+    label, der = _read_pem(path)
+    return label, der_parse_seq(der)
+
+
+# ---------------------------------------------------------------------------
+# Key serialization helpers
+# ---------------------------------------------------------------------------
+
+_CLASSICAL_GF_ALGOS = {'hkex-gf', 'hpks', 'hpks-nl', 'hpke', 'hpke-nl'}
+_STERN_ALGOS        = {'hpks-stern', 'hpke-stern'}
+
+
+def _encode_classical_privkey(priv_int, pub_int, nbits, algo):
+    der = der_seq(der_int(priv_int, nbits // 8),
+                  der_int(pub_int,  nbits // 8),
+                  der_int(nbits))
+    return pem_wrap(_PRIV_ALGOS[algo], der)
+
+
+def _encode_classical_pubkey(pub_int, nbits, algo):
+    der = der_seq(der_int(pub_int, nbits // 8), der_int(nbits))
+    return pem_wrap(_PUB_ALGOS[algo], der)
+
+
+def _rnl_privkey_fields(n, s_poly, m_poly):
+    s_packed, s_nb = pack_poly(s_poly, 4)   # Z_q coeff → 4 bytes (q = 65537 ≤ 3 bytes; padded)
+    m_packed, m_nb = pack_poly(m_poly, 4)   # m_blind in Z_q → 4 bytes per coeff
+    return s_packed, s_nb, m_packed, m_nb
+
+
+def _encode_rnl_privkey(s_poly, m_poly, n):
+    s_packed, s_nb, m_packed, m_nb = _rnl_privkey_fields(n, s_poly, m_poly)
+    der = der_seq(der_int(s_packed, s_nb), der_int(m_packed, m_nb), der_int(n))
+    return pem_wrap(_PRIV_ALGOS['hkex-rnl'], der)
+
+
+def _encode_rnl_pubkey(C_poly, m_poly, n):
+    C_packed, C_nb = pack_poly(C_poly, 2)   # Z_p coeff → 2 bytes (p = 4096)
+    m_packed, m_nb = pack_poly(m_poly, 4)
+    der = der_seq(der_int(C_packed, C_nb), der_int(m_packed, m_nb), der_int(n))
+    return pem_wrap(_PUB_ALGOS['hkex-rnl'], der)
+
+
+def _decode_rnl_privkey(ints):
+    """Return (s_poly, m_poly, n) from parsed private key integers."""
+    s_packed, m_packed, n = ints
+    s_poly = unpack_poly(s_packed, n, 4)
+    m_poly = unpack_poly(m_packed, n, 4)
+    return s_poly, m_poly, n
+
+
+def _decode_rnl_pubkey(ints):
+    """Return (C_poly, m_poly, n) from parsed public key integers."""
+    C_packed, m_packed, n = ints
+    C_poly = unpack_poly(C_packed, n, 2)
+    m_poly = unpack_poly(m_packed, n, 4)
+    return C_poly, m_poly, n
+
+
+def _rnl_derive_C(m_poly, s_poly, n):
+    """Compute C = round_p(m_blind * s) given m_blind and s (both as Z_q polys)."""
+    ms = _rnl_poly_mul(m_poly, s_poly, RNLQ, n)
+    return _suite_mod._rnl_round(ms, RNLQ, RNLP)
+
+
+def _encode_stern_privkey(e_int, seed, n, algo):
+    nbytes = n // 8
+    der = der_seq(der_int(e_int, nbytes), der_int(seed.uint, nbytes), der_int(n))
+    return pem_wrap(_PRIV_ALGOS[algo], der)
+
+
+def _encode_stern_pubkey(syn_int, seed, n, algo):
+    nbytes = n // 8
+    der = der_seq(der_int(syn_int, nbytes), der_int(seed.uint, nbytes), der_int(n))
+    return pem_wrap(_PUB_ALGOS[algo], der)
+
+
+def _decode_privkey(path):
+    """Load a private key PEM; return (algo, fields_list)."""
+    label, ints = _read_pem_ints(path)
+    algo = _LABEL_TO_ALGO.get(label)
+    if algo is None:
+        raise ValueError(f"Unrecognised PEM label: {label!r}")
+    return algo, ints
+
+
+def _decode_pubkey(path):
+    """Load a public key PEM; return (algo, fields_list)."""
+    label, ints = _read_pem_ints(path)
+    algo = _LABEL_TO_ALGO.get(label)
+    if algo is None:
+        raise ValueError(f"Unrecognised PEM label: {label!r}")
+    return algo, ints
+
+
+# ---------------------------------------------------------------------------
+# Session key serialization
+# ---------------------------------------------------------------------------
+
+def _encode_session_key(key_int, nbits):
+    """Encode a plain session key (HKEX-GF or completed HKEX-RNL)."""
+    nbytes = max(1, (key_int.bit_length() + 7) // 8)
+    der = der_seq(der_int(key_int, nbytes), der_int(nbits))
+    return pem_wrap(_LABEL_SESSION, der)
+
+
+def _encode_rnl_response(K_int, C_B_poly, hint, n):
+    """Encode Bob's HKEX-RNL response: (K_B, C_B, hint, n, hint_len).
+
+    K_B is Bob's session key (stored so enc/dec can use this file directly).
+    C_B and hint are the public parts Alice uses to complete the handshake.
+    """
+    K_nb    = max(1, (K_int.bit_length() + 7) // 8)
+    C_packed, C_nb = pack_poly(C_B_poly, 2)
+    hint_int = 0
+    for i, b in enumerate(hint):
+        hint_int |= b << i
+    hint_nb = max(1, (len(hint) + 7) // 8)
+    der = der_seq(der_int(K_int,    K_nb),
+                  der_int(C_packed, C_nb),
+                  der_int(hint_int, hint_nb),
+                  der_int(n),
+                  der_int(len(hint)))
+    return pem_wrap(_LABEL_RNL_RESP, der)
+
+
+def _decode_session_key(path):
+    """Return (key_int, nbits) from either SESSION KEY or RNL RESPONSE PEM."""
+    label, ints = _read_pem_ints(path)
+    if label == _LABEL_SESSION:
+        key_int, nbits = ints
+        return key_int, nbits
+    elif label == _LABEL_RNL_RESP:
+        # K_B is the first field — usable directly for enc/dec
+        K_int, _, _, n, _ = ints
+        return K_int, n
+    else:
+        raise ValueError(f"Expected SESSION KEY or RNL RESPONSE PEM, got {label!r}")
+
+
+def _decode_rnl_response(path):
+    """Return (K_int, C_B_poly, hint, n) from a HKEX-RNL RESPONSE PEM."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_RNL_RESP:
+        raise ValueError(f"Expected HKEX-RNL RESPONSE PEM, got {label!r}")
+    K_int, C_packed, hint_int, n, hint_len = ints
+    C_B_poly = unpack_poly(C_packed, n, 2)
+    hint = [(hint_int >> i) & 1 for i in range(hint_len)]
+    return K_int, C_B_poly, hint, n
+
+
+# ---------------------------------------------------------------------------
+# Ciphertext serialization (symmetric)
+# ---------------------------------------------------------------------------
+
+def _encode_sym_ct(algo, E_int, nbits, nonce_int=None):
+    nbytes = nbits // 8
+    if algo == 'hske-nla1' and nonce_int is not None:
+        der = der_seq(der_int(1),               # format tag 1: NLA1 with nonce
+                      der_int(nonce_int, nbytes),
+                      der_int(E_int, nbytes),
+                      der_int(nbits))
+    else:
+        der = der_seq(der_int(0),               # format tag 0: no nonce
+                      der_int(E_int, nbytes),
+                      der_int(nbits))
+    return pem_wrap(_LABEL_CT, der)
+
+
+def _decode_sym_ct(path):
+    """Return (E_int, nbits, nonce_int_or_None)."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_CT:
+        raise ValueError(f"Expected CIPHERTEXT PEM, got {label!r}")
+    fmt = ints[0]
+    if fmt == 1:
+        _, nonce_int, E_int, nbits = ints
+        return E_int, nbits, nonce_int
+    else:
+        _, E_int, nbits = ints
+        return E_int, nbits, None
+
+
+# ---------------------------------------------------------------------------
+# Ciphertext serialization (asymmetric HPKE / HPKE-NL)
+# ---------------------------------------------------------------------------
+
+def _encode_asym_ct(R_int, E_int, nbits):
+    nbytes = nbits // 8
+    der = der_seq(der_int(R_int, nbytes), der_int(E_int, nbytes), der_int(nbits))
+    return pem_wrap(_LABEL_CT, der)
+
+
+def _decode_asym_ct(path):
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_CT:
+        raise ValueError(f"Expected CIPHERTEXT PEM, got {label!r}")
+    R_int, E_int, nbits = ints
+    return R_int, E_int, nbits
+
+
+# ---------------------------------------------------------------------------
+# Ciphertext serialization (HPKE-Stern-F KEM)
+# ---------------------------------------------------------------------------
+
+def _encode_stern_ct(ct_syn, e_p, K_int, E_int, n):
+    """HPKE-Stern-F demo ciphertext: syndrome + plaintext error (demo) + HSKE payload."""
+    nbytes = n // 8
+    der = der_seq(der_int(ct_syn, nbytes),
+                  der_int(e_p,    nbytes),   # demo: e' transmitted for brute-force decap
+                  der_int(K_int,  nbytes),
+                  der_int(E_int,  nbytes),
+                  der_int(n))
+    return pem_wrap(_LABEL_CT, der)
+
+
+def _decode_stern_ct(path):
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_CT:
+        raise ValueError(f"Expected CIPHERTEXT PEM, got {label!r}")
+    ct_syn, e_p, K_int, E_int, n = ints
+    return ct_syn, e_p, K_int, E_int, n
+
+
+# ---------------------------------------------------------------------------
+# Signature serialization (HPKS / HPKS-NL — Schnorr)
+# ---------------------------------------------------------------------------
+
+def _encode_schnorr_sig(s_int, R_int, e_int, nbits):
+    nbytes = nbits // 8
+    der = der_seq(der_int(s_int, nbytes),
+                  der_int(R_int, nbytes),
+                  der_int(e_int, nbytes),
+                  der_int(nbits))
+    return pem_wrap(_LABEL_SIG, der)
+
+
+def _decode_schnorr_sig(path):
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_SIG:
+        raise ValueError(f"Expected SIGNATURE PEM, got {label!r}")
+    s_int, R_int, e_int, nbits = ints
+    return s_int, R_int, e_int, nbits
+
+
+# ---------------------------------------------------------------------------
+# Signature serialization (HPKS-Stern-F)
+# Stores: n, rounds, packed commits (3×rounds×n bits), packed challenges
+# (2 bits each), packed responses (2×n bits per round).
+# ---------------------------------------------------------------------------
+
+def _pack_stern_sig(sig, n):
+    commits, challenges, responses = sig
+    rounds  = len(commits)
+    nbytes  = n // 8
+
+    commits_ba = bytearray()
+    for c0, c1, c2 in commits:
+        commits_ba += c0.uint.to_bytes(nbytes, 'big')
+        commits_ba += c1.uint.to_bytes(nbytes, 'big')
+        commits_ba += c2.uint.to_bytes(nbytes, 'big')
+
+    chal_bytes = bytearray((rounds + 3) // 4)
+    for i, b in enumerate(challenges):
+        chal_bytes[i // 4] |= (b & 3) << ((i % 4) * 2)
+
+    resp_ba = bytearray()
+    for resp in responses:
+        v0 = resp[0].uint if isinstance(resp[0], BitArray) else resp[0]
+        v1 = resp[1].uint if isinstance(resp[1], BitArray) else resp[1]
+        resp_ba += v0.to_bytes(nbytes, 'big')
+        resp_ba += v1.to_bytes(nbytes, 'big')
+
+    c_int  = int.from_bytes(commits_ba, 'big')
+    ch_int = int.from_bytes(chal_bytes, 'big')
+    r_int  = int.from_bytes(resp_ba,   'big')
+
+    der = der_seq(der_int(n),
+                  der_int(rounds),
+                  der_int(c_int,  len(commits_ba)),
+                  der_int(ch_int, len(chal_bytes)),
+                  der_int(r_int,  len(resp_ba)))
+    return pem_wrap(_LABEL_SIG, der)
+
+
+def _unpack_stern_sig(path):
+    """Return (commits, challenges, responses, n) from a Stern-F signature PEM."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_SIG:
+        raise ValueError(f"Expected SIGNATURE PEM, got {label!r}")
+    n, rounds, c_int, ch_int, r_int = ints
+    nbytes = n // 8
+
+    commits_ba = c_int.to_bytes(3 * rounds * nbytes, 'big')
+    commits = []
+    for i in range(rounds):
+        off = i * 3 * nbytes
+        c0 = BitArray(n, int.from_bytes(commits_ba[off           :off + nbytes],     'big'))
+        c1 = BitArray(n, int.from_bytes(commits_ba[off + nbytes  :off + 2 * nbytes], 'big'))
+        c2 = BitArray(n, int.from_bytes(commits_ba[off + 2*nbytes:off + 3 * nbytes], 'big'))
+        commits.append((c0, c1, c2))
+
+    chal_nb    = (rounds + 3) // 4
+    chal_bytes = ch_int.to_bytes(chal_nb, 'big')
+    challenges = [(chal_bytes[i // 4] >> ((i % 4) * 2)) & 3 for i in range(rounds)]
+
+    resp_ba   = r_int.to_bytes(2 * rounds * nbytes, 'big')
+    responses = []
+    for i in range(rounds):
+        off = i * 2 * nbytes
+        v0  = int.from_bytes(resp_ba[off:off + nbytes],          'big')
+        v1  = int.from_bytes(resp_ba[off + nbytes:off + 2*nbytes], 'big')
+        b   = challenges[i]
+        if b == 0:
+            responses.append((v0, v1))
+        else:
+            responses.append((BitArray(n, v0), v1))
+
+    return commits, challenges, responses, n
+
+
+# ---------------------------------------------------------------------------
+# Key-loading helper for enc/dec (accepts both SESSION KEY and RNL RESPONSE)
+# ---------------------------------------------------------------------------
+
+def _load_key(path):
+    """Return (key_int, nbits) from a session key PEM or hex string."""
+    raw = _read_file(path)
+    key_str = raw.decode('ascii', errors='replace').strip()
+    if key_str.startswith('0x') or key_str.startswith('0X'):
+        key_int = int(key_str, 16)
+        nbits   = max(32, ((key_int.bit_length() + 31) // 32) * 32)
+        return key_int, nbits
+    return _decode_session_key(path)
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: genpkey
+# ---------------------------------------------------------------------------
+
+def cmd_genpkey(args):
+    algo = args.algo
+    bits = args.bits or KEYBITS
+
+    if algo in _CLASSICAL_GF_ALGOS:
+        poly    = GF_POLY.get(bits, GF_POLY[256])
+        a       = BitArray.random(bits)
+        C       = BitArray(bits, gf_pow(GF_GEN, a.uint, poly, bits))
+        pem_out = _encode_classical_privkey(a.uint, C.uint, bits, algo)
+
+    elif algo == 'hkex-rnl':
+        n       = bits
+        m_base  = _rnl_m_poly(n)
+        a_rand  = _rnl_rand_poly(n, RNLQ)
+        m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)   # randomised m_blind
+        s, C    = _rnl_keygen(m_blind, n, RNLQ, RNLP, RNLB)
+        pem_out = _encode_rnl_privkey(s, m_blind, n)
+
+    elif algo in _STERN_ALGOS:
+        seed, e_int, syn = stern_f_keygen(bits)
+        pem_out = _encode_stern_privkey(e_int, seed, bits, algo)
+
+    else:
+        sys.exit(f"Unknown algorithm: {algo!r}")
+
+    _write_file(args.out or '-', pem_out)
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: pkey
+# ---------------------------------------------------------------------------
+
+def cmd_pkey(args):
+    in_path = getattr(args, 'in')
+    algo, ints = _decode_privkey(in_path)
+
+    if args.pubout:
+        if algo in _CLASSICAL_GF_ALGOS:
+            priv_int, pub_int, nbits = ints
+            pem_out = _encode_classical_pubkey(pub_int, nbits, algo)
+        elif algo == 'hkex-rnl':
+            s_poly, m_poly, n = _decode_rnl_privkey(ints)
+            C_poly  = _rnl_derive_C(m_poly, s_poly, n)
+            pem_out = _encode_rnl_pubkey(C_poly, m_poly, n)
+        elif algo in _STERN_ALGOS:
+            e_int, seed_int, n = ints
+            syn   = _suite_mod._stern_syndrome(seed_int, e_int, n, n // 2)
+            seed  = BitArray(n, seed_int)
+            pem_out = _encode_stern_pubkey(syn, seed, n, algo)
+        else:
+            sys.exit(f"Unknown algorithm: {algo!r}")
+        _write_file(args.out or '-', pem_out)
+
+    elif args.text:
+        if algo in _CLASSICAL_GF_ALGOS:
+            priv_int, pub_int, nbits = ints
+            print(f"algorithm : {algo}")
+            print(f"bits      : {nbits}")
+            print(f"private   : {priv_int:0{nbits//4}x}")
+            print(f"public    : {pub_int:0{nbits//4}x}")
+        elif algo == 'hkex-rnl':
+            s_poly, m_poly, n = _decode_rnl_privkey(ints)
+            C_poly = _rnl_derive_C(m_poly, s_poly, n)
+            C_packed, _ = pack_poly(C_poly, 2)
+            s_packed, _ = pack_poly(s_poly, 4)
+            print(f"algorithm : {algo}")
+            print(f"n         : {n}")
+            print(f"s_packed  : {s_packed:0{n}x}")
+            print(f"C_packed  : {C_packed:0{n//2}x}")
+        elif algo in _STERN_ALGOS:
+            e_int, seed_int, n = ints
+            print(f"algorithm : {algo}")
+            print(f"n         : {n}")
+            print(f"e_int     : {e_int:0{n//4}x}")
+            print(f"seed      : {seed_int:0{n//4}x}")
+    else:
+        sys.exit("Specify --pubout or --text")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: kex
+# ---------------------------------------------------------------------------
+
+def cmd_kex(args):
+    algo      = args.algo
+    our_path  = args.our
+    their_path = args.their
+
+    if algo == 'hkex-gf':
+        our_algo,   our_ints   = _decode_privkey(our_path)
+        their_algo, their_ints = _decode_pubkey(their_path)
+        priv_int, _, nbits = our_ints
+        pub_int = their_ints[0]
+        poly    = GF_POLY.get(nbits, GF_POLY[256])
+        sk_int  = gf_pow(pub_int, priv_int, poly, nbits)
+        _write_file(args.out, _encode_session_key(sk_int, nbits))
+
+    elif algo == 'hkex-rnl':
+        # Detect protocol step from the type of --their file
+        their_label, their_ints = _read_pem_ints(their_path)
+
+        if their_label == _PUB_ALGOS['hkex-rnl']:
+            # ── STEP 1: Bob responds to Alice's public key ──────────────────
+            # Bob has: s_B (private), reads C_A and m_A from Alice's pubkey.
+            # Re-derives C_B = round_p(m_A * s_B) using Alice's m_blind.
+            # Generates (K_B, hint) and writes RESPONSE PEM.
+            our_algo, our_ints = _decode_privkey(our_path)
+            s_B, _, n = _decode_rnl_privkey(our_ints)
+            C_A, m_A, n_their = _decode_rnl_pubkey(their_ints)
+            if n != n_their:
+                sys.exit(f"Ring size mismatch: ours n={n}, theirs n={n_their}")
+            C_B    = _rnl_derive_C(m_A, s_B, n)
+            K_B, hint = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n, n)
+            _write_file(args.out, _encode_rnl_response(K_B.uint, C_B, hint, n))
+
+        elif their_label == _LABEL_RNL_RESP:
+            # ── STEP 2: Alice completes the handshake ───────────────────────
+            # Alice has: s_A (private), reads K_B, C_B, hint from Bob's response.
+            # Computes K_A = _rnl_agree(s_A, C_B, ..., hint).
+            our_algo, our_ints = _decode_privkey(our_path)
+            s_A, m_A, n = _decode_rnl_privkey(our_ints)
+            _, C_B, hint, n_resp = _decode_rnl_response(their_path)
+            if n != n_resp:
+                sys.exit(f"Ring size mismatch: ours n={n}, response n={n_resp}")
+            K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n, n, hint)
+            _write_file(args.out, _encode_session_key(K_A.uint, n))
+
+        else:
+            sys.exit(
+                f"kex hkex-rnl: --their must be an HKEX-RNL PUBLIC KEY or RESPONSE PEM "
+                f"(got label {their_label!r})"
+            )
+
+    else:
+        sys.exit(f"kex: unsupported algorithm {algo!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: enc
+# ---------------------------------------------------------------------------
+
+def cmd_enc(args):
+    algo     = args.algo
+    in_bytes = _read_file(getattr(args, 'in'))
+    out_path = args.out
+
+    # ── Symmetric algos ─────────────────────────────────────────────────────
+    if algo in ('hske', 'hske-nla1', 'hske-nla2'):
+        key_path = args.key
+        if not key_path:
+            sys.exit(f"--key required for {algo}")
+        key_int, nbits = _load_key(key_path)
+        nbytes  = nbits // 8
+        in_padded = in_bytes[:nbytes].ljust(nbytes, b'\x00')
+        P = BitArray(nbits, int.from_bytes(in_padded, 'big'))
+        K = BitArray(nbits, key_int)
+
+        if algo == 'hske':
+            E = fscx_revolve(P, K, nbits // 4)
+            _write_file(out_path, _encode_sym_ct('hske', E.uint, nbits))
+
+        elif algo == 'hske-nla1':
+            N_nonce = BitArray.random(nbits)
+            base    = BitArray(nbits, K.uint ^ N_nonce.uint)
+            seed    = base.rotated(nbits // 8)
+            ks      = nl_fscx_revolve_v1(seed, BitArray(nbits, base.uint ^ 0), nbits // 4)
+            E       = BitArray(nbits, P.uint ^ ks.uint)
+            _write_file(out_path, _encode_sym_ct('hske-nla1', E.uint, nbits, nonce_int=N_nonce.uint))
+
+        else:  # hske-nla2
+            E = nl_fscx_revolve_v2(P, K, 3 * nbits // 4)
+            _write_file(out_path, _encode_sym_ct('hske-nla2', E.uint, nbits))
+        return
+
+    # ── Asymmetric algos ────────────────────────────────────────────────────
+    pubkey_path = args.pubkey
+    if not pubkey_path:
+        sys.exit(f"--pubkey required for {algo}")
+    their_algo, their_ints = _decode_pubkey(pubkey_path)
+
+    if algo == 'hpke':
+        pub_int, nbits = their_ints
+        poly    = GF_POLY.get(nbits, GF_POLY[256])
+        nbytes  = nbits // 8
+        P       = BitArray(nbits, int.from_bytes(in_bytes[:nbytes].ljust(nbytes, b'\x00'), 'big'))
+        r       = BitArray.random(nbits)
+        R       = BitArray(nbits, gf_pow(GF_GEN, r.uint, poly, nbits))
+        enc_key = BitArray(nbits, gf_pow(pub_int, r.uint, poly, nbits))
+        E       = fscx_revolve(P, enc_key, nbits // 4)
+        _write_file(out_path, _encode_asym_ct(R.uint, E.uint, nbits))
+
+    elif algo == 'hpke-nl':
+        pub_int, nbits = their_ints
+        poly    = GF_POLY.get(nbits, GF_POLY[256])
+        nbytes  = nbits // 8
+        P       = BitArray(nbits, int.from_bytes(in_bytes[:nbytes].ljust(nbytes, b'\x00'), 'big'))
+        r       = BitArray.random(nbits)
+        R       = BitArray(nbits, gf_pow(GF_GEN, r.uint, poly, nbits))
+        enc_key = BitArray(nbits, gf_pow(pub_int, r.uint, poly, nbits))
+        E       = nl_fscx_revolve_v2(P, enc_key, nbits // 4)
+        _write_file(out_path, _encode_asym_ct(R.uint, E.uint, nbits))
+
+    elif algo == 'hpke-stern':
+        syn_int, seed_int, n = their_ints
+        seed    = BitArray(n, seed_int)
+        nbytes  = n // 8
+        P       = BitArray(n, int.from_bytes(in_bytes[:nbytes].ljust(nbytes, b'\x00'), 'big'))
+        K, ct_syn, e_p = hpke_stern_f_encap_with_e(seed, n)
+        E       = fscx_revolve(P, K, n // 4)
+        _write_file(out_path, _encode_stern_ct(ct_syn, e_p, K.uint, E.uint, n))
+
+    else:
+        sys.exit(f"enc: unsupported algorithm {algo!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: dec
+# ---------------------------------------------------------------------------
+
+def cmd_dec(args):
+    algo     = args.algo
+    out_path = args.out
+
+    # ── Symmetric algos ─────────────────────────────────────────────────────
+    if algo in ('hske', 'hske-nla1', 'hske-nla2'):
+        key_path = args.key
+        if not key_path:
+            sys.exit(f"--key required for {algo}")
+        key_int, nbits = _load_key(key_path)
+        K = BitArray(nbits, key_int)
+
+        E_int, _nbits, nonce_int = _decode_sym_ct(getattr(args, 'in'))
+        E = BitArray(nbits, E_int)
+
+        if algo == 'hske':
+            D = fscx_revolve(E, K, 3 * nbits // 4)
+        elif algo == 'hske-nla1':
+            if nonce_int is None:
+                sys.exit("hske-nla1 ciphertext missing nonce")
+            N_nonce = BitArray(nbits, nonce_int)
+            base    = BitArray(nbits, K.uint ^ N_nonce.uint)
+            seed    = base.rotated(nbits // 8)
+            ks      = nl_fscx_revolve_v1(seed, BitArray(nbits, base.uint ^ 0), nbits // 4)
+            D       = BitArray(nbits, E.uint ^ ks.uint)
+        else:  # hske-nla2
+            D = nl_fscx_revolve_v2_inv(E, K, 3 * nbits // 4)
+
+        _write_file(out_path, D.uint.to_bytes(nbits // 8, 'big'))
+        return
+
+    # ── Asymmetric algos ────────────────────────────────────────────────────
+    key_path = args.key
+    if not key_path:
+        sys.exit(f"--key required for {algo}")
+    our_algo, our_ints = _decode_privkey(key_path)
+
+    if algo == 'hpke':
+        priv_int, _, nbits = our_ints
+        poly    = GF_POLY.get(nbits, GF_POLY[256])
+        R_int, E_int, _nb = _decode_asym_ct(getattr(args, 'in'))
+        E       = BitArray(nbits, E_int)
+        dec_key = BitArray(nbits, gf_pow(R_int, priv_int, poly, nbits))
+        D       = fscx_revolve(E, dec_key, 3 * nbits // 4)
+        _write_file(out_path, D.uint.to_bytes(nbits // 8, 'big'))
+
+    elif algo == 'hpke-nl':
+        priv_int, _, nbits = our_ints
+        poly    = GF_POLY.get(nbits, GF_POLY[256])
+        R_int, E_int, _nb = _decode_asym_ct(getattr(args, 'in'))
+        E       = BitArray(nbits, E_int)
+        dec_key = BitArray(nbits, gf_pow(R_int, priv_int, poly, nbits))
+        D       = nl_fscx_revolve_v2_inv(E, dec_key, nbits // 4)
+        _write_file(out_path, D.uint.to_bytes(nbits // 8, 'big'))
+
+    elif algo == 'hpke-stern':
+        e_int, seed_int, n = our_ints
+        ct_syn, e_p, K_int, E_int, _n = _decode_stern_ct(getattr(args, 'in'))
+        seed    = BitArray(n, seed_int)
+        K_dec   = hpke_stern_f_decap(ct_syn, e_p, seed, n)
+        if K_dec is None:
+            sys.exit("HPKE-Stern-F decap failed (brute-force exhausted)")
+        E       = BitArray(n, E_int)
+        D       = fscx_revolve(E, K_dec, 3 * n // 4)
+        _write_file(out_path, D.uint.to_bytes(n // 8, 'big'))
+
+    else:
+        sys.exit(f"dec: unsupported algorithm {algo!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: sign
+# ---------------------------------------------------------------------------
+
+def cmd_sign(args):
+    algo     = args.algo
+    key_path = args.key
+    in_bytes = _read_file(getattr(args, 'in'))
+
+    our_algo, our_ints = _decode_privkey(key_path)
+
+    if algo in ('hpks', 'hpks-nl'):
+        priv_int, pub_int, nbits = our_ints
+        poly = GF_POLY.get(nbits, GF_POLY[256])
+        msg  = BitArray(nbits, int.from_bytes(in_bytes[:nbits // 8].ljust(nbits // 8, b'\x00'), 'big'))
+        k    = BitArray.random(nbits)
+        R    = BitArray(nbits, gf_pow(GF_GEN, k.uint, poly, nbits))
+        if algo == 'hpks':
+            e = fscx_revolve(R, msg, nbits // 4)
+        else:
+            e = nl_fscx_revolve_v1(R, msg, nbits // 4)
+        ord_n = (1 << nbits) - 1
+        s     = (k.uint - priv_int * e.uint) % ord_n
+        _write_file(args.out, _encode_schnorr_sig(s, R.uint, e.uint, nbits))
+
+    elif algo == 'hpks-stern':
+        e_int, seed_int, n = our_ints
+        seed = BitArray(n, seed_int)
+        syn  = _suite_mod._stern_syndrome(seed_int, e_int, n, n // 2)
+        msg  = BitArray(n, int.from_bytes(in_bytes[:n // 8].ljust(n // 8, b'\x00'), 'big'))
+        sig  = hpks_stern_f_sign(msg, e_int, seed, syn, n)
+        _write_file(args.out, _pack_stern_sig(sig, n))
+
+    else:
+        sys.exit(f"sign: unsupported algorithm {algo!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command: verify
+# ---------------------------------------------------------------------------
+
+def cmd_verify(args):
+    algo        = args.algo
+    pubkey_path = args.pubkey
+    in_bytes    = _read_file(getattr(args, 'in'))
+    sig_path    = args.sig
+
+    their_algo, their_ints = _decode_pubkey(pubkey_path)
+
+    if algo in ('hpks', 'hpks-nl'):
+        pub_int, nbits = their_ints
+        poly = GF_POLY.get(nbits, GF_POLY[256])
+        msg  = BitArray(nbits, int.from_bytes(in_bytes[:nbits // 8].ljust(nbits // 8, b'\x00'), 'big'))
+        s_int, R_int, e_int, _nb = _decode_schnorr_sig(sig_path)
+        R    = BitArray(nbits, R_int)
+        e_v  = (fscx_revolve(R, msg, nbits // 4)
+                if algo == 'hpks'
+                else nl_fscx_revolve_v1(R, msg, nbits // 4))
+        lhs  = gf_mul(gf_pow(GF_GEN, s_int, poly, nbits),
+                      gf_pow(pub_int, e_v.uint, poly, nbits), poly, nbits)
+        if lhs == R_int:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    elif algo == 'hpks-stern':
+        syn_int, seed_int, n = their_ints
+        seed = BitArray(n, seed_int)
+        msg  = BitArray(n, int.from_bytes(in_bytes[:n // 8].ljust(n // 8, b'\x00'), 'big'))
+        commits, challenges, responses, _n = _unpack_stern_sig(sig_path)
+        sig  = (commits, challenges, responses)
+        ok   = hpks_stern_f_verify(msg, sig, seed, syn_int, n)
+        if ok:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    else:
+        sys.exit(f"verify: unsupported algorithm {algo!r}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog='herradura',
+        description='Herradura Cryptographic Suite CLI v1.5.23',
+    )
+    sub = p.add_subparsers(dest='cmd', required=True)
+
+    # genpkey
+    gp = sub.add_parser('genpkey', help='Generate a private key')
+    gp.add_argument('--algo', required=True, choices=list(_PRIV_ALGOS))
+    gp.add_argument('--bits', type=int, default=None,
+                    help='Key size in bits (default 256; Stern: matrix dimension N)')
+    gp.add_argument('--out', default='-')
+
+    # pkey
+    pk = sub.add_parser('pkey', help='Display or extract a key')
+    pk.add_argument('--in', required=True, dest='in')
+    pk.add_argument('--pubout', action='store_true')
+    pk.add_argument('--text',   action='store_true')
+    pk.add_argument('--out', default='-')
+
+    # kex
+    kx = sub.add_parser('kex', help='Key exchange')
+    kx.add_argument('--algo', required=True, choices=['hkex-gf', 'hkex-rnl'])
+    kx.add_argument('--our',   required=True)
+    kx.add_argument('--their', required=True)
+    kx.add_argument('--out',   required=True)
+
+    # enc
+    en = sub.add_parser('enc', help='Encrypt')
+    en.add_argument('--algo', required=True,
+                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hpke', 'hpke-nl', 'hpke-stern'])
+    en.add_argument('--key',    default=None)
+    en.add_argument('--pubkey', default=None)
+    en.add_argument('--in',  required=True, dest='in')
+    en.add_argument('--out', required=True)
+
+    # dec
+    de = sub.add_parser('dec', help='Decrypt')
+    de.add_argument('--algo', required=True,
+                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hpke', 'hpke-nl', 'hpke-stern'])
+    de.add_argument('--key',    default=None)
+    de.add_argument('--in',  required=True, dest='in')
+    de.add_argument('--out', required=True)
+
+    # sign
+    sg = sub.add_parser('sign', help='Sign a message')
+    sg.add_argument('--algo', required=True, choices=['hpks', 'hpks-nl', 'hpks-stern'])
+    sg.add_argument('--key',  required=True)
+    sg.add_argument('--in',  required=True, dest='in')
+    sg.add_argument('--out', required=True)
+
+    # verify
+    vf = sub.add_parser('verify', help='Verify a signature')
+    vf.add_argument('--algo', required=True, choices=['hpks', 'hpks-nl', 'hpks-stern'])
+    vf.add_argument('--pubkey', required=True)
+    vf.add_argument('--in',  required=True, dest='in')
+    vf.add_argument('--sig', required=True)
+
+    return p
+
+
+_DISPATCH = {
+    'genpkey': cmd_genpkey,
+    'pkey':    cmd_pkey,
+    'kex':     cmd_kex,
+    'enc':     cmd_enc,
+    'dec':     cmd_dec,
+    'sign':    cmd_sign,
+    'verify':  cmd_verify,
+}
+
+
+def main():
+    parser = build_parser()
+    args   = parser.parse_args()
+    _DISPATCH[args.cmd](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -1,0 +1,60 @@
+# HerraduraCli/primitives.py — loads the Herradura suite and re-exports symbols (v1.5.23)
+# Uses importlib.util to load a file with spaces in its name without renaming it.
+import importlib.util
+import os
+
+_SUITE_PATH = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), '..', 'Herradura cryptographic suite.py')
+)
+
+
+def _load_suite():
+    spec = importlib.util.spec_from_file_location('herradura_suite', _SUITE_PATH)
+    mod  = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_s = _load_suite()
+
+# ── Primitive functions ──────────────────────────────────────────────────────
+BitArray               = _s.BitArray
+fscx_revolve           = _s.fscx_revolve
+nl_fscx_revolve_v1     = _s.nl_fscx_revolve_v1
+nl_fscx_revolve_v2     = _s.nl_fscx_revolve_v2
+nl_fscx_revolve_v2_inv = _s.nl_fscx_revolve_v2_inv
+gf_mul                 = _s.gf_mul
+gf_pow                 = _s.gf_pow
+
+# ── Ring-LWR / HKEX-RNL ─────────────────────────────────────────────────────
+_rnl_keygen         = _s._rnl_keygen
+_rnl_agree          = _s._rnl_agree
+_rnl_hint           = _s._rnl_hint
+_rnl_reconcile_bits = _s._rnl_reconcile_bits
+_rnl_m_poly         = _s._rnl_m_poly
+_rnl_rand_poly      = _s._rnl_rand_poly
+_rnl_poly_add       = _s._rnl_poly_add
+_rnl_lift           = _s._rnl_lift
+_rnl_poly_mul       = _s._rnl_poly_mul
+
+# ── Stern-F (code-based PQC) ─────────────────────────────────────────────────
+stern_f_keygen            = _s.stern_f_keygen
+hpks_stern_f_sign         = _s.hpks_stern_f_sign
+hpks_stern_f_verify       = _s.hpks_stern_f_verify
+hpke_stern_f_encap_with_e = _s.hpke_stern_f_encap_with_e
+hpke_stern_f_decap        = _s.hpke_stern_f_decap
+
+# ── Module-level constants ───────────────────────────────────────────────────
+KEYBITS = _s.KEYBITS          # default key width (256)
+GF_POLY = _s.GF_POLY          # irreducible poly dict keyed by bit width
+GF_GEN  = _s.GF_GEN           # DH generator (3)
+ORD     = _s.ORD               # group order = 2^KEYBITS − 1
+RNLQ   = _s.RNLQ              # Ring-LWR prime modulus (65537)
+RNLP   = _s.RNLP              # Ring-LWR public-key rounding modulus (4096)
+RNLPP  = _s.RNLPP             # Ring-LWR reconciliation modulus (2)
+RNLB   = _s.RNLB              # Ring-LWR CBD eta (1)
+I_VALUE = _s.I_VALUE          # FSCX encrypt steps (KEYBITS/4 = 64)
+R_VALUE = _s.R_VALUE          # FSCX decrypt steps (3*KEYBITS/4 = 192)
+SDFT   = _s.SDFT              # Stern-F error weight t
+SDFNR  = _s.SDFNR             # Stern-F parity-check rows
+SDFR   = _s.SDFR              # Stern-F Fiat-Shamir rounds


### PR DESCRIPTION
## Summary

- **New `HerraduraCli/` Python CLI** (Phase 1–6): `herradura.py` exposes all non-broken Herradura protocols through `genpkey`, `pkey`, `kex`, `enc`, `dec`, `sign`, `verify` subcommands analogous to OpenSSL. Keys and signatures use custom PEM labels with hand-rolled DER encoding (`codec.py`). The suite file is loaded via `importlib.util` in `primitives.py` to handle the space in the filename without renaming it.
- **HKEX-RNL 2-round protocol**: Alice's public key embeds a fresh random `m_blind`; Bob re-derives `C_B = round_p(m_A × s_B)` and writes a RESPONSE PEM; Alice reconciles with the Peikert hint to obtain matching session key `K_A = K_B`.
- **New `CliTest/` shell test suite** (Phase 7): four bash scripts covering all 8 algorithms — 33 test cases total, all passing.
- **CHANGELOG.md** updated with full v1.5.23 entry.
- **Version-banner sync**: all 12 implementation files advanced to v1.5.23 (Python suite and Python/C test files had been stuck at v1.5.20 since v1.5.21/22 missed them).

## Test plan

- [x] `bash CliTest/test_keygen.sh` → 16 PASS / 0 FAIL (genpkey + pkey --pubout for all 8 algos)
- [x] `bash CliTest/test_encrypt.sh` → 7 PASS / 0 FAIL (hske, hske-nla1, hske-nla2, hkex-rnl cross-party, hpke, hpke-nl, hpke-stern)
- [x] `bash CliTest/test_sign.sh` → 7 PASS / 0 FAIL (hpks, hpks-nl, hpks-stern; correct + tampered + wrong-key)
- [x] `bash CliTest/test_vectors.sh` → 3 PASS / 0 FAIL (HKEX-GF same-PEM agreement, HKEX-RNL bidirectional cross-party enc/dec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)