### PR TITLE
v1.7.4 Developer tutorial & library documentation (TODO #44)

### DIFF
--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1388,7 +1388,7 @@ def main():
 
 
 hkex_rnl_keygen = _rnl_keygen   # (m_blind, n, q, p, b) -> (s, C)
-hkex_rnl_agree  = _rnl_agree    # (s, C_other, q, p, pp, n, key_bits, hint=None) -> (K, hint)
+hkex_rnl_agree  = _rnl_agree    # (s, C_other, q, p, pp, n, key_bits, hint=None) -> (K, hint) or K
 
 if __name__ == '__main__':
     main()

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -127,6 +127,33 @@
 
     --- v1.3.2: performance and readability ---
     --- v1.3: BitArray (multi-byte parameter support) ---
+
+    Library usage
+    ─────────────
+    This file is importable as a Python module.  Because the filename contains
+    spaces, use importlib to load it:
+
+        import importlib.util, pathlib
+        _spec = importlib.util.spec_from_file_location(
+            "herradura",
+            pathlib.Path(__file__).parent / "Herradura cryptographic suite.py")
+        h = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(h)
+
+    Public API (no underscore prefix):
+        BitArray, fscx, fscx_revolve
+        gf_mul, gf_pow
+        nl_fscx_v1, nl_fscx_revolve_v1
+        nl_fscx_v2, nl_fscx_v2_inv, nl_fscx_revolve_v2, nl_fscx_revolve_v2_inv
+        hfscx_256
+        stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify
+        hpke_stern_f_encap, hpke_stern_f_decap
+        hkex_rnl_keygen, hkex_rnl_agree  (public aliases added in v1.7.4)
+
+    Key module constants: KEYBITS, I_VALUE, R_VALUE, GF_POLY, GF_GEN, ORD,
+        RNLQ, RNLP, RNLPP, RNLB, SDFNR, SDFT, SDFR.
+
+    See docs/TUTORIAL.md for complete per-protocol code examples.
 '''
 
 import itertools
@@ -1359,6 +1386,9 @@ def main():
     else:
         print("- Eve random guess does not match session key (SD protection)")
 
+
+hkex_rnl_keygen = _rnl_keygen   # (m_blind, n, q, p, b) -> (s, C)
+hkex_rnl_agree  = _rnl_agree    # (s, C_other, q, p, pp, n, key_bits, hint=None) -> (K, hint)
 
 if __name__ == '__main__':
     main()

--- a/TODO.md
+++ b/TODO.md
@@ -2879,3 +2879,57 @@ present in C, Go, or Python suite files ✓.  Confirmed outside production key-g
 paths ✓.
 
 Status: **DONE** — audit complete 2026-05-20; findings SA-01 through SA-09 logged above.
+
+---
+
+### 44. Tutorial and library documentation for C, Go, and Python targets (Documentation, Medium)
+**Files:** `herradura.h`, `Herradura cryptographic suite.py`, `docs/TUTORIAL.md` (new),
+`docs/examples/c/hello_herradura.c` (new), `docs/examples/go/hello_herradura.go` (new),
+`docs/examples/python/hello_herradura.py` (new)
+
+The suite has no documentation or examples aimed at developers who want to integrate
+it into their own projects.  All three language implementations are structured as
+standalone demo programs.  Concrete friction points:
+
+- **C** — `herradura.h` is a valid header-only library but has no usage guide,
+  no concise API summary, and no example project.  The calling sequence for each
+  protocol is only visible by reading the 568-line demo `main()`.
+- **Go** — the `herradura/` package exists (`package herradura`, module path
+  `herradurakex/herradura`) but is undocumented and has no import examples.
+- **Python** — the filename contains spaces (`"Herradura cryptographic suite.py"`),
+  preventing a plain `import` statement; all Ring-LWR functions are `_`-prefixed
+  (private), making HKEX-RNL inaccessible without reading the source.
+
+**Plan:**
+
+1. **`herradura.h` — Protocol Layer section:** eight thin `static inline` wrappers
+   that assemble primitives into the four named classical protocols:
+   `hkex_gf_pubkey`, `hkex_gf_agree`, `hske_encrypt`, `hske_decrypt`,
+   `hpks_sign`, `hpks_verify`, `hpke_encrypt`, `hpke_decrypt`.
+   PQC functions (`rnl_keygen`, `rnl_agree`, `hpks_stern_f_sign`, etc.) are
+   already protocol-level and need no additional wrappers.
+
+2. **`"Herradura cryptographic suite.py"` — Public aliases:** add
+   `hkex_rnl_keygen = _rnl_keygen` and `hkex_rnl_agree = _rnl_agree` before
+   `if __name__ == '__main__':`, and extend the module docstring with a
+   "Library usage" section documenting the `importlib` load pattern and the
+   public API surface.
+
+3. **`docs/TUTORIAL.md`:** comprehensive integration guide covering C, Go, and
+   Python — getting started, per-protocol code recipes for all protocol families,
+   parameter reference table (KEYBITS, I_VALUE, R_VALUE, RNLQ/P/PP, SDF_N/T/ROUNDS),
+   and security notes (classical vs NL/PQC vs code-based; constant-time status;
+   production caveats for Stern demo parameters and QC-MDPC decoder gap).
+
+4. **`docs/examples/`:** three minimal runnable programs — one per language — each
+   demonstrating HKEX-GF, HSKE, HKEX-RNL, and HPKS-Stern-F in ~80 LOC.
+
+**Standardization changes only where necessary:** the Go package and `herradura.h`
+are already well-structured; changes are additive only.  Python private `_rnl_*`
+aliases are exposed without renaming.  No wire-format changes, no version bumps
+to protocol output.
+
+Status: **DONE v1.7.4** — Protocol Layer wrappers added to `herradura.h`; public
+aliases `hkex_rnl_keygen` / `hkex_rnl_agree` and library docstring added to
+`"Herradura cryptographic suite.py"`; `docs/TUTORIAL.md`, `docs/examples/c/`,
+`docs/examples/go/`, `docs/examples/python/` created and verified.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,0 +1,484 @@
+# Herradura Cryptographic Suite — Integration Tutorial
+
+This guide shows how to use the Herradura suite as a library in your own C, Go, or Python project.
+
+The suite implements four protocol families:
+
+| Protocol | Classical | NL/PQC variant | Code-based PQC |
+|----------|-----------|----------------|----------------|
+| Key exchange | HKEX-GF | HKEX-RNL (Ring-LWR) | — |
+| Symmetric encryption | HSKE | HSKE-NL-A1, HSKE-NL-A2 | — |
+| Schnorr signature | HPKS | HPKS-NL | HPKS-Stern-F |
+| El Gamal encryption | HPKE | HPKE-NL | HPKE-Stern-F |
+
+**Security note:** The classical protocols (HKEX-GF, HSKE, HPKS, HPKE) are vulnerable to quantum
+attacks. Use the NL/PQC or code-based variants for new deployments. See [Security notes](#security-notes).
+
+---
+
+## Contents
+
+1. [C integration](#c-integration)
+2. [Go integration](#go-integration)
+3. [Python integration](#python-integration)
+4. [Protocol reference](#protocol-reference)
+5. [Parameter reference](#parameter-reference)
+6. [Security notes](#security-notes)
+
+---
+
+## C integration
+
+`herradura.h` is a **header-only library** — every function is `static inline`.
+Copy `herradura.h` into your project (or keep it in the repo and use `-I`) then:
+
+```c
+#include "herradura.h"
+```
+
+No additional source files, no link flags, no build system changes.
+
+### Build
+
+```bash
+gcc -O2 myapp.c -o myapp
+# or, pointing at the repo:
+gcc -O2 -I/path/to/HerraduraKEx myapp.c -o myapp
+```
+
+### HKEX-GF key exchange (classical)
+
+```c
+#include "herradura.h"
+#include <stdio.h>
+
+int main(void) {
+    FILE *urnd = fopen("/dev/urandom", "rb");
+
+    BitArray alice_priv, alice_pub;
+    BitArray bob_priv,   bob_pub;
+    BitArray alice_shared, bob_shared;
+
+    ba_rand(&alice_priv, urnd);
+    ba_rand(&bob_priv,   urnd);
+
+    hkex_gf_pubkey(&alice_priv, &alice_pub);   /* publish alice_pub */
+    hkex_gf_pubkey(&bob_priv,   &bob_pub);     /* publish bob_pub   */
+
+    hkex_gf_agree(&alice_priv, &bob_pub,   &alice_shared);
+    hkex_gf_agree(&bob_priv,   &alice_pub, &bob_shared);
+    /* alice_shared == bob_shared */
+
+    fclose(urnd);
+}
+```
+
+### HSKE symmetric encryption (classical)
+
+```c
+BitArray plaintext, key, ciphertext, recovered;
+
+ba_rand(&plaintext, urnd);
+/* key = alice_shared from HKEX-GF above */
+
+hske_encrypt(&plaintext,  &key, &ciphertext);
+hske_decrypt(&ciphertext, &key, &recovered);
+/* ba_equal(&plaintext, &recovered) == 1 */
+```
+
+### HPKS Schnorr signature (classical)
+
+```c
+BitArray msg, R, s;
+ba_rand(&msg, urnd);
+
+hpks_sign(&msg, &alice_priv, &R, &s, urnd);    /* sign   */
+int ok = hpks_verify(&msg, &alice_pub, &R, &s); /* verify */
+```
+
+### HPKE El Gamal encryption (classical)
+
+```c
+BitArray plaintext, R_ephem, ciphertext, recovered;
+ba_rand(&plaintext, urnd);
+
+hpke_encrypt(&plaintext,  &alice_pub,  &R_ephem, &ciphertext, urnd);
+hpke_decrypt(&ciphertext, &R_ephem, &alice_priv, &recovered);
+```
+
+### HKEX-RNL key exchange (Ring-LWR, PQC)
+
+```c
+#include "herradura.h"
+
+/* Both parties agree on a shared public polynomial m_blind. */
+rnl_poly_t m_poly, a_poly, m_blind;
+rnl_m_poly(m_poly);
+rnl_rand_poly(a_poly, urnd);
+for (int i = 0; i < RNL_N; i++)
+    m_blind[i] = (m_poly[i] + a_poly[i]) % RNL_Q;
+
+/* Each party generates a secret and public polynomial. */
+int32_t sA[RNL_N], CA[RNL_N];
+int32_t sB[RNL_N], CB[RNL_N];
+rnl_keygen(sA, CA, m_blind, urnd);
+rnl_keygen(sB, CB, m_blind, urnd);
+
+/* Key agreement with Peikert reconciliation. */
+uint8_t  hintA[RNL_N / 8];
+BitArray kA, kB;
+rnl_agree(&kA, sA, CB, hintA, NULL);  /* Alice sends hintA to Bob */
+rnl_agree(&kB, sB, CA, NULL, hintA);  /* Bob uses Alice's hint   */
+/* kA == kB (raw key bits) */
+
+/* KDF: ROL(K, n/8) breaks step-1 degeneracy; NL-FSCX-v1 finalizes. */
+BitArray seed, sk;
+ba_rol_k(&seed, &kA, KEYBITS / 8);
+nl_fscx_revolve_v1_ba(&sk, &seed, &kA, I_VALUE);
+```
+
+### HPKS-Stern-F signature (code-based PQC)
+
+```c
+#include "herradura.h"
+
+BitArray seed, e;
+uint8_t  syndr[SDF_SYNBYTES];
+
+stern_f_keygen(&seed, &e, syndr, urnd);  /* keygen: (seed, e) private; syndr public */
+
+SternSig sig;
+BitArray msg;
+ba_rand(&msg, urnd);
+hpks_stern_f_sign(&sig, &msg, &e, &seed, urnd);           /* sign   */
+int ok = hpks_stern_f_verify(&sig, &msg, &seed, syndr);   /* verify */
+```
+
+### Complete runnable example
+
+See [`docs/examples/c/hello_herradura.c`](examples/c/hello_herradura.c).
+
+---
+
+## Go integration
+
+The library lives in the `herradura/` subdirectory of the repo as `package herradura`
+(module path `herradurakex/herradura`).
+
+### Using the library from the same module
+
+The root `go.mod` already declares `module herradurakex`.  Any `.go` file in the
+repo can import the package with:
+
+```go
+import "herradurakex/herradura"
+```
+
+or use a dot-import (all names imported directly into the calling package):
+
+```go
+import . "herradurakex/herradura"
+```
+
+### Vendoring into your own module
+
+Copy the `herradura/` directory into your project and add or update your `go.mod`:
+
+```
+require yourmodule/herradura v0.0.0
+replace yourmodule/herradura => ./herradura
+```
+
+Then import as `yourmodule/herradura`.
+
+### HKEX-GF key exchange (classical)
+
+```go
+import (
+    "fmt"
+    "math/big"
+    . "herradurakex/herradura"
+)
+
+func main() {
+    const n = 256
+    poly := GfPoly[n]
+    g    := big.NewInt(GfGen)
+
+    alicePriv := NewRandBitArray(n)
+    bobPriv   := NewRandBitArray(n)
+
+    alicePub := NewBitArray(n, GfPow(g, &alicePriv.Val, poly, n))
+    bobPub   := NewBitArray(n, GfPow(g, &bobPriv.Val,   poly, n))
+
+    aliceShared := NewBitArray(n, GfPow(&bobPub.Val,   &alicePriv.Val, poly, n))
+    bobShared   := NewBitArray(n, GfPow(&alicePub.Val, &bobPriv.Val,   poly, n))
+    /* aliceShared.Equal(bobShared) */
+}
+```
+
+### HSKE symmetric encryption (classical)
+
+```go
+const iValue = n / 4
+const rValue = 3 * n / 4
+
+plaintext  := NewRandBitArray(n)
+ciphertext := FscxRevolve(plaintext,  aliceShared, iValue)
+recovered  := FscxRevolve(ciphertext, aliceShared, rValue)
+/* plaintext.Equal(recovered) */
+```
+
+### HKEX-RNL key exchange (Ring-LWR, PQC)
+
+```go
+mBase  := RnlMPoly(n)
+aRand  := RnlRandPoly(n, RnlQ)
+mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
+
+sA, CA := RnlKeygen(mBlind, n, RnlQ, RnlP)
+sB, CB := RnlKeygen(mBlind, n, RnlQ, RnlP)
+
+kA, hintA := RnlAgree(sA, CB, RnlQ, RnlP, RnlPP, n, n, nil)
+kB, _      := RnlAgree(sB, CA, RnlQ, RnlP, RnlPP, n, n, hintA)
+/* kA.Equal(kB) */
+
+// KDF
+skA := NlFscxRevolveV1(kA.RotateLeft(n/8), kA, n/4)
+```
+
+### HPKS-Stern-F signature (code-based PQC)
+
+```go
+seed, e, syn := SternFKeygen(n)
+msg := NewRandBitArray(n)
+sig := HpksSternFSign(msg, e, seed, SdfRounds)
+ok  := HpksSternFVerify(msg, sig, seed, syn)
+```
+
+### Complete runnable example
+
+```bash
+go run docs/examples/go/hello_herradura.go
+```
+
+See [`docs/examples/go/hello_herradura.go`](examples/go/hello_herradura.go).
+
+---
+
+## Python integration
+
+### Importing the module
+
+The filename contains spaces, so a plain `import` statement will not work.
+Use `importlib` instead:
+
+```python
+import importlib.util, pathlib
+
+_path = pathlib.Path("/path/to/HerraduraKEx/Herradura cryptographic suite.py")
+_spec = importlib.util.spec_from_file_location("herradura", _path)
+h = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(h)
+```
+
+After this, every public name is accessible as `h.<name>`.
+
+### HKEX-GF key exchange (classical)
+
+```python
+n    = h.KEYBITS          # 256
+poly = h.GF_POLY[n]
+g    = h.GF_GEN           # 3
+
+alice_priv = h.BitArray.random(n)
+bob_priv   = h.BitArray.random(n)
+
+alice_pub = h.BitArray(n, h.gf_pow(g, alice_priv.uint, poly, n))
+bob_pub   = h.BitArray(n, h.gf_pow(g, bob_priv.uint,   poly, n))
+
+alice_shared = h.BitArray(n, h.gf_pow(bob_pub.uint,   alice_priv.uint, poly, n))
+bob_shared   = h.BitArray(n, h.gf_pow(alice_pub.uint, bob_priv.uint,   poly, n))
+assert alice_shared == bob_shared
+```
+
+### HSKE symmetric encryption (classical)
+
+```python
+plaintext  = h.BitArray.random(n)
+ciphertext = h.fscx_revolve(plaintext,  alice_shared, h.I_VALUE)
+recovered  = h.fscx_revolve(ciphertext, alice_shared, h.R_VALUE)
+assert plaintext == recovered
+```
+
+### HSKE-NL-A2 symmetric encryption (NL/PQC)
+
+```python
+key       = h.BitArray.random(n)
+plaintext = h.BitArray.random(n)
+
+ciphertext = h.nl_fscx_revolve_v2(plaintext, key, h.R_VALUE)
+recovered  = h.nl_fscx_revolve_v2_inv(ciphertext, key, h.R_VALUE)
+assert plaintext == recovered
+```
+
+### HKEX-RNL key exchange (Ring-LWR, PQC)
+
+```python
+m_base  = h._rnl_m_poly(n)
+a_rand  = h._rnl_rand_poly(n, h.RNLQ)
+m_blind = h._rnl_poly_add(m_base, a_rand, h.RNLQ)
+
+# hkex_rnl_keygen / hkex_rnl_agree are public aliases (v1.7.4+)
+sA, CA = h.hkex_rnl_keygen(m_blind, n, h.RNLQ, h.RNLP, h.RNLB)
+sB, CB = h.hkex_rnl_keygen(m_blind, n, h.RNLQ, h.RNLP, h.RNLB)
+
+kA, hint_A = h.hkex_rnl_agree(sA, CB, h.RNLQ, h.RNLP, h.RNLPP, n, n)
+kB         = h.hkex_rnl_agree(sB, CA, h.RNLQ, h.RNLP, h.RNLPP, n, n, hint=hint_A)
+assert kA == kB
+
+# KDF
+skA = h.nl_fscx_revolve_v1(kA.rotated(n // 8), kA, n // 4)
+```
+
+### HPKS-Stern-F signature (code-based PQC)
+
+```python
+seed, e_int, syndrome = h.stern_f_keygen(n)
+msg = h.BitArray.random(n)
+sig = h.hpks_stern_f_sign(msg, e_int, seed, syndrome, n)
+ok  = h.hpks_stern_f_verify(msg, sig, seed, syndrome, n)
+```
+
+### NumPy acceleration
+
+The NTT-based polynomial multiply used by HKEX-RNL runs roughly 10× faster when
+NumPy is installed.  The module auto-detects it:
+
+```python
+import numpy  # install via: pip install numpy
+# Now h._NUMPY == True and _rnl_poly_mul uses the vectorised path automatically.
+```
+
+### Complete runnable example
+
+```bash
+python3 docs/examples/python/hello_herradura.py
+```
+
+See [`docs/examples/python/hello_herradura.py`](examples/python/hello_herradura.py).
+
+---
+
+## Protocol reference
+
+### Classical protocols
+
+| Protocol | Key exchange | Encryption | Signature |
+|----------|-------------|------------|-----------|
+| HKEX-GF | `gf_pow(g, priv, poly, n)` → pub | — | — |
+| HSKE | — | `fscx_revolve(pt, key, I_VALUE)` | — |
+| HPKS | — | — | Schnorr over GF(2^n)* |
+| HPKE | — | El Gamal + FSCX revolve | — |
+
+### NL/PQC protocols
+
+| Protocol | Primitive | Direction |
+|----------|-----------|-----------|
+| HSKE-NL-A1 | `nl_fscx_revolve_v1` | counter-mode (one-way) |
+| HSKE-NL-A2 | `nl_fscx_revolve_v2` / `_inv` | revolve-mode (invertible) |
+| HKEX-RNL | Ring-LWR polynomial arithmetic | key exchange |
+| HPKS-NL | `nl_fscx_revolve_v1` as Schnorr challenge | signature |
+| HPKE-NL | `nl_fscx_revolve_v2` / `_inv` | El Gamal encryption |
+
+### Code-based PQC
+
+| Protocol | Security | Status |
+|----------|----------|--------|
+| HPKS-Stern-F | SD(N,t) + NL-FSCX v1 PRF | Demo params (rounds=32); production needs rounds≥219 |
+| HPKE-Stern-F | SD(N,t) | Demo only; decap requires QC-MDPC decoder for production |
+
+### C high-level wrappers (added in v1.7.4)
+
+```c
+/* HKEX-GF */
+void hkex_gf_pubkey(const BitArray *priv, BitArray *pub);
+void hkex_gf_agree (const BitArray *my_priv, const BitArray *their_pub, BitArray *shared);
+
+/* HSKE */
+void hske_encrypt(const BitArray *pt,  const BitArray *key, BitArray *ct);
+void hske_decrypt(const BitArray *ct,  const BitArray *key, BitArray *pt);
+
+/* HPKS */
+void hpks_sign  (const BitArray *msg, const BitArray *priv, BitArray *R, BitArray *s, FILE *urnd);
+int  hpks_verify(const BitArray *msg, const BitArray *pub,  const BitArray *R, const BitArray *s);
+
+/* HPKE */
+void hpke_encrypt(const BitArray *pt, const BitArray *pub, BitArray *R, BitArray *ct, FILE *urnd);
+void hpke_decrypt(const BitArray *ct, const BitArray *R,   const BitArray *priv, BitArray *pt);
+
+/* PQC (existing, unchanged) */
+void stern_f_keygen      (BitArray *seed, BitArray *e, uint8_t *syndr, FILE *urnd);
+void hpks_stern_f_sign   (SternSig *sig, const BitArray *msg, const BitArray *e,
+                           const BitArray *seed, FILE *urnd);
+int  hpks_stern_f_verify (const SternSig *sig, const BitArray *msg,
+                           const BitArray *seed, const uint8_t *syndr);
+```
+
+---
+
+## Parameter reference
+
+| Parameter | C macro | Go constant | Python constant | Value |
+|-----------|---------|-------------|-----------------|-------|
+| Key size (bits) | `KEYBITS` | — | `KEYBITS` | 256 |
+| FSCX encrypt steps | `I_VALUE` | `iValue = n/4` | `I_VALUE` | 64 |
+| FSCX decrypt steps | `R_VALUE` | `rValue = 3*n/4` | `R_VALUE` | 192 |
+| RLWR modulus q | `RNL_Q` | `RnlQ` | `RNLQ` | 65537 |
+| RLWR public modulus p | `RNL_P` | `RnlP` | `RNLP` | 4096 |
+| RLWR reconciliation pp | `RNL_PP` | `RnlPP` | `RNLPP` | 4 |
+| RLWR polynomial degree | `RNL_N` | (= key bits) | (= `KEYBITS`) | 256 |
+| RLWR secret distribution | `RNL_ETA` | — | `RNLB` | 1 (CBD) |
+| Stern error weight | `SDF_T` | `SdfT` | `SDFT` | 16 |
+| Stern ZKP rounds (demo) | `SDF_ROUNDS` | `SdfRounds` | `SDFR` | 32 |
+| GF generator | `GF_GEN` (BitArray) | `GfGen = 3` | `GF_GEN = 3` | 3 |
+
+---
+
+## Security notes
+
+### Classical protocols (HKEX-GF, HSKE, HPKS, HPKE)
+
+- **HKEX-GF, HPKS, HPKE** rest on the discrete logarithm problem in GF(2^256)*.
+  Shor's algorithm solves DLP in polynomial time on a quantum computer.
+- **HSKE** is vulnerable to linear key recovery from a single known-plaintext pair.
+
+Use these protocols for compatibility testing, educational purposes, or in threat
+models that exclude quantum adversaries.
+
+### NL/PQC protocols (HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL)
+
+- **HKEX-RNL** is conjectured quantum-resistant, based on Ring-LWR hardness.
+  It has not been formally reduced from NIST-standardised parameters.
+- **HPKS-NL and HPKE-NL** still use GF(2^256)* DLP for the public key; the NL
+  extension hardens only the symmetric sub-protocol.  They are not fully PQC.
+- **HSKE-NL-A1/A2** are symmetric-only and do not depend on any public-key assumption.
+
+### Code-based PQC (HPKS-Stern-F, HPKE-Stern-F)
+
+- **HPKS-Stern-F** has a complete security reduction to SD(N,t) + NL-FSCX v1 PRF
+  (Theorem 17, `SecurityProofs-2.md §11.8.4`).  SD(N,t) is NP-complete and believed
+  quantum-hard (BMvT 1978).
+- **Demo parameters** use `SDF_ROUNDS=32` (soundness error (2/3)^32 ≈ 2^-19).
+  Production requires `rounds ≥ 219` for 128-bit soundness.
+- **HPKE-Stern-F decapsulation** in the demo uses a known error vector (`e'`).
+  A production deployment requires a QC-MDPC or similar decoder.
+
+### Constant-time status
+
+- **C and assembly targets** implement branchless GF multiply, branchless
+  `stern_apply_perm`, and constant-time equality checks.
+- **Python** is a reference implementation and is **not** constant-time.
+  Do not use the Python target in production where timing side-channels matter.
+- **Go** avoids data-dependent branching in critical paths but has not undergone
+  formal constant-time verification.

--- a/docs/examples/c/hello_herradura.c
+++ b/docs/examples/c/hello_herradura.c
@@ -1,0 +1,83 @@
+/*  hello_herradura.c — Minimal C integration example for the Herradura suite.
+ *
+ *  Build:
+ *    gcc -O2 -I../../.. hello_herradura.c -o hello_herradura
+ *
+ *  Run:
+ *    ./hello_herradura
+ *
+ *  Demonstrates HKEX-GF key exchange and HSKE symmetric encryption using the
+ *  header-only herradura.h library.  No other source files or link flags needed.
+ */
+
+#include <stdio.h>
+#include "../../../herradura.h"
+
+int main(void)
+{
+    FILE *urnd = fopen("/dev/urandom", "rb");
+    if (!urnd) { perror("/dev/urandom"); return 1; }
+
+    /* ── HKEX-GF: Diffie-Hellman over GF(2^256)* ──────────────────────── */
+    printf("=== HKEX-GF key exchange ===\n");
+
+    BitArray alice_priv, alice_pub, bob_priv, bob_pub;
+    BitArray alice_shared, bob_shared;
+
+    ba_rand(&alice_priv, urnd);
+    ba_rand(&bob_priv,   urnd);
+
+    hkex_gf_pubkey(&alice_priv, &alice_pub);   /* Alice: pub = g^priv  */
+    hkex_gf_pubkey(&bob_priv,   &bob_pub);     /* Bob:   pub = g^priv  */
+
+    hkex_gf_agree(&alice_priv, &bob_pub,   &alice_shared); /* Alice: bob_pub^alice_priv */
+    hkex_gf_agree(&bob_priv,   &alice_pub, &bob_shared);   /* Bob:   alice_pub^bob_priv */
+
+    ba_print_hex("Alice shared: ", &alice_shared);
+    ba_print_hex("Bob   shared: ", &bob_shared);
+    puts(ba_equal(&alice_shared, &bob_shared)
+         ? "✓ shared secrets agree" : "✗ shared secrets differ!");
+
+    /* ── HSKE: symmetric encryption with the derived shared key ──────── */
+    printf("\n=== HSKE symmetric encryption ===\n");
+
+    BitArray plaintext, ciphertext, recovered;
+    ba_rand(&plaintext, urnd);
+
+    hske_encrypt(&plaintext,  &alice_shared, &ciphertext);
+    hske_decrypt(&ciphertext, &alice_shared, &recovered);
+
+    ba_print_hex("Plaintext : ", &plaintext);
+    ba_print_hex("Ciphertext: ", &ciphertext);
+    ba_print_hex("Recovered : ", &recovered);
+    puts(ba_equal(&plaintext, &recovered)
+         ? "✓ decryption correct" : "✗ decryption failed!");
+
+    /* ── HPKS: Schnorr signature ─────────────────────────────────────── */
+    printf("\n=== HPKS Schnorr signature ===\n");
+
+    BitArray msg, R, s;
+    ba_rand(&msg, urnd);
+
+    hpks_sign(&msg, &alice_priv, &R, &s, urnd);
+    puts(hpks_verify(&msg, &alice_pub, &R, &s)
+         ? "✓ signature verified" : "✗ signature invalid!");
+
+    /* ── HPKE: El Gamal encryption ───────────────────────────────────── */
+    printf("\n=== HPKE El Gamal encryption ===\n");
+
+    BitArray ct_hpke, R_hpke, dec_hpke;
+    ba_rand(&plaintext, urnd);
+
+    hpke_encrypt(&plaintext, &alice_pub, &R_hpke, &ct_hpke, urnd);
+    hpke_decrypt(&ct_hpke, &R_hpke, &alice_priv, &dec_hpke);
+
+    ba_print_hex("Plaintext : ", &plaintext);
+    ba_print_hex("Ciphertext: ", &ct_hpke);
+    ba_print_hex("Decrypted : ", &dec_hpke);
+    puts(ba_equal(&plaintext, &dec_hpke)
+         ? "✓ decryption correct" : "✗ decryption failed!");
+
+    fclose(urnd);
+    return 0;
+}

--- a/docs/examples/go/hello_herradura.go
+++ b/docs/examples/go/hello_herradura.go
@@ -1,0 +1,105 @@
+/*  hello_herradura.go — Minimal Go integration example for the Herradura suite.
+ *
+ *  Build / run from the repo root:
+ *    go run docs/examples/go/hello_herradura.go
+ *
+ *  Or from this directory if your GOPATH / module config points to the repo root:
+ *    go run hello_herradura.go
+ *
+ *  The herradura package lives at herradurakex/herradura (see go.mod in the
+ *  repo root).  Copy or vendor the herradura/ directory into your own module
+ *  and adjust the import path to match your module name.
+ */
+
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	. "herradurakex/herradura"
+)
+
+func main() {
+	const n = 256
+	iValue := n / 4
+	rValue := 3 * n / 4
+	poly := GfPoly[n]
+
+	// ── HKEX-GF: Diffie-Hellman over GF(2^256)* ─────────────────────────────
+	fmt.Println("=== HKEX-GF key exchange ===")
+
+	alicePriv := NewRandBitArray(n)
+	bobPriv   := NewRandBitArray(n)
+	g         := big.NewInt(GfGen)
+
+	alicePub := NewBitArray(n, GfPow(g, &alicePriv.Val, poly, n))
+	bobPub   := NewBitArray(n, GfPow(g, &bobPriv.Val,  poly, n))
+
+	aliceShared := NewBitArray(n, GfPow(&bobPub.Val,   &alicePriv.Val, poly, n))
+	bobShared   := NewBitArray(n, GfPow(&alicePub.Val, &bobPriv.Val,   poly, n))
+
+	fmt.Printf("Alice shared: %x\n", aliceShared)
+	fmt.Printf("Bob   shared: %x\n", bobShared)
+	if aliceShared.Equal(bobShared) {
+		fmt.Println("✓ shared secrets agree")
+	} else {
+		fmt.Println("✗ shared secrets differ!")
+	}
+
+	// ── HSKE: symmetric encryption with the derived shared key ───────────────
+	fmt.Println("\n=== HSKE symmetric encryption ===")
+
+	plaintext := NewRandBitArray(n)
+	ciphertext := FscxRevolve(plaintext, aliceShared, iValue)
+	recovered  := FscxRevolve(ciphertext, aliceShared, rValue)
+
+	fmt.Printf("Plaintext : %x\n", plaintext)
+	fmt.Printf("Ciphertext: %x\n", ciphertext)
+	fmt.Printf("Recovered : %x\n", recovered)
+	if plaintext.Equal(recovered) {
+		fmt.Println("✓ decryption correct")
+	} else {
+		fmt.Println("✗ decryption failed!")
+	}
+
+	// ── HKEX-RNL: Ring-LWR key exchange (PQC-hardened) ───────────────────────
+	fmt.Printf("\n=== HKEX-RNL (Ring-LWR, n=%d, q=%d) ===\n", n, RnlQ)
+
+	mBase  := RnlMPoly(n)
+	aRand  := RnlRandPoly(n, RnlQ)
+	mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
+
+	sA, CA := RnlKeygen(mBlind, n, RnlQ, RnlP)
+	sB, CB := RnlKeygen(mBlind, n, RnlQ, RnlP)
+
+	kA, hintA := RnlAgree(sA, CB, RnlQ, RnlP, RnlPP, n, n, nil)
+	kB, _      := RnlAgree(sB, CA, RnlQ, RnlP, RnlPP, n, n, hintA)
+
+	// KDF: seed = ROL(K, n/8); sk = NL-FSCX-v1(seed, K, n/4)
+	skA := NlFscxRevolveV1(kA.RotateLeft(n/8), kA, n/4)
+	skB := NlFscxRevolveV1(kB.RotateLeft(n/8), kB, n/4)
+
+	fmt.Printf("sk (Alice): %x\n", skA)
+	fmt.Printf("sk (Bob)  : %x\n", skB)
+	if kA.Equal(kB) {
+		fmt.Println("✓ Ring-LWR keys agree")
+	} else {
+		fmt.Println("✗ Ring-LWR key disagreement!")
+	}
+	_ = skA; _ = skB
+
+	// ── HPKS-Stern-F: code-based signature (PQC) ─────────────────────────────
+	fmt.Printf("\n=== HPKS-Stern-F (N=%d, t=%d, rounds=%d) ===\n",
+		n, SdfT, SdfRounds)
+
+	seed, e, syn := SternFKeygen(n)
+	msg := NewRandBitArray(n)
+	sig := HpksSternFSign(msg, e, seed, SdfRounds)
+
+	if HpksSternFVerify(msg, sig, seed, syn) {
+		fmt.Println("✓ Stern-F signature verified")
+	} else {
+		fmt.Println("✗ Stern-F signature invalid!")
+	}
+}

--- a/docs/examples/python/hello_herradura.py
+++ b/docs/examples/python/hello_herradura.py
@@ -1,0 +1,86 @@
+"""
+hello_herradura.py — Minimal Python integration example for the Herradura suite.
+
+Run from the repo root:
+    python3 docs/examples/python/hello_herradura.py
+
+The suite file has spaces in its name, so it must be loaded via importlib.
+The pattern shown below works from any directory as long as you set SUITE_PATH.
+"""
+
+import importlib.util
+import pathlib
+
+# ── Load the Herradura module ─────────────────────────────────────────────────
+SUITE_PATH = pathlib.Path(__file__).parent.parent.parent.parent / "Herradura cryptographic suite.py"
+_spec = importlib.util.spec_from_file_location("herradura", SUITE_PATH)
+h = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(h)
+
+
+# ── HKEX-GF: Diffie-Hellman over GF(2^256)* ─────────────────────────────────
+print("=== HKEX-GF key exchange ===")
+
+n    = h.KEYBITS          # 256
+poly = h.GF_POLY[n]
+g    = h.GF_GEN           # 3
+
+alice_priv = h.BitArray.random(n)
+bob_priv   = h.BitArray.random(n)
+
+alice_pub = h.BitArray(n, h.gf_pow(g, alice_priv.uint, poly, n))
+bob_pub   = h.BitArray(n, h.gf_pow(g, bob_priv.uint,   poly, n))
+
+alice_shared = h.BitArray(n, h.gf_pow(bob_pub.uint,   alice_priv.uint, poly, n))
+bob_shared   = h.BitArray(n, h.gf_pow(alice_pub.uint, bob_priv.uint,   poly, n))
+
+print(f"Alice shared: {alice_shared.hex}")
+print(f"Bob   shared: {bob_shared.hex}")
+print("✓ shared secrets agree" if alice_shared == bob_shared else "✗ shared secrets differ!")
+
+
+# ── HSKE: symmetric encryption with the derived shared key ────────────────────
+print("\n=== HSKE symmetric encryption ===")
+
+plaintext  = h.BitArray.random(n)
+ciphertext = h.fscx_revolve(plaintext, alice_shared, h.I_VALUE)
+recovered  = h.fscx_revolve(ciphertext, alice_shared, h.R_VALUE)
+
+print(f"Plaintext : {plaintext.hex}")
+print(f"Ciphertext: {ciphertext.hex}")
+print(f"Recovered : {recovered.hex}")
+print("✓ decryption correct" if plaintext == recovered else "✗ decryption failed!")
+
+
+# ── HKEX-RNL: Ring-LWR key exchange (PQC-hardened) ───────────────────────────
+print(f"\n=== HKEX-RNL (Ring-LWR, n={n}, q={h.RNLQ}) ===")
+
+m_base  = h._rnl_m_poly(n)
+a_rand  = h._rnl_rand_poly(n, h.RNLQ)
+m_blind = h._rnl_poly_add(m_base, a_rand, h.RNLQ)
+
+# Use the public aliases added in v1.7.4
+sA, CA = h.hkex_rnl_keygen(m_blind, n, h.RNLQ, h.RNLP, h.RNLB)
+sB, CB = h.hkex_rnl_keygen(m_blind, n, h.RNLQ, h.RNLP, h.RNLB)
+
+kA, hint_A = h.hkex_rnl_agree(sA, CB, h.RNLQ, h.RNLP, h.RNLPP, n, n)
+kB         = h.hkex_rnl_agree(sB, CA, h.RNLQ, h.RNLP, h.RNLPP, n, n, hint=hint_A)
+
+# KDF: seed = ROL(K, n/8); sk = NL-FSCX-v1(seed, K, n/4)
+skA = h.nl_fscx_revolve_v1(kA.rotated(n // 8), kA, n // 4)
+skB = h.nl_fscx_revolve_v1(kB.rotated(n // 8), kB, n // 4)
+
+print(f"sk (Alice): {skA.hex}")
+print(f"sk (Bob)  : {skB.hex}")
+print("✓ Ring-LWR keys agree" if kA == kB else "✗ Ring-LWR key disagreement!")
+
+
+# ── HPKS-Stern-F: code-based signature (PQC) ─────────────────────────────────
+print(f"\n=== HPKS-Stern-F (N={n}, t={h.SDFT}, rounds={h.SDFR}) ===")
+
+seed, e_int, syndrome = h.stern_f_keygen(n)
+msg = h.BitArray.random(n)
+sig = h.hpks_stern_f_sign(msg, e_int, seed, syndrome, n)
+
+result = h.hpks_stern_f_verify(msg, sig, seed, syndrome, n)
+print("✓ Stern-F signature verified" if result else "✗ Stern-F signature invalid!")

--- a/herradura.h
+++ b/herradura.h
@@ -1176,4 +1176,99 @@ static void hpke_stern_f_decap_known(BitArray *K_out,
     stern_hash(K_out, items, 2, 4);
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Protocol Layer — high-level wrappers for library callers
+ *
+ * These thin functions assemble the low-level primitives into the four named
+ * Herradura protocols.  Include herradura.h in any C translation unit, compile
+ * with -O2, and call these directly — no separate library build step needed.
+ *
+ *   hkex_gf_pubkey / hkex_gf_agree   — HKEX-GF key exchange
+ *   hske_encrypt   / hske_decrypt     — HSKE symmetric encryption
+ *   hpks_sign      / hpks_verify      — HPKS Schnorr signature
+ *   hpke_encrypt   / hpke_decrypt     — HPKE El Gamal encryption
+ *
+ * For PQC-hardened protocols use: hpks_stern_f_sign / hpks_stern_f_verify
+ * (Stern ZKP, code-based), rnl_keygen / rnl_agree (Ring-LWR), and the
+ * NL-FSCX revolve primitives directly — they are already protocol-level.
+ *
+ * See docs/TUTORIAL.md for complete usage examples.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+/* HKEX-GF: derive public key pub = g^priv in GF(2^KEYBITS)*. */
+static inline void hkex_gf_pubkey(const BitArray *priv, BitArray *pub)
+{
+    gf_pow_ba(pub, &GF_GEN, priv);
+}
+
+/* HKEX-GF: derive shared secret shared = their_pub^my_priv in GF(2^KEYBITS)*. */
+static inline void hkex_gf_agree(const BitArray *my_priv,
+                                   const BitArray *their_pub,
+                                   BitArray *shared)
+{
+    gf_pow_ba(shared, their_pub, my_priv);
+}
+
+/* HSKE: encrypt pt -> ct using key (I_VALUE steps). */
+static inline void hske_encrypt(const BitArray *pt, const BitArray *key,
+                                 BitArray *ct)
+{
+    ba_fscx_revolve(ct, pt, key, I_VALUE);
+}
+
+/* HSKE: decrypt ct -> pt using key (R_VALUE steps). */
+static inline void hske_decrypt(const BitArray *ct, const BitArray *key,
+                                 BitArray *pt)
+{
+    ba_fscx_revolve(pt, ct, key, R_VALUE);
+}
+
+/* HPKS: sign msg with private key priv.
+ * Outputs commitment R = g^k and scalar s = (k - priv*e) mod ord.
+ * Send (R, s) to the verifier along with the message. */
+static inline void hpks_sign(const BitArray *msg, const BitArray *priv,
+                               BitArray *R_out, BitArray *s_out, FILE *urnd)
+{
+    BitArray k, e, ae;
+    ba_rand(&k, urnd);
+    gf_pow_ba(R_out, &GF_GEN, &k);
+    ba_fscx_revolve(&e, R_out, msg, I_VALUE);
+    ba_mul_mod_ord(&ae, priv, &e);
+    ba_sub_mod_ord(s_out, &k, &ae);
+}
+
+/* HPKS: verify Schnorr signature (R, s) on msg under public key pub.
+ * Returns 1 if valid, 0 otherwise. */
+static inline int hpks_verify(const BitArray *msg, const BitArray *pub,
+                                const BitArray *R, const BitArray *s)
+{
+    BitArray e, gs, Ce, lhs;
+    ba_fscx_revolve(&e, R, msg, I_VALUE);
+    gf_pow_ba(&gs, &GF_GEN, s);
+    gf_pow_ba(&Ce, pub, &e);
+    gf_mul_ba(&lhs, &gs, &Ce);
+    return ba_equal(&lhs, R);
+}
+
+/* HPKE: encrypt pt for the holder of private key corresponding to pub.
+ * Outputs ephemeral R (send alongside ciphertext) and ciphertext ct. */
+static inline void hpke_encrypt(const BitArray *pt, const BitArray *pub,
+                                  BitArray *R_out, BitArray *ct_out, FILE *urnd)
+{
+    BitArray r, enc_key;
+    ba_rand(&r, urnd);
+    gf_pow_ba(R_out, &GF_GEN, &r);
+    gf_pow_ba(&enc_key, pub, &r);
+    ba_fscx_revolve(ct_out, pt, &enc_key, I_VALUE);
+}
+
+/* HPKE: decrypt ciphertext ct using private key priv and sender's ephemeral R. */
+static inline void hpke_decrypt(const BitArray *ct, const BitArray *R,
+                                  const BitArray *priv, BitArray *pt_out)
+{
+    BitArray dec_key;
+    gf_pow_ba(&dec_key, R, priv);
+    ba_fscx_revolve(pt_out, ct, &dec_key, R_VALUE);
+}
+
 #endif /* HERRADURA_H */


### PR DESCRIPTION
## Summary

- Add `docs/TUTORIAL.md` — comprehensive integration guide for C, Go, and Python covering all six protocols (HKEX-GF, HSKE, HPKS, HPKE, HKEX-RNL, HPKS-Stern-F) with per-protocol recipes, parameter reference table, and security notes
- Add runnable examples: `docs/examples/c/hello_herradura.c`, `docs/examples/go/hello_herradura.go`, `docs/examples/python/hello_herradura.py`
- `herradura.h`: add Protocol Layer section with 8 `static inline` wrappers (`hkex_gf_pubkey`, `hkex_gf_agree`, `hske_encrypt`, `hske_decrypt`, `hpks_sign`, `hpks_verify`, `hpke_encrypt`, `hpke_decrypt`)
- `"Herradura cryptographic suite.py"`: extend module docstring with library-usage section; add public aliases `hkex_rnl_keygen` and `hkex_rnl_agree` to expose the Ring-LWR protocol layer

## Test plan

- [x] `gcc -O2 -I. docs/examples/c/hello_herradura.c -o /tmp/hello_c && /tmp/hello_c` — all 4 protocols print ✓
- [x] `go run docs/examples/go/hello_herradura.go` — all 4 protocols print ✓
- [x] `python3 docs/examples/python/hello_herradura.py` — all 4 protocols print ✓ (expected RuntimeWarning about Stern-F soundness at rounds=32)
- [ ] Existing test suites still pass: `cd CryptosuiteTests && go run Herradura_tests.go -r 10 -t 3.0` and `python3 CryptosuiteTests/Herradura_tests.py -r 5 -t 2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)