### PR TITLE
v1.5.29 PQC review: HPKS-Stern-F CSPRNG fix + Stern matrix cache + perf + #34-#41 filed

### DIFF
--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -126,8 +126,10 @@
 '''
 
 import itertools
+import math
 import os
 import random
+import warnings
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +155,11 @@ RNLB  = 1      # centered-binomial eta=1: secret coefficients drawn from CBD(1) 
 # HPKS-Stern-F / HPKE-Stern-F code-based PQC parameters (SecurityProofs.md §11.8.4)
 SDFNR = KEYBITS // 2           # parity-check rows (syndrome bits; [N, N/2, t] code, N=KEYBITS)
 SDFT  = max(2, KEYBITS // 16)  # error weight t (= 16 at n=256; ≥ 2 at all widths)
-SDFR  = 32                     # Fiat-Shamir rounds (32 → ~19-bit soundness; production: ≥ 219)
+SDFR  = 32                     # ⚠ DEMO ONLY: Fiat-Shamir rounds (~19-bit soundness).
+                               # Production deployments MUST use rounds ≥ 219 for
+                               # 128-bit soundness (⌈λ / log2(3/2)⌉ at λ=128).
+                               # Signing emits a RuntimeWarning when called below
+                               # the production threshold.
 
 
 # ---------------------------------------------------------------------------
@@ -362,10 +368,18 @@ def nl_fscx_v2_inv(Y: BitArray, B: BitArray) -> BitArray:
 
 
 def nl_fscx_revolve_v2(A: BitArray, B: BitArray, steps: int) -> BitArray:
-    """Iterate nl_fscx_v2 *steps* times (B held constant)."""
+    """Iterate nl_fscx_v2 *steps* times (B held constant).
+
+    delta(B) is precomputed once before the loop (mirrors nl_fscx_revolve_v2_inv);
+    the inner step body becomes one fscx + one integer add. Saves one bigint
+    multiply and one rotation per iteration vs. calling nl_fscx_v2 in the loop.
+    """
+    n     = A._size
+    mask  = A._mask
+    delta = BitArray(n, (B.uint * ((B.uint + 1) >> 1)) & mask).rotated(n // 4)
     result = A.copy()
     for _ in range(steps):
-        result = nl_fscx_v2(result, B)
+        result = BitArray(n, (fscx(result, B).uint + delta.uint) & mask)
     return result
 
 
@@ -600,6 +614,27 @@ def _rnl_agree(s, C_other, q, p, pp, n, key_bits, hint=None):
 # Security reduces to SD(N,t) [NP-complete] + NL-FSCX v1 PRF.  See §11.8.4.
 # ---------------------------------------------------------------------------
 
+# Stern-F soundness threshold: ⌈λ / log2(3/2)⌉ for λ=128-bit security.
+_STERN_F_PRODUCTION_ROUNDS = 219
+
+
+def _csprng_weight_t(n: int, t: int) -> int:
+    """Sample a uniform weight-t bit vector on n positions using os.urandom.
+
+    Replaces random.sample() (Mersenne Twister — predictable from observed
+    outputs, unsuitable for sampling secret error vectors). Used for HPKS-Stern-F
+    private keys, per-round Fiat-Shamir blinding, and HPKE-Stern-F encapsulated
+    errors. 4-byte rejection sampling eliminates modular bias for any n ≤ 2^32.
+    """
+    chosen = set()
+    threshold = (1 << 32) - (1 << 32) % n
+    while len(chosen) < t:
+        v = int.from_bytes(os.urandom(4), 'big')
+        if v < threshold:
+            chosen.add(v % n)
+    return sum(1 << p for p in chosen)
+
+
 def _stern_hash(n: int, *items: 'BitArray') -> 'BitArray':
     """Chain-hash items to n bits: h ← NL-FSCX_v1^{n/4}(h⊕v, ROL(v,n/8)) for each v."""
     mask = (1 << n) - 1
@@ -617,13 +652,31 @@ def _stern_matrix_row(seed_int: int, row: int, n: int) -> 'BitArray':
     return nl_fscx_revolve_v1(A0, seed, n // 4)
 
 
-def _stern_syndrome(seed_int: int, e_int: int, n: int, n_rows: int) -> int:
-    """Compute n_rows-bit syndrome s = H·e^T mod 2."""
+def _stern_build_H(seed_int: int, n: int, n_rows: int) -> list:
+    """Build all n_rows of the public parity matrix once, returned as int row words.
+
+    Hot paths (sign/verify/keygen/encap) call _stern_syndrome many times against
+    the same seed; building H once and reusing it eliminates the rounds × n_rows
+    per-call PRF evaluations the original implementation incurred.
+    """
+    return [_stern_matrix_row(seed_int, i, n).uint for i in range(n_rows)]
+
+
+def _stern_syndrome_H(H_rows: list, e_int: int) -> int:
+    """Compute syndrome H·e^T mod 2 from a precomputed matrix (list of row ints)."""
     s = 0
-    for i in range(n_rows):
-        row = _stern_matrix_row(seed_int, i, n)
-        s  |= (bin(row.uint & e_int).count('1') & 1) << i
+    for i, row in enumerate(H_rows):
+        s |= (bin(row & e_int).count('1') & 1) << i
     return s
+
+
+def _stern_syndrome(seed_int: int, e_int: int, n: int, n_rows: int) -> int:
+    """Compute n_rows-bit syndrome s = H·e^T mod 2.
+
+    Convenience wrapper that builds H on each call. Hot paths should instead call
+    _stern_build_H once and reuse the result via _stern_syndrome_H.
+    """
+    return _stern_syndrome_H(_stern_build_H(seed_int, n, n_rows), e_int)
 
 
 def _stern_gen_perm(pi_seed: 'BitArray', N: int) -> list:
@@ -659,8 +712,9 @@ def stern_f_keygen(n: int = None):
     n_rows = n // 2
     t      = max(2, n // 16)
     seed   = BitArray.random(n)
-    e_int  = sum(1 << p for p in random.sample(range(n), t))
-    return seed, e_int, _stern_syndrome(seed.uint, e_int, n, n_rows)
+    e_int  = _csprng_weight_t(n, t)
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
+    return seed, e_int, _stern_syndrome_H(H_rows, e_int)
 
 
 def hpks_stern_f_sign(msg: 'BitArray', e_int: int, seed: 'BitArray',
@@ -684,14 +738,25 @@ def hpks_stern_f_sign(msg: 'BitArray', e_int: int, seed: 'BitArray',
     n_rows = n // 2
     t      = max(2, n // 16)
 
+    if rounds < _STERN_F_PRODUCTION_ROUNDS:
+        bits = rounds * math.log2(1.5)
+        warnings.warn(
+            f"HPKS-Stern-F: rounds={rounds} gives ~{bits:.1f}-bit soundness; "
+            f"production deployments require rounds ≥ {_STERN_F_PRODUCTION_ROUNDS} "
+            f"for 128-bit soundness.",
+            RuntimeWarning, stacklevel=2,
+        )
+
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
+
     commits    = []
     round_data = []
     for _ in range(rounds):
-        r_int   = sum(1 << p for p in random.sample(range(n), t))  # weight-t blinding
+        r_int   = _csprng_weight_t(n, t)                            # weight-t blinding
         y_int   = (e_int ^ r_int) & ((1 << n) - 1)                # y = e ⊕ r
         pi_seed = BitArray.random(n)
         perm    = _stern_gen_perm(pi_seed, n)
-        Hr  = _stern_syndrome(seed.uint, r_int, n, n_rows)
+        Hr  = _stern_syndrome_H(H_rows, r_int)
         sr  = _stern_apply_perm(perm, r_int, n)
         sy  = _stern_apply_perm(perm, y_int, n)
         commits.append((_stern_hash(n, pi_seed, BitArray(n, Hr)),
@@ -736,6 +801,9 @@ def hpks_stern_f_verify(msg: 'BitArray', sig, seed: 'BitArray',
         if ch_st.uint % 3 != b:
             return False
 
+    # Build H once: only needed for b ∈ {1, 2} branches but the seed is fixed.
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
+
     for i, b in enumerate(challenges):
         c0, c1, c2 = commits[i]
         resp = responses[i]
@@ -748,14 +816,14 @@ def hpks_stern_f_verify(msg: 'BitArray', sig, seed: 'BitArray',
             pi_seed, r_int = resp
             if bin(r_int).count('1') != t:                     return False
             perm = _stern_gen_perm(pi_seed, n)
-            Hr   = _stern_syndrome(seed.uint, r_int, n, n_rows)
+            Hr   = _stern_syndrome_H(H_rows, r_int)
             if _stern_hash(n, pi_seed, BitArray(n, Hr)) != c0: return False
             sr   = _stern_apply_perm(perm, r_int, n)
             if _stern_hash(n, BitArray(n, sr)) != c1:          return False
         else:                                             # reveal (σ_seed, y)
             pi_seed, y_int = resp
             perm = _stern_gen_perm(pi_seed, n)
-            Hy   = _stern_syndrome(seed.uint, y_int, n, n_rows)
+            Hy   = _stern_syndrome_H(H_rows, y_int)
             if _stern_hash(n, pi_seed, BitArray(n, Hy ^ syndrome)) != c0: return False
             sy   = _stern_apply_perm(perm, y_int, n)
             if _stern_hash(n, BitArray(n, sy)) != c2:          return False
@@ -772,8 +840,9 @@ def hpke_stern_f_encap(seed: 'BitArray', n: int = None):
     if n is None: n = KEYBITS
     n_rows = n // 2
     t      = max(2, n // 16)
-    e_p    = sum(1 << p for p in random.sample(range(n), t))
-    ct     = _stern_syndrome(seed.uint, e_p, n, n_rows)
+    e_p    = _csprng_weight_t(n, t)
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
+    ct     = _stern_syndrome_H(H_rows, e_p)
     K      = _stern_hash(n, seed, BitArray(n, e_p & ((1 << n) - 1)))
     return K, ct
 
@@ -787,7 +856,8 @@ def hpke_stern_f_decap(ciphertext: int, e_int: int, seed: 'BitArray',
       Use when the caller holds the plaintext error (test/demo) or a QC-MDPC
       decoder has already recovered it.
     - Brute-force (e_int == 0): enumerate all weight-t candidates.
-      Practical only for N ≤ 64, t ≤ 4.  Production requires QC-MDPC.
+      Refuses to enter the brute-force loop above 2^32 candidates; production
+      deployments must supply a QC-MDPC decoder instead.
     Returns session key K or None if decode fails.
     """
     if n is None: n = KEYBITS
@@ -795,9 +865,16 @@ def hpke_stern_f_decap(ciphertext: int, e_int: int, seed: 'BitArray',
     t      = max(2, n // 16)
     if e_int:
         return _stern_hash(n, seed, BitArray(n, e_int & ((1 << n) - 1)))
+    if math.comb(n, t) > (1 << 32):
+        raise ValueError(
+            f"hpke_stern_f_decap: brute-force search infeasible at n={n}, t={t} "
+            f"(C(n,t)={math.comb(n, t):.2e} > 2^32). Provide e_int from a "
+            f"QC-MDPC decoder or use hpke_stern_f_decap_known."
+        )
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
     for pos in itertools.combinations(range(n), t):
         e_p = sum(1 << p for p in pos)
-        if _stern_syndrome(seed.uint, e_p, n, n_rows) == ciphertext:
+        if _stern_syndrome_H(H_rows, e_p) == ciphertext:
             return _stern_hash(n, seed, BitArray(n, e_p & ((1 << n) - 1)))
     return None
 
@@ -807,8 +884,9 @@ def hpke_stern_f_encap_with_e(seed: 'BitArray', n: int = None):
     if n is None: n = KEYBITS
     n_rows = n // 2
     t      = max(2, n // 16)
-    e_p    = sum(1 << p for p in random.sample(range(n), t))
-    ct     = _stern_syndrome(seed.uint, e_p, n, n_rows)
+    e_p    = _csprng_weight_t(n, t)
+    H_rows = _stern_build_H(seed.uint, n, n_rows)
+    ct     = _stern_syndrome_H(H_rows, e_p)
     K      = _stern_hash(n, seed, BitArray(n, e_p & ((1 << n) - 1)))
     return K, ct, e_p
 

--- a/TODO.md
+++ b/TODO.md
@@ -2130,6 +2130,304 @@ Status: **TODO** — not yet started.
 
 ---
 
+## v1.5.28 PQC Security & Performance Review — Findings (2026-05-08)
+
+Findings from a focused review of `SecurityProofs.md` §11 (PQC sections) and the
+Python proof scripts (`hkex_nl_verification.py`, `hkex_rnl_failure_rate.py`,
+`nl_fscx_prf_analysis.py`).  Each item has been independently audited against the
+deployed code paths.  Items #29–#33 were patched in v1.5.28; #34–#41 remain open.
+
+---
+
+### 29. HPKS-Stern-F secret sampling used Mersenne Twister (Security, Critical)
+**File:** `Herradura cryptographic suite.py` (Python only — C uses `/dev/urandom`,
+Go uses `crypto/rand`)
+
+`stern_f_keygen`, `hpks_stern_f_sign`, `hpke_stern_f_encap`, and
+`hpke_stern_f_encap_with_e` all sampled secret weight-`t` error vectors with
+`random.sample(range(n), t)`.  Python's `random` module is Mersenne Twister
+(MT19937) — not a CSPRNG; its 19937-bit state is recoverable from ~624 32-bit
+outputs.  The leaked values include the long-term private key `e_int`, the
+per-round Fiat-Shamir blinding `r_int` (and therefore `y = e ⊕ r`, leaking `e`),
+and the Niederreiter encapsulation error `e'`.
+
+Fix: introduced `_csprng_weight_t(n, t)` using `os.urandom` with 4-byte rejection
+sampling; replaced all four `random.sample` call sites.
+
+Status: **DONE (v1.5.28)** — Python only.  C and Go versions independently verified
+to be CSPRNG-clean (`/dev/urandom` and `crypto/rand` respectively).
+
+---
+
+### 30. `SDFR=32` default gives ~19-bit signature soundness (Security, Critical)
+**File:** `Herradura cryptographic suite.py:155`
+
+`SDFR = 32` Fiat-Shamir rounds yields `(2/3)^32 ≈ 2⁻¹⁸·⁷` soundness — a forger
+succeeds with probability one in ~430 000.  Production needs `rounds ≥ 219`
+(`⌈λ / log₂(3/2)⌉` for λ=128).  The doc-string warned but offered no runtime
+signal; tests, demos, and downstream callers using the default would silently
+ship a forgeable scheme.
+
+Fix: relabelled `SDFR` as DEMO ONLY, defined `_STERN_F_PRODUCTION_ROUNDS = 219`,
+and added a `RuntimeWarning` from `hpks_stern_f_sign` whenever `rounds < 219`,
+quoting the actual soundness in bits (`rounds × log₂(1.5)`).
+
+Status: **DONE (v1.5.28)**.
+
+---
+
+### 31. Stern parity matrix `H` rebuilt on every syndrome call (Performance, High)
+**File:** `Herradura cryptographic suite.py` (`_stern_syndrome`, callers)
+
+`_stern_syndrome` reconstructs every row of `H` via the NL-FSCX v1 PRF for each
+call.  Inside `hpks_stern_f_sign` and `hpks_stern_f_verify` the same `seed`
+generates the same `H` `(rounds × n_rows)` times: at `n=256, n_rows=128, rounds=219`
+that is 28 032 row-rebuilds, each 64 NL-FSCX steps — 1.79M wasted PRF evaluations
+per signature.
+
+Fix: added `_stern_build_H(seed_int, n, n_rows)` and `_stern_syndrome_H(H_rows, e_int)`.
+`stern_f_keygen`, `hpks_stern_f_sign`, `hpks_stern_f_verify`, `hpke_stern_f_encap`,
+`hpke_stern_f_encap_with_e`, and `hpke_stern_f_decap` build `H` once per call and
+reuse it.  The legacy `_stern_syndrome` is preserved as a thin wrapper for any
+external callers.
+
+Status: **DONE (v1.5.28)** — algorithmic save: `(rounds + verify_calls) × n_rows × (n/4)`
+NL-FSCX evals per sign/verify pair.  No wire-format change.
+
+---
+
+### 32. `delta(B)` recomputed inside `nl_fscx_revolve_v2` inner loop (Performance, Medium)
+**File:** `Herradura cryptographic suite.py:364`
+
+`nl_fscx_revolve_v2` called `nl_fscx_v2` in its loop, recomputing
+`delta(B) = ROL(B·⌊(B+1)/2⌋ mod 2ⁿ, n/4)` every step.  Since `B` is held constant
+across the revolve, `delta(B)` is a per-call constant.
+
+Fix: precompute `delta(B)` once before the loop (mirrors the existing
+`nl_fscx_revolve_v2_inv` optimization from v1.5.9); inner step is now one `fscx`
+plus one integer add.  Saves one bigint multiply and one rotation per step.
+
+Status: **DONE (v1.5.28)**.
+
+---
+
+### 33. `hpke_stern_f_decap` brute-force search has no upper bound (Robustness, Low)
+**File:** `Herradura cryptographic suite.py:826`
+
+When called without a known `e_int`, `hpke_stern_f_decap` enumerated
+`itertools.combinations(range(n), t)` — at `n=256, t=16` that is `C(256,16) ≈ 6.4×10²²`
+iterations, effectively non-terminating.
+
+Fix: refuse the brute-force path with a `ValueError` whenever `C(n,t) > 2³²`,
+directing the caller to supply `e_int` from a QC-MDPC decoder or to use
+`hpke_stern_f_decap_known`.
+
+Status: **DONE (v1.5.28)**.
+
+---
+
+### 34. HFSCX-256 lacks formal analysis in `SecurityProofs.md` (Documentation/Security, Medium)
+**Files:** `Herradura cryptographic suite.py:393` (`hfscx_256`), `SecurityProofs.md` §11
+
+The `hfscx_256` Merkle-Damgård hash on NL-FSCX v1 is used implicitly throughout
+the suite (Stern-F commitments via `_stern_hash`, the `dgst` subcommand, signature
+pre-hashing) but `SecurityProofs.md` §11 contains no analysis of it.
+
+Specific gaps:
+- No collision-resistance argument.
+- No second-preimage / preimage argument.
+- The `len_raw ^ init_int` MD-strengthening prevents fixed-point collapse on empty
+  input but introduces a length-block dependence on the initial state; the
+  cryptographic effect of this twist is unanalysed.
+- The MD compression is `state ← nl_fscx_revolve_v1(state, block, n/4)` — the
+  Davies-Meyer feed-forward `state ← state ⊕ E(state, block)` is **not** applied.
+  NL-FSCX v1 is non-bijective in `A` (§11.5 Q3), so without the D-M XOR,
+  Joux-style free-start collisions are not ruled out.
+
+Add a `§11.9` covering: (1) collision-resistance heuristic, (2) recommended MAC
+mode (raw keyed-IV vs. HMAC-HFSCX-256), (3) domain separation strategy across
+suite call sites, (4) consideration of switching to Davies-Meyer compression for
+theoretical hardness against free-start collisions.
+
+Status: **TODO**.
+
+---
+
+### 35. NL-FSCX v1 PRF — exhaustive Walsh spectrum at small `n` (Research/Cryptanalysis, Medium)
+**File:** `SecurityProofsCode/nl_fscx_prf_analysis.py` §5
+
+§5 of the PRF analysis script samples 2 000 random `(a, b)` mask pairs out of
+`2^{2n} = 2^64` (at `n=32`) and reports the maximum observed |bias|.  This is a
+Monte-Carlo estimate, not a bound — a low-frequency bias whose mask falls outside
+the 2 000-element sample is invisible.
+
+Add an exhaustive Walsh transform at small `n` (e.g. `n=12` or `n=16`):
+- Compute `|Bias(a, b)|` for **all** mask pairs.
+- Report max bias and compare to the random-function bound `O(√n / 2^{n/2})`.
+- Extrapolate (Bernstein bound) to `n=32, 256`.
+
+A confirmed bound is required for any rigorous PRF claim under §11.8.4 Theorem 17.
+
+Status: **TODO**.
+
+---
+
+### 36. `_stern_hash` not modeled as QRO in Theorem 17 reduction (Documentation/Security, Medium)
+**Files:** `Herradura cryptographic suite.py:603` (`_stern_hash`), `SecurityProofs.md` §11.8.4
+
+Theorem 17's EUF-CMA bound `Pr[forge] ≤ q_H / T_SD + ε_PRF` invokes Unruh's QROM
+Fiat-Shamir transform, which requires the hash to behave as a quantum random
+oracle.  The implementation uses `_stern_hash`, a chain of `nl_fscx_revolve_v1`
+evaluations:
+
+```
+h ← NL_FSCX_v1^{n/4}(h ⊕ v_i, ROL(v_i, n/8))   for each item v_i
+```
+
+This chain does **not** automatically inherit QRO behaviour from a PRF assumption
+on NL-FSCX v1.  Two paths:
+
+1. **Replace** `_stern_hash` with HMAC-HFSCX-256 plus per-slot domain-separation
+   constants (`c0`, `c1`, `c2` get distinct DS bytes); reduces security to
+   HFSCX-256 collision resistance — depends on #34 first.
+2. **Prove** the chain is QRO under the NL-FSCX v1 PRF/OWF assumption using the
+   indifferentiability framework (Maurer-Renner-Holenstein 2004 / Coron et al. 2005).
+
+Until this gap is closed, Theorem 17's bound is contingent on an unstated
+assumption.
+
+Status: **TODO**.
+
+---
+
+### 37. `_rnl_lift` rounds toward zero — switch to centered rounding (Performance/Correctness, Medium)
+**Files:** `Herradura cryptographic suite.py:510-512`, C / Go / ARM / NASM / Arduino
+equivalents, `SecurityProofsCode/hkex_rnl_failure_rate.py:95-97`
+
+`_rnl_round` uses centered rounding `(c·to_p + from_q//2) // from_q`, but
+`_rnl_lift` rounds toward zero: `c·to_q // from_p`.  The asymmetry adds a
+systematic bias of up to `q/(2p)` to every coefficient, eating into the noise
+budget.
+
+Fix:
+```python
+def _rnl_lift(poly, from_p, to_q):
+    return [(c * to_q + from_p // 2) // from_p % to_q for c in poly]
+```
+
+**Cross-language coordination required.**  The lift output enters `K_poly` and
+the reconciliation hint, so Python's lift must match C, Go, ARM Thumb-2, NASM i386,
+and Arduino.  Update all six language implementations in lockstep, then re-run
+`hkex_rnl_failure_rate.py` to refresh the failure-rate numbers in
+`SecurityProofs.md` §11.5 Q2 / §11.6.
+
+Expected effect: ~2× reduction in worst-case pre-reconciliation failure rate
+(currently 2.04 % at `n=32`, 37.24 % at `n=256`).  Post-reconciliation rate stays
+at 0 % — this is a margin improvement, not a correctness fix.
+
+Status: **TODO**.
+
+---
+
+### 38. KDF seed degenerates on rotation-periodic K (Security, Low)
+**File:** `Herradura cryptographic suite.py` HKEX-RNL KDF and HSKE-NL-A1 seed
+derivation (and the equivalent paths in C / Go / ARM / NASM / Arduino).
+
+The v1.5.10 / v1.5.13 fix sets `seed = ROL(K, n/8)` to break the step-1
+degeneracy when `A=B=K` (which makes `fscx(K,K)=0`).  The patch degenerates back
+to the original problem when `K` has a rotational period dividing `n/8` — e.g.
+any `K` of the form `pattern || pattern || …` with `pattern` of width `n/8`.
+At `n=32` this is roughly `2⁴ / 2³² ≈ 2⁻²⁸` of the keyspace; at `n=256` negligible.
+
+Defence in depth: XOR a non-rotational nothing-up-my-sleeve constant after the
+rotation:
+
+```python
+DOMAIN_CONST = 0x6A09E667...   # n-bit constant, low rotational symmetry
+seed = ROL(K, n/8) ^ DOMAIN_CONST
+```
+
+**Cross-language coordination required.**  Changes the derived `sk`; breaks
+Python ↔ C/Go/asm interop.  Schedule with the next major suite version bump.
+
+Practical risk: low — the attacker cannot choose `K` (it is the reconciled
+session secret), so the bad-`K` rate is the random-`K` rate, not adversarial.
+
+Status: **TODO**.
+
+---
+
+### 39. 2-bit Peikert reconciliation for higher key density (Performance, Low)
+**Files:** `Herradura cryptographic suite.py` `_rnl_hint`, `_rnl_reconcile_bits`,
+plus C / Go / asm / Arduino equivalents.
+
+§11.5 Q2 measures `‖e_A − e_B‖_∞ ≤ 379 ≪ q/8 = 8192`.  With this slack a 2-bit
+reconciliation (4 buckets, NewHope-style cross-rounding extension) extracts ~2
+bits per coefficient instead of 1.  At `n=256` this halves the polynomial size
+needed for a fixed-length output key, doubling HKEX-RNL throughput at the same
+security level.
+
+**Cross-language wire-format change.**  Hint encoding and extraction formulas
+change; coordinate across all six language targets and refresh
+`SecurityProofs.md` §11.4.2 / §11.5 Q2 numbers.
+
+Status: **TODO**.
+
+---
+
+### 40. NumPy NTT optional acceleration (Performance, Low)
+**File:** `Herradura cryptographic suite.py:448` (`_ntt_inplace`)
+
+`_ntt_inplace` does `wn = wn * w % q` in a hot pure-Python inner loop.  At
+`q = 65537` all NTT values fit in `uint32`.  A NumPy lift would give roughly 10×
+speedup on `_rnl_poly_mul` without changing semantics or wire format:
+
+- Precompute bit-reversal permutation and twiddle table once (already partial in
+  v1.5.17 — the table cache is the right hook).
+- Vectorize the butterfly with `np.uint32` arithmetic + Mersenne-style modular
+  reduction.
+- Gate behind `try: import numpy` so plain-Python deployments keep working.
+
+Python-side only; no cross-language coordination needed.
+
+Status: **TODO**.
+
+---
+
+### 41. Constant-time audit for `_stern_apply_perm` and friends (Security, Medium)
+**Files:** `Herradura cryptographic suite.py:686-692` (`_stern_apply_perm`),
+`:620-626` (`_stern_syndrome`), `:530-551` (`_rnl_cbd_poly`); plus the C, Go,
+ARM Thumb-2, NASM i386, and Arduino Stern-F implementations.
+
+The Python implementation has data-dependent branching on secret bit-vectors:
+
+```python
+for i in range(N):
+    if (v_int >> i) & 1:           # branches on each secret bit of r/y/e
+        result |= 1 << perm[i]
+```
+
+Stern's protocol relies on hiding which positions are set in `e`; branch timing
+leaks them.  CPython further leaks via `bin(x).count('1')` (variable-time over
+int size) and `% q` on bigints.
+
+Action items:
+1. **Document** that the Python suite is a reference implementation and is **not**
+   constant-time; production deployments must use the C / asm targets.
+2. **Audit** the C, Go, ARM Thumb-2, NASM i386, and Arduino Stern-F implementations
+   for the same data-dependent branching.  Where present, replace with branchless
+   bit manipulation:
+   ```c
+   result |= ((-((v >> i) & 1)) & (1ULL << perm[i]));
+   ```
+3. **Add a constant-time test** to the Python proof scripts that measures timing
+   variance vs. secret Hamming weight, failing if Pearson correlation exceeds a
+   threshold.
+
+Status: **TODO**.
+
+---
+
 ## Updated priority order
 
 1. #28 — Go CLI + `herradura` Go package (**active**)
@@ -2149,3 +2447,16 @@ Status: **TODO** — not yet started.
 15. #18 — Parameterized integer arithmetic layer (**DONE v1.5.20**)
 16. #15 — Fermat prime fast modulo (**DONE v1.5.20**)
 17. #14 — NTT twiddle precomputation (**DONE v1.5.17**)
+18. #29 — HPKS-Stern-F CSPRNG fix (**DONE v1.5.28**)
+19. #30 — `SDFR=32` demo runtime warning (**DONE v1.5.28**)
+20. #31 — Stern parity matrix caching (**DONE v1.5.28**)
+21. #32 — `delta(B)` precompute in `nl_fscx_revolve_v2` (**DONE v1.5.28**)
+22. #33 — `hpke_stern_f_decap` brute-force guard (**DONE v1.5.28**)
+23. #37 — `_rnl_lift` centered rounding (cross-language wire change) (**TODO**)
+24. #34 — HFSCX-256 formal analysis in §11 (**TODO**)
+25. #36 — `_stern_hash` QRO modeling for Theorem 17 (**TODO**)
+26. #41 — Constant-time audit / documentation (**TODO**)
+27. #35 — NL-FSCX v1 PRF Walsh spectrum at small `n` (**TODO**)
+28. #39 — 2-bit Peikert reconciliation (cross-language wire change) (**TODO**)
+29. #38 — KDF rotation-periodic-K patch (cross-language wire change) (**TODO**)
+30. #40 — NumPy NTT optional acceleration (**TODO**)


### PR DESCRIPTION
## Summary

Security & performance review of `SecurityProofs.md` §11 (PQC sections) and the Python proof scripts. Five fixes shipped, eight follow-ups filed.

### Closed (Python suite — `Herradura cryptographic suite.py`)

- **#29 (Critical security):** HPKS-Stern-F secret error vectors (private key, per-round Fiat-Shamir blinding, Niederreiter encapsulation error) were drawn with `random.sample` — Mersenne Twister, predictable from observed outputs. Replaced 4 call sites with `_csprng_weight_t()` (`os.urandom` + 4-byte rejection sampling). C and Go versions independently verified to use `/dev/urandom` and `crypto/rand` respectively, so the bug was Python-only.
- **#30 (Critical security):** `SDFR=32` default gives `(2/3)^32 ≈ 2⁻¹⁸·⁷` signature soundness. Added a `RuntimeWarning` from `hpks_stern_f_sign` whenever `rounds < 219` (the `⌈128 / log₂(1.5)⌉` production threshold). The constant is relabelled DEMO ONLY.
- **#31 (High perf):** `_stern_syndrome` rebuilt the parity matrix `H` on every call. New `_stern_build_H` / `_stern_syndrome_H` helpers let each Stern-F sign/verify/keygen/encap build `H` once. Saves `(rounds + 1) × n_rows × (n/4)` NL-FSCX evaluations per signing — at production parameters (`n=256, n_rows=128, rounds=219`) that is 1.79M wasted PRF evals per signature, eliminated.
- **#32 (Medium perf):** `nl_fscx_revolve_v2` now precomputes `delta(B)` before the inner loop (mirrors the v1.5.9 `_inv` optimization). Saves one bigint multiply + rotation per step.
- **#33 (Robustness):** `hpke_stern_f_decap` brute-force search refuses `C(n,t) > 2³²` with a `ValueError` instead of silently iterating ~6×10²² candidates at `n=256, t=16`.

No wire-format changes; no cross-language coordination required for any of the closed items.

### Filed (open follow-ups in `TODO.md`)

- **#34:** HFSCX-256 missing from `SecurityProofs.md §11` — collision/preimage analysis & Davies-Meyer consideration
- **#35:** NL-FSCX v1 PRF — exhaustive Walsh spectrum bound at small `n`
- **#36:** `_stern_hash` not modeled as QRO in Theorem 17 reduction
- **#37:** `_rnl_lift` centered rounding (cross-language wire change)
- **#38:** KDF rotation-periodic-`K` degeneracy patch (cross-language wire change)
- **#39:** 2-bit Peikert reconciliation (cross-language wire change)
- **#40:** NumPy NTT optional acceleration
- **#41:** constant-time audit for `_stern_apply_perm` and friends

## Test plan

- [x] `python3 CryptosuiteTests/Herradura_tests.py -r 10 -t 0.5` — all 19 security tests PASS, benchmarks complete normally
- [x] `RuntimeWarning` fires at `rounds=8` ("~4.7-bit soundness") and is silent at `rounds=219`
- [x] `HerraduraCli/primitives.py` imports cleanly post-refactor
- [x] `nl_fscx_revolve_v2(A, B, 16)` matches step-by-step `nl_fscx_v2` iteration; `nl_fscx_revolve_v2_inv` round-trips
- [ ] Re-run on full suite (`-r 500 -t 2.0`) before merging
- [ ] Confirm CHANGELOG.md updates land in a follow-up if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)