### PR TITLE
v1.7.2 Peikert codegen cleanup — % 4 → & 3 in hint/reconcile; fix TIMEOUT check

### DIFF
--- a/CryptosuiteTests/Herradura_tests.ino
+++ b/CryptosuiteTests/Herradura_tests.ino
@@ -263,13 +263,12 @@ static uint32 rnl_hint(const long *K_poly) {
     for (int i = 0; i < RNL_N / 2; i++) {
         unsigned long c = (unsigned long)K_poly[i];
         unsigned long r = (unsigned long)((8UL * c + (unsigned long)(RNL_Q / 4))
-                                          / (unsigned long)RNL_Q) % 4UL;
+                                          / (unsigned long)RNL_Q) & 3UL;
         hint |= (uint32)(r << (unsigned)(i * 2));
     }
     return hint;
 }
 
-/* 2-bit reconciliation: 2 bits per coeff from RNL_N/2 coefficients. */
 static uint32 rnl_reconcile(const long *K_poly, uint32 hint) {
     const unsigned long qq = (unsigned long)(RNL_Q / 4);
     uint32 key = 0;
@@ -277,7 +276,7 @@ static uint32 rnl_reconcile(const long *K_poly, uint32 hint) {
         unsigned long c = (unsigned long)K_poly[i];
         unsigned long h = (hint >> (unsigned)(i * 2)) & 3UL;
         unsigned long b = (4UL * c + (2UL * h + 1UL) * qq) / (unsigned long)RNL_Q
-                          % (unsigned long)RNL_PP;
+                          & 3UL;
         key |= (uint32)(b << (unsigned)(i * 2));
     }
     return key;

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -297,13 +297,12 @@ static uint32 rnl_hint(const long *K_poly) {
     for (int i = 0; i < RNL_N / 2; i++) {
         unsigned long c = (unsigned long)K_poly[i];
         unsigned long r = (unsigned long)((8UL * c + (unsigned long)(RNL_Q / 4))
-                                          / (unsigned long)RNL_Q) % 4UL;
+                                          / (unsigned long)RNL_Q) & 3UL;
         hint |= (uint32)(r << (unsigned)(i * 2));
     }
     return hint;
 }
 
-/* 2-bit reconciliation: 2 bits per coeff from RNL_N/2 coefficients. */
 static uint32 rnl_reconcile(const long *K_poly, uint32 hint) {
     const unsigned long qq = (unsigned long)(RNL_Q / 4);
     uint32 key = 0;
@@ -311,7 +310,7 @@ static uint32 rnl_reconcile(const long *K_poly, uint32 hint) {
         unsigned long c = (unsigned long)K_poly[i];
         unsigned long h = (hint >> (unsigned)(i * 2)) & 3UL;
         unsigned long b = (4UL * c + (2UL * h + 1UL) * qq) / (unsigned long)RNL_Q
-                          % (unsigned long)RNL_PP;
+                          & 3UL;
         key |= (uint32)(b << (unsigned)(i * 2));
     }
     return key;

--- a/run_arduino.sh
+++ b/run_arduino.sh
@@ -41,7 +41,7 @@ run_elf() {
         exit 1
     fi
     echo "=== Arduino (ATmega2560) — ${LABEL} ===" >&2
-    if [ "${TIMEOUT}" -gt 0 ] 2>/dev/null; then
+    if (( TIMEOUT > 0 )); then
         timeout "${TIMEOUT}" simavr -m "${MCU}" -f "${FREQ}" "${ELF}" || true
     else
         simavr -m "${MCU}" -f "${FREQ}" "${ELF}"


### PR DESCRIPTION
## Summary

- **`rnl_hint`** (tests + suite): `% 4UL` → `& 3UL` — AVR has no hardware divider; power-of-two modulo is only folded to a bitmask by the compiler as a quality-of-implementation optimization, not a language guarantee
- **`rnl_reconcile`** (tests + suite): `% (unsigned long)RNL_PP` → `& 3UL` (same reason; `RNL_PP=4` is always a power of two); removed redundant comment that mirrored `rnl_hint`'s comment verbatim
- **`run_arduino.sh`**: `[ "${TIMEOUT}" -gt 0 ] 2>/dev/null` → `(( TIMEOUT > 0 ))` — removes silent error-swallowing on non-numeric `$TIMEOUT` values

## Test plan

- [x] Both ELFs rebuild cleanly under `build_arduino.sh`
- [x] All 12 tests `[PASS]` under simavr after the bitmask changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)