### PR TITLE
v1.7.1 Arduino sync — tests HKEX-RNL parity with v1.7.0 Peikert; fix run_arduino.sh output

### DIFF
--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -35,7 +35,7 @@
 #define RNL_N   32
 #define RNL_Q   65537L
 #define RNL_P   4096L
-#define RNL_PP  2L
+#define RNL_PP  4L
 #define RNL_ETA 1  /* CBD eta: secret coeffs drawn from CBD(1) in {-1,0,1} mod q */
 
 typedef unsigned long uint32;
@@ -216,7 +216,7 @@ static void rnl_round(long *out, const long *in, long from_q, long to_p) {
 
 static void rnl_lift(long *out, const long *in, long from_p, long to_q) {
     for (int i = 0; i < RNL_N; i++)
-        out[i] = (long)((long long)in[i] * to_q / from_p % to_q);
+        out[i] = (long)(((long long)in[i] * to_q + from_p / 2) / from_p % to_q);
 }
 
 static void rnl_m_poly(long *p) {
@@ -235,7 +235,11 @@ static void rnl_cbd_poly(long *p) {
 }
 
 static void rnl_rand_poly(long *p) {
-    for (int i = 0; i < RNL_N; i++) p[i] = (long)(prng_next() % (uint32)RNL_Q);
+    static const uint32 threshold = 0xFF00FFu; /* (1<<24) - (1<<24)%RNL_Q */
+    for (int i = 0; i < RNL_N; ) {
+        uint32 v = prng_next() & 0xFFFFFFu;
+        if (v < threshold) p[i++] = (long)(v % (uint32)RNL_Q);
+    }
 }
 
 static uint32 rnl_bits_to_key(const long *bits_poly) {
@@ -253,12 +257,43 @@ static void rnl_keygen(long *s, long *C, const long *m_blind) {
     rnl_round(C, ms, RNL_Q, RNL_P);
 }
 
-static uint32 rnl_agree(const long *s, const long *C_other) {
-    static long c_lifted[RNL_N], k_poly[RNL_N], k_bits[RNL_N];
+/* 2-bit Peikert hint for first RNL_N/2 coefficients, packed 2 bits/coeff. */
+static uint32 rnl_hint(const long *K_poly) {
+    uint32 hint = 0;
+    for (int i = 0; i < RNL_N / 2; i++) {
+        unsigned long c = (unsigned long)K_poly[i];
+        unsigned long r = (unsigned long)((8UL * c + (unsigned long)(RNL_Q / 4))
+                                          / (unsigned long)RNL_Q) % 4UL;
+        hint |= (uint32)(r << (unsigned)(i * 2));
+    }
+    return hint;
+}
+
+/* 2-bit reconciliation: 2 bits per coeff from RNL_N/2 coefficients. */
+static uint32 rnl_reconcile(const long *K_poly, uint32 hint) {
+    const unsigned long qq = (unsigned long)(RNL_Q / 4);
+    uint32 key = 0;
+    for (int i = 0; i < RNL_N / 2; i++) {
+        unsigned long c = (unsigned long)K_poly[i];
+        unsigned long h = (hint >> (unsigned)(i * 2)) & 3UL;
+        unsigned long b = (4UL * c + (2UL * h + 1UL) * qq) / (unsigned long)RNL_Q
+                          % (unsigned long)RNL_PP;
+        key |= (uint32)(b << (unsigned)(i * 2));
+    }
+    return key;
+}
+
+/* agree: reconciler path (hint_out != NULL) or receiver path (hint_in != NULL). */
+static uint32 rnl_agree(const long *s, const long *C_other,
+                         const uint32 *hint_in, uint32 *hint_out) {
+    static long c_lifted[RNL_N], k_poly[RNL_N];
     rnl_lift(c_lifted, C_other, RNL_P, RNL_Q);
     rnl_poly_mul(k_poly, s, c_lifted);
-    rnl_round(k_bits, k_poly, RNL_Q, RNL_PP);
-    return rnl_bits_to_key(k_bits);
+    if (!hint_in) {
+        *hint_out = rnl_hint(k_poly);
+        return rnl_reconcile(k_poly, *hint_out);
+    }
+    return rnl_reconcile(k_poly, *hint_in);
 }
 
 /* ------------------------------------------------------------------ */
@@ -536,8 +571,9 @@ void test_hkex_rnl() {
         rnl_poly_add(m_blind, m_base, a_rand);
         rnl_keygen(s_A, C_A, m_blind);
         rnl_keygen(s_B, C_B, m_blind);
-        uint32 KA = rnl_agree(s_A, C_B);
-        uint32 KB = rnl_agree(s_B, C_A);
+        uint32 hint_A;
+        uint32 KA = rnl_agree(s_A, C_B, NULL, &hint_A);   /* reconciler */
+        uint32 KB = rnl_agree(s_B, C_A, &hint_A, NULL);   /* receiver */
         if (KA == KB) {
             ok_raw++;
             uint32 skA = nl_fscx_revolve_v1(_rol32(KA, 4), KA, I_VALUE);

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -515,7 +515,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura Cryptographic Suite v1.5.23 (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura Cryptographic Suite v1.6.1 (Arduino, 32-bit) ===");
     Serial.println();
 
     printHexLine("a_priv : ", A_PRIV);

--- a/TODO.md
+++ b/TODO.md
@@ -2704,4 +2704,38 @@ This fix is documented in CLAUDE.md Rule 5 (per-page math expression limit).
 | v1.5.37 | Fixed `\begin{cases}` Rule 8 violation in §11.9 | Cascade still present |
 | v1.5.38 | Reverted to single-line `$$expr$$` format; split document | Cascade resolved |
 
+---
+
+## Arduino AVR Emulation Verification (2026-05-20)
+
+**Goal:** Confirm both `.ino` files compile cleanly to ATmega2560 ELF binaries and produce
+correct output when run under `simavr`.
+
+### Batch 1 — Prerequisites
+- [x] `avr-gcc` / `avr-g++` present (`/usr/bin/avr-gcc`)
+- [x] Arduino core headers present (`/usr/share/arduino/hardware/arduino/avr/cores/arduino/`)
+- [x] ATmega2560 variant headers present (`…/variants/mega/`)
+- [x] `simavr` present (`/usr/bin/simavr`)
+
+### Batch 2 — Build (DONE 2026-05-20)
+- [x] `build_arduino.sh` compiles suite → `Herradura cryptographic suite_avr.elf` (43586 text + 2100 data + 2687 bss = 48373 bytes)
+- [x] `build_arduino.sh` compiles tests → `CryptosuiteTests/Herradura_tests_avr.elf` (46098 text + 1048 data + 2719 bss = 49865 bytes)
+- [x] No compiler errors or warnings in either target
+
+### Batch 3 — Run suite under simavr (DONE 2026-05-20 — all pass)
+- [x] Output captured; runs one full iteration and loops correctly
+- [x] All protocol sections printed: HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1, HSKE-NL-A2, HKEX-RNL, HPKS-NL, HPKE-NL, HPKS-Stern-F, HPKE-Stern-F
+- [x] All `+` pass markers present; no `-` failure markers; HKEX-RNL keys agreed on first try
+- [x] EVE bypass section: all 4 bypass attempts rejected (`- Eve …`)
+
+### Batch 4 — Run tests under simavr (DONE 2026-05-20 — all pass)
+- [x] All 12 tests print `[PASS]` on every loop iteration
+- [x] Test [7] HKEX-RNL: 10/10 raw agree, 10/10 sk agree (100%; uses simpler PP=2 rounding)
+
+### Batch 5 — Known issues to address after verification
+- [x] **Version string stale:** suite `loop()` prints `v1.5.23` but file header is `v1.6.1` — fixed banner to `v1.6.1`
+- [x] **Tests use old HKEX-RNL reconciliation:** upgraded `RNL_PP=2`→`4`, added `rnl_hint`/`rnl_reconcile`, updated `rnl_agree` to hint-based signature, fixed `rnl_lift` to centered rounding, updated `test_hkex_rnl` call site — all 12 tests still `[PASS]`
+- [x] **Tests `rnl_rand_poly` missing rejection sampling:** replaced bare `% RNL_Q` with 3-byte threshold guard (threshold=`0xFF00FFu`) matching suite
+
+
 **Status:** **DONE** (v1.5.38) — resolved by splitting the document; per-page expression limit documented in CLAUDE.md Rule 5.

--- a/run_arduino.sh
+++ b/run_arduino.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# HerraduraKEx v1.5.8 — Arduino (AVR) run script
+# HerraduraKEx v1.6.1 — Arduino (AVR) run script
 # Runs the ATmega2560 ELF binaries under simavr (AVR cycle-accurate emulator).
-# Output appears on the emulated UART0 (simavr maps it to stdout).
+# Output appears on the emulated UART0; simavr writes it to stderr with ANSI
+# color codes.  Both firmware UART output and simavr status lines go to stderr.
 #
 # Dependencies:
 #   simavr   — sudo apt-get install -y simavr
@@ -13,8 +14,8 @@
 #   ./run_arduino.sh suite             # run suite only
 #   ./run_arduino.sh tests             # run tests only
 #
-# Note: simavr exits automatically when the firmware calls exit() or loops
-#       forever after the last Serial.print.  If it hangs, Ctrl-C to stop.
+# TIMEOUT (default 90s): the firmware loops forever, so simavr never exits on
+# its own.  Set TIMEOUT=0 to disable (Ctrl-C to stop).
 #
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -23,6 +24,7 @@ SUITE_ELF="Herradura cryptographic suite_avr.elf"
 TESTS_ELF="CryptosuiteTests/Herradura_tests_avr.elf"
 MCU="atmega2560"
 FREQ="16000000"
+TIMEOUT="${TIMEOUT:-90}"
 
 # ── dependency check ──────────────────────────────────────────────────────────
 if ! command -v simavr &>/dev/null; then
@@ -38,8 +40,12 @@ run_elf() {
         echo "ERROR: ${ELF} not found — run ./build_arduino.sh first."
         exit 1
     fi
-    echo "=== Arduino (ATmega2560) — ${LABEL} ==="
-    simavr -m "${MCU}" -f "${FREQ}" "${ELF}" 2>/dev/null
+    echo "=== Arduino (ATmega2560) — ${LABEL} ===" >&2
+    if [ "${TIMEOUT}" -gt 0 ] 2>/dev/null; then
+        timeout "${TIMEOUT}" simavr -m "${MCU}" -f "${FREQ}" "${ELF}" || true
+    else
+        simavr -m "${MCU}" -f "${FREQ}" "${ELF}"
+    fi
 }
 
 MODE="${1:-all}"


### PR DESCRIPTION
## Summary

- **`Herradura_tests.ino`** — sync HKEX-RNL reconciliation to suite v1.7.0: `RNL_PP` 2→4, centered rounding in `rnl_lift`, 3-byte rejection sampling in `rnl_rand_poly`, new `rnl_hint`/`rnl_reconcile` functions, `rnl_agree` updated to hint-based signature, `test_hkex_rnl` call site updated
- **`Herradura cryptographic suite.ino`** — fix stale version banner (`v1.5.23` → `v1.6.1`)
- **`run_arduino.sh`** — remove `2>/dev/null` that was silencing all UART output; add 90 s default timeout (`$TIMEOUT` env override) since firmware loops forever; fix incorrect comment claiming simavr auto-exits

## Test plan

- [x] Both ELFs rebuild cleanly under `build_arduino.sh` (no errors or warnings)
- [x] Suite: all 11 protocol sections print `+` pass markers under simavr; all 4 EVE bypass attempts rejected
- [x] Tests: all 12 tests `[PASS]` under simavr; test [7] HKEX-RNL 10/10 raw + sk agreement
- [x] `run_arduino.sh tests` produces visible output (was previously silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)