### PR TITLE
Precompute H matrix in Stern sign/verify — TODO #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.8.2] - 2026-05-21
+
+### Performance — precompute H matrix in Stern sign/verify (TODO #52)
+
+`stern_syndrome` / `SternSyndrome` rebuilt all `SDF_N_ROWS` (128) rows of the
+parity-check matrix from seed on every call.  In `hpks_stern_f_sign` (32 rounds) and
+`hpks_stern_f_verify` (up to 32 rounds) this meant 33+ full matrix constructions per
+sign+verify cycle; at production parameters (≥219 rounds) the overhead is ~440 builds.
+Each build costs 128 × `I_VALUE` (= 64) NL-FSCX v1 steps, so sign+verify was burning
+~33 × 128 × 64 = **270 k PRF evaluations** on matrix generation alone.
+
+**Fix:** Added `stern_build_H` (C, `herradura.h`) and `SternBuildH` (Go) that
+precompute the full H matrix once; added `stern_syndrome_H` (C) and `sternSyndromeH`
+(Go) that compute `H·e^T` from the prebuilt rows.  `hpks_stern_f_sign` and
+`hpks_stern_f_verify` in both C and Go now build H once at entry and reuse it for all
+per-round syndrome evaluations (32× → 1× matrix build per sign or verify call).
+`stern_syndrome` / `SternSyndrome` are retained as one-off wrappers (keygen, encap).
+Python already used this pattern via `_stern_build_H` / `_stern_syndrome_H`.
+
+**Files changed:** `herradura.h`, `herradura/herradura.go`.
+
+---
+
 ## [1.8.1] - 2026-05-21
 
 ### Security — `stern_gen_perm` PRNG bias eliminated (TODO #45)

--- a/TODO.md
+++ b/TODO.md
@@ -3136,7 +3136,13 @@ avoids this with `_stern_build_H` which precomputes the matrix once.
 `SternBuildH` in Go.  Update `hpks_stern_f_sign` / `HpksSternFSign` and
 `hpks_stern_f_verify` / `HpksSternFVerify` to build H once and pass it through.
 
-Status: **Open**
+Status: **DONE (v1.8.2)** — Added `stern_build_H` (C) and `SternBuildH` (Go) that precompute
+all `SDF_N_ROWS` rows of H once.  Added `stern_syndrome_H` (C) and `sternSyndromeH` (Go)
+that compute `H·e^T` from the prebuilt matrix.  `stern_syndrome` (C) and `SternSyndrome`
+(Go) are retained as one-off wrappers (keygen, encap) that build H internally.
+`hpks_stern_f_sign` and `hpks_stern_f_verify` in both C and Go now call `stern_build_H` /
+`SternBuildH` once at entry and use the fast `_H` variant for all per-round syndrome
+evaluations, reducing matrix construction from `rounds` calls down to 1.
 
 ---
 

--- a/herradura.h
+++ b/herradura.h
@@ -966,21 +966,38 @@ static void stern_matrix_row(BitArray *out, const BitArray *seed, int row)
     nl_fscx_revolve_v1_ba(out, &a0, seed, I_VALUE);
 }
 
-/* n_rows-bit syndrome s = H*e^T mod 2 packed into syndr[SDF_SYNBYTES]. */
-static void stern_syndrome(uint8_t *syndr, const BitArray *seed,
-                            const BitArray *e)
+/* Build all SDF_N_ROWS rows of parity-check matrix H from seed.
+   Hot paths (sign/verify) call this once and reuse H via stern_syndrome_H. */
+static void stern_build_H(BitArray *H, const BitArray *seed)
+{
+    int i;
+    for (i = 0; i < SDF_N_ROWS; i++)
+        stern_matrix_row(&H[i], seed, i);
+}
+
+/* Syndrome from prebuilt H: s = H*e^T mod 2, packed into syndr[SDF_SYNBYTES]. */
+static void stern_syndrome_H(uint8_t *syndr, const BitArray *H,
+                              const BitArray *e)
 {
     int i;
     memset(syndr, 0, SDF_SYNBYTES);
     for (i = 0; i < SDF_N_ROWS; i++) {
-        BitArray row;
         int pc = 0, k;
-        stern_matrix_row(&row, seed, i);
         for (k = 0; k < KEYBYTES; k++)
-            pc ^= __builtin_popcount(row.b[k] & e->b[k]);
+            pc ^= __builtin_popcount(H[i].b[k] & e->b[k]);
         if (pc & 1)
             syndr[i / 8] |= (uint8_t)(1u << (i % 8));
     }
+}
+
+/* n_rows-bit syndrome s = H*e^T mod 2 packed into syndr[SDF_SYNBYTES].
+   One-off wrapper; hot paths should use stern_build_H + stern_syndrome_H. */
+static void stern_syndrome(uint8_t *syndr, const BitArray *seed,
+                            const BitArray *e)
+{
+    BitArray H[SDF_N_ROWS];
+    stern_build_H(H, seed);
+    stern_syndrome_H(syndr, H, e);
 }
 
 /* Pack syndrome into lower half of a BitArray (upper bytes = 0). */
@@ -1134,6 +1151,7 @@ static void hpks_stern_f_sign(SternSig *sig, const BitArray *msg,
     BitArray *sr = (BitArray *)malloc(SDF_ROUNDS * sizeof(BitArray));
     BitArray *sy = (BitArray *)malloc(SDF_ROUNDS * sizeof(BitArray));
     uint8_t  *Hr = (uint8_t  *)malloc(SDF_ROUNDS * SDF_SYNBYTES);
+    BitArray H_mat[SDF_N_ROWS];
     uint8_t perm[KEYBITS];
     int i;
 
@@ -1141,12 +1159,14 @@ static void hpks_stern_f_sign(SternSig *sig, const BitArray *msg,
         fprintf(stderr, "hpks_stern_f_sign: out of memory\n"); exit(1);
     }
 
+    stern_build_H(H_mat, seed);
+
     for (i = 0; i < SDF_ROUNDS; i++) {
         BitArray items[2];
         stern_rand_error(&r[i], urnd);
         ba_xor(&y[i], e, &r[i]);
         ba_rand(&pi[i], urnd);
-        stern_syndrome(Hr + i * SDF_SYNBYTES, seed, &r[i]);
+        stern_syndrome_H(Hr + i * SDF_SYNBYTES, H_mat, &r[i]);
         stern_gen_perm(perm, &pi[i], KEYBITS);
         stern_apply_perm(&sr[i], perm, &r[i], KEYBITS);
         stern_apply_perm(&sy[i], perm, &y[i], KEYBITS);
@@ -1174,8 +1194,11 @@ static int hpks_stern_f_verify(const SternSig *sig, const BitArray *msg,
                                 const BitArray *seed, const uint8_t *syndr)
 {
     int chals[SDF_ROUNDS];
+    BitArray H_mat[SDF_N_ROWS];
     uint8_t perm[KEYBITS];
     int i;
+
+    stern_build_H(H_mat, seed);
 
     stern_fs_challenges(chals, SDF_ROUNDS, msg,
                         sig->c0, sig->c1, sig->c2);
@@ -1195,7 +1218,7 @@ static int hpks_stern_f_verify(const SternSig *sig, const BitArray *msg,
             uint8_t Hr[SDF_SYNBYTES];
             BitArray items[2], sr2;
             if (ba_popcount(&sig->resp_b[i]) != SDF_T) return 0;
-            stern_syndrome(Hr, seed, &sig->resp_b[i]);
+            stern_syndrome_H(Hr, H_mat, &sig->resp_b[i]);
             items[0] = sig->resp_a[i]; syndr_to_ba(&items[1], Hr);
             stern_hash(&tmp, items, 2, 1);
             if (!ba_equal(&tmp, &sig->c0[i])) return 0;
@@ -1207,7 +1230,7 @@ static int hpks_stern_f_verify(const SternSig *sig, const BitArray *msg,
             uint8_t Hy[SDF_SYNBYTES], Hys[SDF_SYNBYTES];
             BitArray items[2], sy2;
             int k;
-            stern_syndrome(Hy, seed, &sig->resp_b[i]);
+            stern_syndrome_H(Hy, H_mat, &sig->resp_b[i]);
             for (k = 0; k < SDF_SYNBYTES; k++) Hys[k] = Hy[k] ^ syndr[k];
             items[0] = sig->resp_a[i]; syndr_to_ba(&items[1], Hys);
             stern_hash(&tmp, items, 2, 1);

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -745,18 +745,33 @@ func SternMatrixRow(seed *BitArray, row int) *BitArray {
 	return NlFscxRevolveV1(sxr.RotateLeft(n/8), seed, n/4)
 }
 
-// SternSyndrome computes H·e^T mod 2.
-func SternSyndrome(seed, e *BitArray) *big.Int {
+// SternBuildH precomputes all n/2 rows of the parity-check matrix.
+// Hot paths (sign/verify) call this once and reuse H via sternSyndromeH.
+func SternBuildH(seed *BitArray) []*BitArray {
 	nRows := seed.size / 2
+	H := make([]*BitArray, nRows)
+	for i := range H {
+		H[i] = SternMatrixRow(seed, i)
+	}
+	return H
+}
+
+// sternSyndromeH computes H·e^T mod 2 from a prebuilt H matrix.
+func sternSyndromeH(H []*BitArray, e *BitArray) *big.Int {
 	syn := new(big.Int)
-	for i := 0; i < nRows; i++ {
-		row := SternMatrixRow(seed, i)
+	for i, row := range H {
 		dot := new(big.Int).And(&row.Val, &e.Val)
 		if CountBits(dot)%2 == 1 {
 			syn.SetBit(syn, i, 1)
 		}
 	}
 	return syn
+}
+
+// SternSyndrome computes H·e^T mod 2.
+// One-off wrapper; hot paths should use SternBuildH + sternSyndromeH.
+func SternSyndrome(seed, e *BitArray) *big.Int {
+	return sternSyndromeH(SternBuildH(seed), e)
 }
 
 // SyndrToBA stores a syndrome *big.Int in the low bits of a BitArray.
@@ -888,6 +903,7 @@ func HpksSternFSign(msg, e, seed *BitArray, rounds int) *SternSig {
 	}
 	n := msg.size
 	t := n / 16
+	H := SternBuildH(seed)
 	sig := &SternSig{Rounds: make([]SternRound, rounds)}
 	type rtmp struct{ r, y, pi, sr, sy *BitArray }
 	tmp := make([]rtmp, rounds)
@@ -902,7 +918,7 @@ func HpksSternFSign(msg, e, seed *BitArray, rounds int) *SternSig {
 		perm := SternGenPerm(pi, n)
 		sr := SternApplyPerm(perm, r)
 		sy := SternApplyPerm(perm, y)
-		hrBA := SyndrToBA(n, SternSyndrome(seed, r))
+		hrBA := SyndrToBA(n, sternSyndromeH(H, r))
 		c0 := SternHash(1, pi, hrBA)
 		c1 := SternHash(2, sr)
 		c2 := SternHash(3, sy)
@@ -938,6 +954,7 @@ func HpksSternFVerify(msg *BitArray, sig *SternSig, seed *BitArray, syndrome *bi
 	rounds := len(sig.Rounds)
 	n := msg.size
 	t := n / 16
+	H := SternBuildH(seed)
 	c0s := make([]*BitArray, rounds)
 	c1s := make([]*BitArray, rounds)
 	c2s := make([]*BitArray, rounds)
@@ -968,7 +985,7 @@ func HpksSternFVerify(msg *BitArray, sig *SternSig, seed *BitArray, syndrome *bi
 			if CountBits(&r.RespB.Val) != t {
 				return false
 			}
-			hrBA := SyndrToBA(n, SternSyndrome(seed, r.RespB))
+			hrBA := SyndrToBA(n, sternSyndromeH(H, r.RespB))
 			if !SternHash(1, r.RespA, hrBA).Equal(r.C0) {
 				return false
 			}
@@ -977,7 +994,7 @@ func HpksSternFVerify(msg *BitArray, sig *SternSig, seed *BitArray, syndrome *bi
 				return false
 			}
 		default:
-			hysBA := SyndrToBA(n, new(big.Int).Xor(SternSyndrome(seed, r.RespB), syndrome))
+			hysBA := SyndrToBA(n, new(big.Int).Xor(sternSyndromeH(H, r.RespB), syndrome))
 			if !SternHash(1, r.RespA, hysBA).Equal(r.C0) {
 				return false
 			}


### PR DESCRIPTION
## Summary
- Adds `stern_build_H` (C) and `SternBuildH` (Go) that precompute all 128 rows of the parity-check matrix once from a seed
- Adds `stern_syndrome_H` (C) and `sternSyndromeH` (Go) that compute `H·e^T` from the prebuilt matrix (no matrix rebuild)
- `hpks_stern_f_sign` and `hpks_stern_f_verify` in C and Go now call the build function once at entry and reuse H for all per-round syndrome evaluations — **32× → 1× matrix build per call**
- `stern_syndrome` / `SternSyndrome` retained as one-off wrappers (used by keygen and encap which call syndrome once)
- Python already used this pattern (`_stern_build_H` / `_stern_syndrome_H`) — no Python changes needed
- Marks TODO #52 DONE; adds CHANGELOG [1.8.2] entry

## Performance impact
Each H build = 128 rows × 64 NL-FSCX v1 steps = 8 192 PRF evaluations.
Before: sign + verify = ~33 builds = ~270 k PRF evals just for H.
After: 2 builds (one in sign, one in verify) = ~16 k PRF evals for H.

## Test plan
- [ ] C: `./CryptosuiteTests/Herradura_tests_c -r 5` — tests [17] [18] PASS
- [ ] Go: `cd CryptosuiteTests && go run Herradura_tests.go -r 5` — tests [18] [19] PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)