### PR TITLE
Fix §9.2.4 KaTeX rendering + v1.8.4 changelog (TODO #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.8.4] - 2026-05-23
+
+### Documentation — KaTeX rendering fixes in SecurityProofs-1.md (TODO #57, #58)
+
+Fixed math rendering failures in three sections of `SecurityProofs-1.md` caused by
+KaTeX pipeline rule violations.  All other sections were unaffected and untouched.
+
+**§10.6.2 HPKS — Classical Forgery Resistance (TODO #57)**
+
+The forgery-resistance paragraph and bullet list contained 14 bare `^*` patterns
+(`R^*`, `s^*`, `e^*`, `P^*`, `C^{-e^*}`).  CommonMark's emphasis parser paired the
+`*` characters across `$...$` boundaries, breaking every math span in the block.
+Replaced all 14 occurrences with `^{\ast}` (Rule 4).
+
+**§10.6.1 HSKE — rank formula**
+
+`rank$(\Phi) = 64$` placed `$` directly after a non-space character, preventing
+GitHub from recognising the opening math delimiter.  Fixed to `$\text{rank}(\Phi) = 64$`
+(Rule 6).  An intermediate attempt using `\operatorname` was rejected by GitHub's KaTeX
+macro allowlist; `\text{}` is the correct substitute.
+
+**§9.2.4 Security assumption (TODO #58)**
+
+Two paragraphs contained multiple `^*` occurrences that caused the same emphasis-pairing
+breakage:
+- Line 730: three `$\mathbb{GF}(2^n)^*$` in one sentence.
+- Lines 739–744: `$\mathbb{GF}(2^n)^*$` (×3) and `$\mathbb{Z}_p^*$` (×1).
+
+Replaced all 7 occurrences with `^{\ast}` (Rule 4).
+
+**CLAUDE.md — added Rule 10**
+
+Documented that `\operatorname` is blocked by GitHub's KaTeX macro allowlist
+("The following macros are not allowed: operatorname").  Use `\text{name}` instead.
+Added Rule 10 and a corresponding row in the correct-patterns table.
+
+**Files changed:** `SecurityProofs-1.md`, `CLAUDE.md`, `TODO.md`, `CHANGELOG.md`.
+
+---
+
 ## [1.8.3] - 2026-05-22
 
 ### Documentation — Cryptographic concepts primer for general IT/security audience (TODO #56)

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -727,7 +727,7 @@ because $S_{r+1}$ is the $\mathbb{GF}(2)$-linear FSCX partial-sum operator actin
 
 The hardness of HKEX-GF reduces to the **Computational Diffie-Hellman (CDH)** problem in $\mathbb{GF}(2^n)^*$: given $g^a$ and $g^b$, compute $g^{ab}$.
 
-CDH in $\mathbb{GF}(2^n)^*$ is believed hard for large $n$, under the assumption that the Discrete Logarithm Problem (DLP) in $\mathbb{GF}(2^n)^*$ is hard.  Known classical attack complexities on the DLP in $\mathbb{GF}(2^n)^*$:
+CDH in $\mathbb{GF}(2^n)^{\ast}$ is believed hard for large $n$, under the assumption that the Discrete Logarithm Problem (DLP) in $\mathbb{GF}(2^n)^{\ast}$ is hard.  Known classical attack complexities on the DLP in $\mathbb{GF}(2^n)^{\ast}$:
 
 | Algorithm | Complexity | Notes |
 |-----------|------------|-------|
@@ -737,11 +737,11 @@ CDH in $\mathbb{GF}(2^n)^*$ is believed hard for large $n$, under the assumption
 | **Quasi-polynomial (Barbulescu–Joux–Pierrot 2013)** | $(\log 2^n)^{O(\log\log 2^n)}$ | Specific to characteristic-2 fields |
 
 The **quasi-polynomial algorithm** is the dominant classical threat.  It exploits the
-characteristic-2 structure of $\mathbb{GF}(2^n)^*$ via a descent using sparse linear systems in
+characteristic-2 structure of $\mathbb{GF}(2^n)^{\ast}$ via a descent using sparse linear systems in
 function fields — a technique with no known analogue for DLP in prime-order elliptic curve groups
-or in $\mathbb{Z}_p^*$.  In practice it has broken DLP in $\mathbb{GF}(2^{1279})$ and related
-fields.  The recommended minimum for $\mathbb{GF}(2^n)^*$ DLP (if it must be used) is $n \geq 3000$;
-most standards bodies advise **against** using $\mathbb{GF}(2^n)^*$ for new DLP-based designs.
+or in $\mathbb{Z}_p^{\ast}$.  In practice it has broken DLP in $\mathbb{GF}(2^{1279})$ and related
+fields.  The recommended minimum for $\mathbb{GF}(2^n)^{\ast}$ DLP (if it must be used) is $n \geq 3000$;
+most standards bodies advise **against** using $\mathbb{GF}(2^n)^{\ast}$ for new DLP-based designs.
 
 **Experimental verification at $n = 32$ (demo parameters).**
 

--- a/TODO.md
+++ b/TODO.md
@@ -3498,3 +3498,19 @@ NODE_PATH=/tmp/katex-validate/node_modules node \
 ```
 
 Status: **DONE** — all 14 `^*` occurrences on lines 962–967 replaced with `^{\ast}`.
+
+---
+
+### 58. SecurityProofs-1.md §9.2.4 — `^*` emphasis breakage in two paragraphs (Documentation, High)
+
+**File:** `SecurityProofs-1.md`, lines 730 and 739–744 (section "9.2.4 Security assumption")
+
+**Symptom (screenshot 2026-05-23):** Math spans broken in two paragraphs — raw `$...$` delimiters visible as plain text, portions of prose rendered as italic.
+
+**Root cause:** Same Rule 4 violation as TODO #57.
+- Line 730: three `$\mathbb{GF}(2^n)^*$` in one sentence — two `*` pair across math boundaries.
+- Lines 739–744: four `^*` across one paragraph (`\mathbb{GF}(2^n)^*` ×3 and `\mathbb{Z}_p^*` ×1) — two pairs, both break math.
+
+**Fix:** Replaced all 7 occurrences of `^*` with `^{\ast}` on those lines only.
+
+Status: **DONE** — 7 replacements across lines 730 and 739–744; no other lines touched.


### PR DESCRIPTION
## Summary

- **§9.2.4 Security assumption:** Two paragraphs had multiple `^*` patterns causing CommonMark to pair asterisks across math-span boundaries (Rule 4). Fixed 7 occurrences of `^*` → `^{\ast}`: three in the CDH sentence (line 730) and four in the quasi-polynomial paragraph (lines 739–744).
- **CHANGELOG.md:** Added v1.8.4 entry covering all KaTeX fixes since v1.8.3 (§10.6.2, §10.6.1 rank, CLAUDE.md Rule 10, §9.2.4).
- **TODO.md:** Added item #58 documenting the §9.2.4 fix (status: DONE).

## Test plan

- [x] Open SecurityProofs-1.md on devtest branch on GitHub and confirm §9.2.4 math renders without errors (CDH paragraph and quasi-polynomial paragraph).
- [x] Confirm no italic bleed-through or raw `$...$` visible in those paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)