### PR TITLE
Fix i386 ASM build portability — probe linker for elf_i386 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,23 @@ arm-linux-gnueabi-gcc -o "Herradura cryptographic suite_arm" "Herradura cryptogr
 arm-linux-gnueabi-gcc -o CryptosuiteTests/Herradura_tests_arm CryptosuiteTests/Herradura_tests.s
 qemu-arm -L /usr/arm-linux-gnueabi "./Herradura cryptographic suite_arm"
 
-# NASM i386
+# NASM i386 — use the build script (it selects a linker with elf_i386 support)
+./build_asm_i386.sh
+qemu-i386 "./Herradura cryptographic suite_i386"
+
+# Manual linker invocation (ld must support elf_i386 — see portability note below)
 nasm -f elf32 "Herradura cryptographic suite.asm" -o suite32.o
 nasm -f elf32 CryptosuiteTests/Herradura_tests.asm -o tests32.o
 x86_64-linux-gnu-ld -m elf_i386 -o "Herradura cryptographic suite_i386" suite32.o
 x86_64-linux-gnu-ld -m elf_i386 -o CryptosuiteTests/Herradura_tests_i386 tests32.o
-qemu-i386 "./Herradura cryptographic suite_i386"
 ```
+
+> **i386 linker portability:** `x86_64-linux-gnu-ld -m elf_i386` fails on ARM64 hosts
+> (e.g. Raspberry Pi 5 / Ubuntu) with "unrecognized emulation mode: elf_i386" because the
+> native `ld` (aarch64) has no i386 emulation.  `build_asm_i386.sh` auto-detects the first
+> available linker with `elf_i386` support.  If none is found, install one:
+> - `sudo apt-get install -y binutils-x86-64-linux-gnu`  (provides `x86_64-linux-gnu-ld`)
+> - `sudo apt-get install -y binutils-i686-linux-gnu`    (provides `i686-linux-gnu-ld`)
 
 ## Testing
 

--- a/build_asm_i386.sh
+++ b/build_asm_i386.sh
@@ -5,7 +5,10 @@
 #
 # Dependencies (build):
 #   nasm     — sudo apt-get install -y nasm
-#   ld       — sudo apt-get install -y binutils
+#   ld with elf_i386 emulation — one of:
+#     x86_64 host : sudo apt-get install -y binutils
+#     ARM64 host  : sudo apt-get install -y binutils-x86-64-linux-gnu
+#                or sudo apt-get install -y binutils-i686-linux-gnu
 #
 # Dependencies (run — see run_asm_i386.sh):
 #   qemu-i386
@@ -29,20 +32,36 @@ if ! command -v nasm &>/dev/null; then
     exit 1
 fi
 
-if ! command -v x86_64-linux-gnu-ld &>/dev/null && ! command -v ld &>/dev/null; then
-    echo "ERROR: linker (ld / x86_64-linux-gnu-ld) not found."
-    echo "  Install: sudo apt-get install -y binutils"
+# Find a linker that actually supports the elf_i386 emulation.
+# The native ld on ARM64 hosts only knows aarch64/arm emulations, so we probe
+# each candidate rather than assuming presence implies elf_i386 support.
+find_i386_linker() {
+    local candidates=(
+        x86_64-linux-gnu-ld   # binutils-x86-64-linux-gnu  (works on any host arch)
+        i686-linux-gnu-ld     # binutils-i686-linux-gnu    (works on any host arch)
+        ld                    # system linker (supports elf_i386 on x86_64 hosts only)
+    )
+    for ld_bin in "${candidates[@]}"; do
+        if command -v "${ld_bin}" &>/dev/null; then
+            if "${ld_bin}" --help 2>&1 | grep -q 'elf_i386'; then
+                echo "${ld_bin}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+if ! LD=$(find_i386_linker); then
+    echo "ERROR: no linker with elf_i386 emulation found."
+    echo "  x86_64 host : sudo apt-get install -y binutils"
+    echo "  ARM64 host  : sudo apt-get install -y binutils-x86-64-linux-gnu"
+    echo "             or sudo apt-get install -y binutils-i686-linux-gnu"
     exit 1
 fi
 
-# Prefer the explicit cross linker; fall back to system ld if capable
-if command -v x86_64-linux-gnu-ld &>/dev/null; then
-    LD="x86_64-linux-gnu-ld"
-else
-    LD="ld"
-fi
-
 echo "=== HerraduraKEx v${VERSION} — NASM i386 build ==="
+echo "  Linker: ${LD}"
 
 echo "  Assembling suite..."
 nasm -f elf32 "${SUITE_SRC}" -o "${SUITE_OBJ}"


### PR DESCRIPTION
## Summary

- `build_asm_i386.sh` previously picked `x86_64-linux-gnu-ld` (or system `ld`) by presence alone, which fails on ARM64/Ubuntu hosts (e.g. Raspberry Pi 5) with **"unrecognized emulation mode: elf_i386"** — that platform's native `ld` only knows aarch64 emulations.
- Replaced the check with `find_i386_linker()`: probes `x86_64-linux-gnu-ld` → `i686-linux-gnu-ld` → `ld` by running `--help | grep elf_i386`, accepting the first that actually supports the emulation.
- Error message now gives the correct `apt-get install` command for both x86_64 and ARM64 hosts.
- Added a `Linker: <name>` line to the build banner so the selected linker is visible.
- Updated `CLAUDE.md` with a portability note and ARM64 install instructions.

## Test plan

- [ ] Run `./build_asm_i386.sh` on an x86_64 host — should select `ld` or `x86_64-linux-gnu-ld` and build cleanly
- [ ] Run `./build_asm_i386.sh` on an ARM64/Ubuntu host with `binutils-x86-64-linux-gnu` installed — should select `x86_64-linux-gnu-ld` and build cleanly
- [ ] Run `./build_asm_i386.sh` on an ARM64 host with only `binutils-i686-linux-gnu` installed — should fall back to `i686-linux-gnu-ld`
- [ ] Run `./build_asm_i386.sh` on an ARM64 host with no cross-linker installed — should print the actionable error with correct package names
- [ ] Verify `qemu-i386 "./Herradura cryptographic suite_i386"` and `qemu-i386 ./CryptosuiteTests/Herradura_tests_i386` produce correct output after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)