### PR TITLE
Document unauthenticated HKEX-RNL hint vector — TODO #47

### DIFF
--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -715,7 +715,12 @@ def _rnl_keygen(m_blind, n, q, p, b):
 def _rnl_agree(s, C_other, q, p, pp, n, key_bits, hint=None):
     """Compute raw key bits with Peikert cross-rounding reconciliation.
     Reconciler path (hint=None): generate hint, return (K_raw, hint).
-    Receiver path (hint provided): use hint, return K_raw."""
+    Receiver path (hint provided): use hint, return K_raw.
+
+    SECURITY: the hint vector is transmitted unauthenticated. An active
+    adversary who tampers with the hint can steer the reconciled key.
+    HKEX-RNL provides key agreement only; the caller must authenticate the
+    transcript (e.g. via HPKS-NL or a MAC over b_pub||hint) before use."""
     C_lifted = _rnl_lift(C_other, p, q)
     K_poly   = _rnl_poly_mul(s, C_lifted, q, n)
     if hint is None:

--- a/TODO.md
+++ b/TODO.md
@@ -3017,7 +3017,12 @@ over `(b_pub ‖ m_blind)`) before using the derived key."  As a separate harden
 step (if desired), consider binding `m_blind` into the KDF input so a tampered hint
 produces a different key rather than silent agreement on a wrong key.
 
-Status: **Open**
+Status: **DONE (v1.8.2)** — Warning added to all three language targets and docs:
+- `herradura.h` `rnl_agree` block comment: unauthenticated hint caveat + example mitigations
+- `herradura/herradura.go` `RnlAgree` doc comment: same caveat
+- `Herradura cryptographic suite.py` `_rnl_agree` docstring: same caveat
+- `docs/TUTORIAL.md` §NL/PQC security notes: "HKEX-RNL unauthenticated hint" bullet with
+  explicit guidance that callers must authenticate `b_pub ‖ m_blind` before using the key.
 
 ---
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -460,6 +460,12 @@ models that exclude quantum adversaries.
 
 - **HKEX-RNL** is conjectured quantum-resistant, based on Ring-LWR hardness.
   It has not been formally reduced from NIST-standardised parameters.
+- **HKEX-RNL unauthenticated hint:** The Peikert reconciliation hint vector
+  (`m_blind`, 64 bytes at n=256) is transmitted from Bob to Alice unauthenticated.
+  An active adversary who can tamper with the channel can flip hint bits to steer
+  the reconciled key toward a value of their choosing.  **HKEX-RNL provides key
+  agreement only; the caller is responsible for authenticating the transcript**
+  (e.g. via HPKS-NL, or a MAC over `b_pub ‖ m_blind`) before using the derived key.
 - **HPKS-NL and HPKE-NL** still use GF(2^256)* DLP for the public key; the NL
   extension hardens only the symmetric sub-protocol.  They are not fully PQC.
 - **HSKE-NL-A1/A2** are symmetric-only and do not depend on any public-key assumption.

--- a/herradura.h
+++ b/herradura.h
@@ -895,7 +895,12 @@ static void rnl_reconcile_bits(BitArray *out, const rnl_poly_t K_poly,
 
 /* agree: compute raw key with Peikert reconciliation.
    Reconciler path (hint_in=NULL, hint_out≠NULL): generate hint, use own hint.
-   Receiver path  (hint_in≠NULL):                 use provided hint.           */
+   Receiver path  (hint_in≠NULL):                 use provided hint.
+   SECURITY: hint_out (m_blind) is transmitted unauthenticated.  An active
+   adversary who tampers with hint_in can steer the reconciled key.  HKEX-RNL
+   provides key agreement only; the caller is responsible for authenticating the
+   transcript (e.g. via HPKS-NL or a MAC over b_pub||m_blind) before using the
+   derived key.                                                                 */
 static void rnl_agree(BitArray *out, const int32_t s[RNL_N],
                       const int32_t c_other[RNL_N],
                       const uint8_t *hint_in, uint8_t *hint_out)

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -693,6 +693,10 @@ func RnlReconcileBits(kPoly []int, hint []byte, q, pp, keyBits int) *BitArray {
 // RnlAgree computes raw key bits with Peikert reconciliation.
 // Reconciler (hintIn==nil): generates hint; returns (K_raw, hint).
 // Receiver  (hintIn!=nil):  uses provided hint; returns (K_raw, nil).
+// SECURITY: the hint vector is transmitted unauthenticated. An active adversary
+// who tampers with hintIn can steer the reconciled key. HKEX-RNL provides key
+// agreement only; the caller must authenticate the transcript (e.g. via HPKS-NL
+// or a MAC over bPub||hint) before using the derived key.
 func RnlAgree(s, cOther []int, q, p, pp, n, keyBits int, hintIn []byte) (*BitArray, []byte) {
 	cLifted := RnlLift(cOther, p, q)
 	kPoly := RnlPolyMul(s, cLifted, q, n)


### PR DESCRIPTION
## Summary
- Adds explicit `SECURITY` warnings to all three language targets (`rnl_agree` in C, `RnlAgree` in Go, `_rnl_agree` in Python) noting that the Peikert hint vector is transmitted unauthenticated and that callers must authenticate the transcript before using the derived key
- Adds a dedicated "HKEX-RNL unauthenticated hint" bullet to `docs/TUTORIAL.md` §NL/PQC security notes with concrete mitigation examples (`HPKS-NL` or MAC over `b_pub ‖ m_blind`)
- Marks TODO #47 DONE in `TODO.md`

No code changes — documentation only.

## Test plan
- [ ] All existing tests continue to pass (no code changed)
- [ ] `grep -n "SECURITY\|unauthenticated" herradura.h herradura/herradura.go` — warnings present in both
- [ ] `grep -n "unauthenticated" docs/TUTORIAL.md` — bullet present in security notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)