### PR TITLE
Fix KaTeX rendering in SecurityProofs-1.md §10.6 + document \operatorname ban

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,10 @@ Fix: avoid repeating `\command{...}_{...}` across multiple rows.  Use either:
 
 The fix is to **omit spacing commands entirely**.  KaTeX automatically applies correct spacing to binary operators (`+`, `-`, `\oplus`, `=`, `\neq`, `\leq`, etc.) and relation operators without any explicit hints.  For negative spacing before big delimiters (`\bigl`, `\left`), simply omit the spacing command — `F^r\bigl(` renders correctly without `\!` or `\negthinspace`.
 
+### Rule 10 — never use `\operatorname` (blocked by GitHub's KaTeX allowlist)
+
+`\operatorname` is not in GitHub's KaTeX macro allowlist and produces the error "The following macros are not allowed: operatorname".  Use `\text{name}` instead — it renders identically for named operators (rank, ker, im, span, etc.) and is always permitted.
+
 ### Correct patterns
 
 The only pattern that survives both rules is **dashes inside a single `\text{}` block** for compound names, and **explicit subscript syntax** when the visual is genuinely a subscript.
@@ -263,6 +267,7 @@ The only pattern that survives both rules is **dashes inside a single `\text{}` 
 | `$[N, k, t]$-code` (`[` right after `$`) | `$(N, k, t)$-code` (parentheses) or `[N, k, t]-code` (plain text) |
 | `\mathrm{IV}_{\text{const}}` repeated in 2+ rows of `\begin{cases}` | `\text{IV-const}` (no subscript, hyphen in text) |
 | `$$\nexpr\n$$` (standalone `$$` delimiter lines) | `$$expr$$` or `$$first-line\n...\nlast-line$$` |
+| `\operatorname{rank}(\Phi)` | `\text{rank}(\Phi)` — `\operatorname` blocked by GitHub allowlist |
 | `\;` / `\!` / `\,` / `\:` in math | (omit — rely on KaTeX auto-spacing) |
 | `\thickspace` / `\negthinspace` / `\thinspace` / `\medspace` in math | (omit — renders incorrectly on GitHub's KaTeX) |
 | `F^r\!\bigl(` or `F^r\negthinspace\bigl(` | `F^r\bigl(` (no spacing before big delimiter) |

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -953,7 +953,7 @@ By Theorem 11 (§11.1): $E = M^i \cdot P \oplus M \cdot S_i \cdot K$.  Defining 
 
 $$c_K = E \oplus M^i \cdot P$$
 
-One known-plaintext pair $(P, E)$ immediately yields $c_K$.  At $n = 64$, $i = 16$: $\operatorname{rank}(\Phi) = 64$
+One known-plaintext pair $(P, E)$ immediately yields $c_K$.  At $n = 64$, $i = 16$: $\text{rank}(\Phi) = 64$
 (experimentally verified: 0 unconstrained key bits from a single pair), meaning $K$ is uniquely
 determined.  **HSKE provides no security under known-plaintext attack at any $n$.**
 

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -959,12 +959,12 @@ determined.  **HSKE provides no security under known-plaintext attack at any $n$
 
 #### 10.6.2 HPKS — Classical Forgery Resistance
 
-Forgery requires finding $(R^*, s^*)$ satisfying $g^{s^*} \cdot C^{e^*} = R^*$ where
-$e^* = \text{fscx-revolve}(R^*_\text{bits}, P^*, i)$, without knowing the private key $a$.
+Forgery requires finding $(R^{\ast}, s^{\ast})$ satisfying $g^{s^{\ast}} \cdot C^{e^{\ast}} = R^{\ast}$ where
+$e^{\ast} = \text{fscx-revolve}(R^{\ast}_\text{bits}, P^{\ast}, i)$, without knowing the private key $a$.
 
-- If Eve fixes $R^*$ first: she needs $s^* = \log_g(R^* \cdot C^{-e^*})$ — a DLP instance.
-- If Eve fixes $s^*$ first: she can compute $g^{s^*} \cdot C^{e^*}$ for any $e^*$, but the
-  constraint $e^* = \text{fscx-revolve}(R^*_\text{bits}, P^*, i)$ ties $R^*$ and $e^*$
+- If Eve fixes $R^{\ast}$ first: she needs $s^{\ast} = \log_g(R^{\ast} \cdot C^{-e^{\ast}})$ — a DLP instance.
+- If Eve fixes $s^{\ast}$ first: she can compute $g^{s^{\ast}} \cdot C^{e^{\ast}}$ for any $e^{\ast}$, but the
+  constraint $e^{\ast} = \text{fscx-revolve}(R^{\ast}_\text{bits}, P^{\ast}, i)$ ties $R^{\ast}$ and $e^{\ast}$
   together.  Since fscx\_revolve is an affine bijection in its first argument (see §10.7),
   solving both simultaneously reduces to DLP hardness.
 

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -953,7 +953,7 @@ By Theorem 11 (§11.1): $E = M^i \cdot P \oplus M \cdot S_i \cdot K$.  Defining 
 
 $$c_K = E \oplus M^i \cdot P$$
 
-One known-plaintext pair $(P, E)$ immediately yields $c_K$.  At $n = 64$, $i = 16$: rank$(\Phi) = 64$
+One known-plaintext pair $(P, E)$ immediately yields $c_K$.  At $n = 64$, $i = 16$: $\operatorname{rank}(\Phi) = 64$
 (experimentally verified: 0 unconstrained key bits from a single pair), meaning $K$ is uniquely
 determined.  **HSKE provides no security under known-plaintext attack at any $n$.**
 

--- a/TODO.md
+++ b/TODO.md
@@ -3455,3 +3455,46 @@ ba_rol_k(dst, k, KEYBYTES); /* ROL left by n/8 bits (KEYBYTES byte positions) */
 ```
 
 Status: **DONE** — comment corrected at `herradura.h:572`.
+
+---
+
+## KaTeX Math Rendering Fixes
+
+### 57. SecurityProofs-1.md §10.6.2 — `^*` emphasis breakage (Documentation, High)
+
+**File:** `SecurityProofs-1.md`, lines 962–969 (section "10.6.2 HPKS — Classical Forgery Resistance")
+
+**Symptom (screenshot 2026-05-23):** Every math span in §10.6.2 fails to render on GitHub — raw LaTeX-like text leaks into the page (e.g. `R^_\textit{bits}` visible as plain text instead of rendered math).  The section immediately above and below renders correctly.
+
+**Root cause:** CLAUDE.md Rule 4 — "never write `^*` inside a math span."  The two-paragraph block (lines 962–969) contains 8+ bare `*` characters (from `R^*`, `s^*`, `e^*`, `P^*`, `C^{-e^*}`, etc.) in the same paragraph and bullet list.  CommonMark's emphasis parser pairs them across `$...$` boundaries, breaking math-span detection for the entire block.  The `\mathbb{GF}(2^n)^*` on line 971 is fine because its paragraph contains only one `*` with no matching partner.
+
+**Fix:** Replace every `^*` with `^{\ast}` in lines 962–969 only.  `\ast` renders identically to `*` in KaTeX and is invisible to the emphasis parser (the leading `\a` is not an emphasis marker).
+
+**Exact substitutions (14 replacements, 8 unique locations):**
+
+| Line | Original | Replacement |
+|---|---|---|
+| 962 | `(R^*, s^*)` | `(R^{\ast}, s^{\ast})` |
+| 962 | `g^{s^*}` | `g^{s^{\ast}}` |
+| 962 | `C^{e^*}` | `C^{e^{\ast}}` |
+| 962 | `R^*` (standalone) | `R^{\ast}` |
+| 963 | `e^*` | `e^{\ast}` |
+| 963 | `R^*_\text{bits}` | `R^{\ast}_\text{bits}` |
+| 963 | `P^*` | `P^{\ast}` |
+| 965 | `$R^*$` | `$R^{\ast}$` |
+| 965 | `s^* = \log_g(R^* \cdot C^{-e^*})` | `s^{\ast} = \log_g(R^{\ast} \cdot C^{-e^{\ast}})` |
+| 966 | `$s^*$` | `$s^{\ast}$` |
+| 966 | `g^{s^*} \cdot C^{e^*}` | `g^{s^{\ast}} \cdot C^{e^{\ast}}` |
+| 966 | `$e^*$` (end of line) | `$e^{\ast}$` |
+| 967 | `e^* = \text{fscx-revolve}(R^*_\text{bits}, P^*, i)` | `e^{\ast} = \text{fscx-revolve}(R^{\ast}_\text{bits}, P^{\ast}, i)` |
+| 967 | `$R^*$ and $e^*$` | `$R^{\ast}$ and $e^{\ast}$` |
+
+**No other lines need changes.**  Lines outside 962–969 either have no `^*` or have a lone `^*` with no pairing partner in the same paragraph (e.g. line 971 `\mathbb{GF}(2^n)^*`).
+
+**Validation:** After applying the fix, run the KaTeX pipeline validator to confirm zero failures in the affected section:
+```bash
+NODE_PATH=/tmp/katex-validate/node_modules node \
+    SecurityProofsCode/validate_katex.js SecurityProofs-1.md
+```
+
+Status: **DONE** — all 14 `^*` occurrences on lines 962–967 replaced with `^{\ast}`.


### PR DESCRIPTION
## Summary

- **§10.6.2 forgery-resistance paragraph:** 8+ bare `^*` patterns in a single paragraph caused CommonMark's emphasis parser to pair `*` characters across `$...$` boundaries, breaking every math span in the section. Replaced all 14 occurrences of `^*` with `^{\ast}` (Rule 4).
- **§10.6.1 rank formula:** `rank$(\Phi)` placed `$` directly after a non-space character, preventing GitHub from recognising the opening delimiter. Folded `rank` into the math span as `$\text{rank}(\Phi) = 64$` (Rule 6). An intermediate attempt using `\operatorname` was rejected by GitHub's KaTeX allowlist; `\text{}` is the correct substitute.
- **CLAUDE.md:** Added Rule 10 documenting that `\operatorname` is blocked by GitHub's KaTeX macro allowlist, with `\text{name}` as the replacement. Added a corresponding row to the correct-patterns table.

## Test plan

- [x] Open SecurityProofs-1.md on the devtest branch on GitHub and confirm §10.6.1 and §10.6.2 math renders without errors.
- [x] Confirm no "Unable to render expression" or "macros not allowed" messages in the affected paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)