### PR TITLE
Fix documentation consistency across source files and markdown (TODO #62–#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ SecurityProofsCode/                                 — standalone Python proof/
   hkex_cfscx_*.py          — preshared-value, two-step, integer-op, compress/blong constructions
   hkex_classical_break.py  — classical algebraic break proofs
   hkex_*_analysis.py       — FSCX_N, multi-nonce, and nonce-impossibility analyses
-SecurityProofs.md                                   — algebraic analysis (incl. §11 NL/PQC, §12 quantum analysis)
+SecurityProofs.md                                   — split index (redirects to SecurityProofs-1.md §1–§10 and SecurityProofs-2.md §11–§11.9; quantum analysis is in SecurityProofs-1.md §6)
 ```
 
 ## Build Commands

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,7 +4,8 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF)
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.8.8
+    v1.8.7: 32-bit benchmark columns added; N=128 HPKS-Stern-F implemented (TODO #61 extension).
     v1.8.0: KDF domain constant — ba_rnl_kdf_seed replaces ba_rol_k at all HSKE-NL-A1/HKEX-RNL seed sites (TODO #38).
     v1.6.1: stern_hash_ba DS parameter — closes QRO gap for Theorem 17 (TODO #36).
     v1.6.0: stern_hash_ba + stern_hash_64 HFSCX-256 finalizer (TODO #43).
@@ -2179,7 +2180,7 @@ static void test_hske_nl_a2_correctness(void)
    Protocol: one party generates a_rand and transmits it in the clear; both derive
    the shared m_blind = m_base + a_rand and compute their individual public keys
    C = round_p(m_blind · s).  Agreement holds because the ring is commutative:
-   s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs.md. */
+   s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs-2.md. */
 static void test_hkex_rnl_correctness(void)
 {
     static const int rnl_sizes[] = {32, 64, 128, 256};
@@ -4267,7 +4268,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.8.0 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.8.8 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
-/*  Herradura KEx — Security & Performance Tests (Go)
+/*  Herradura KEx — Security & Performance Tests (Go) v1.8.8
+    v1.8.7: 32-bit benchmark columns; benchHpksSternF loops over all sizes (TODO #61 extension).
     v1.8.0: KDF domain constant (TODO #38) — RnlKdfSeed applied to all HSKE-NL-A1 and HKEX-RNL seed sites.
     v1.6.1: SternHash ds parameter (TODO #36).
     v1.5.27: refactored to import package herradura; added HFSCX-256 KAV test [17].
@@ -926,7 +927,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.8.0 — Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.8.8 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python)
+    Herradura KEx — Security & Performance Tests (Python) v1.8.8
+    v1.8.7: 32-bit benchmark columns; bench_hpks_stern_f loops over all sizes (TODO #61 extension).
     v1.8.0: KDF domain constant (TODO #38) — _RNL_KDF_DC_256 applied to all HSKE-NL-A1 and HKEX-RNL seed sites.
     v1.7.3: NumPy NTT acceleration — ~10× speedup on _rnl_poly_mul (TODO #40).
     v1.5.24: HFSCX-256 hash primitive (TODO #26 Phase 1) — KAT, determinism, collision sanity.
@@ -957,7 +958,7 @@ def test_hkex_rnl_correctness():
     # Protocol: one party generates a_rand and transmits it in the clear; both
     # derive the shared m_blind = m_base + a_rand and compute individual public keys
     # C = round_p(m_blind · s).  Agreement holds by ring commutativity:
-    # s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs.md.
+    # s_A·(m_blind·s_B) = s_B·(m_blind·s_A).  See §11.4.2 of SecurityProofs-2.md.
     print("[14] HKEX-RNL key agreement: K_raw_A == K_raw_B / sk_A == sk_B  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; Peikert reconciliation — expect 100% agreement)")
     for n_rnl in RNL_SIZES:
@@ -1361,7 +1362,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.8.0 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.8.8 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.8.0
+/*  Herradura Cryptographic Suite v1.8.8
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -1,4 +1,4 @@
-/*  Herradura Cryptographic Suite v1.8.0
+/*  Herradura Cryptographic Suite v1.8.8
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1,5 +1,5 @@
 '''
-    Herradura Cryptographic Suite v1.8.0
+    Herradura Cryptographic Suite v1.8.8
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -29,7 +29,7 @@
     Adds HPKS-Stern-F (Stern identification + Fiat-Shamir, §11.8.4) and HPKE-Stern-F
     (Niederreiter KEM). Security of HPKS-Stern-F reduces to SD(N,t) [NP-complete,
     BMvT 1978] plus NL-FSCX v1 PRF — the only complete chain to a studied hard
-    problem in the suite (Theorem 17, SecurityProofs.md §11.8.4).
+    problem in the suite (Theorem 17, SecurityProofs-2.md §11.8.4).
     Replaces the GF(2^n)* discrete-log base that Shor's algorithm breaks in HPKS-NL
     and HPKE-NL.  Parameters: N=n, n_rows=n/2, t=n/16 (16 at n=256), SDFR=32 rounds
     (demo; production requires ≥219 for 128-bit soundness).
@@ -242,7 +242,7 @@ I_VALUE = KEYBITS // 4       # 64  for 256-bit
 R_VALUE = 3 * KEYBITS // 4   # 192 for 256-bit
 ORD     = (1 << KEYBITS) - 1  # order of GF(2^n)* (for Schnorr integer arithmetic)
 
-# HKEX-RNL Ring-LWR parameters (see SecurityProofs.md §11.4)
+# HKEX-RNL Ring-LWR parameters (see SecurityProofs-2.md §11.4)
 # q=65537 (Fermat prime, fast arithmetic) gives lower noise-to-margin ratio than
 # q=3329 (Kyber), ensuring reliable single-block agreement at the cost of larger
 # keys.  2-bit Peikert reconciliation doubles extracted bits per coefficient.
@@ -251,7 +251,7 @@ RNLP  = 4096   # public-key rounding modulus
 RNLPP = 4      # reconciliation modulus (2 bits extracted per ring coefficient)
 RNLB  = 1      # centered-binomial eta=1: secret coefficients drawn from CBD(1) in {-1,0,1}
 
-# HPKS-Stern-F / HPKE-Stern-F code-based PQC parameters (SecurityProofs.md §11.8.4)
+# HPKS-Stern-F / HPKE-Stern-F code-based PQC parameters (SecurityProofs-2.md §11.8.4)
 SDFNR = KEYBITS // 2           # parity-check rows (syndrome bits; [N, N/2, t] code, N=KEYBITS)
 SDFT  = max(2, KEYBITS // 16)  # error weight t (= 16 at n=256; ≥ 2 at all widths)
 SDFR  = 32                     # ⚠ DEMO ONLY: Fiat-Shamir rounds (~19-bit soundness).
@@ -1076,7 +1076,7 @@ HPKE (El Gamal + fscx_revolve, linear encryption):
   Break:   DLP recovers a; HSKE sub-protocol has linear key recovery.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-PQC-HARDENED PROTOCOLS (v1.5.0, C3 hybrid — see SecurityProofs.md §11)
+PQC-HARDENED PROTOCOLS (v1.5.0, C3 hybrid — see SecurityProofs-2.md §11)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 HSKE-NL-A1 (counter-mode HSKE with NL-FSCX v1):
@@ -1122,7 +1122,7 @@ HPKE-NL (El Gamal + NL-FSCX v2):
            sub-protocol linear key-recovery attack.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-CODE-BASED PQC PROTOCOLS (v1.5.18 — Theorem 17, SecurityProofs.md §11.8.4)
+CODE-BASED PQC PROTOCOLS (v1.5.18 — Theorem 17, SecurityProofs-2.md §11.8.4)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 HPKS-Stern-F (Stern syndrome-decoding signature — replaces HPKS-NL):

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# HerraduraCli/herradura.py — OpenSSL-style CLI for the Herradura Cryptographic Suite (v1.8.0)
+# HerraduraCli/herradura.py — OpenSSL-style CLI for the Herradura Cryptographic Suite (v1.8.8)
 #
 # Usage examples:
 #   python3 herradura.py genpkey --algo hkex-gf  --bits 256 --out alice.pem

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -1,5 +1,5 @@
 // HerraduraCli/herradura_cli.go — Go CLI for the Herradura Cryptographic Suite
-// v1.8.0
+// v1.8.8
 //
 // Usage:
 //   herradura_cli_go genpkey  --algo hkex-gf  --bits 256 --out alice.pem

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# Herradura Cryptographic Suite (v1.8.3)
+# Herradura Cryptographic Suite (v1.8.8)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 
 > **v1.4.0 note:** The original HKEX key exchange (based directly on FSCX_REVOLVE) was classically broken — the shared secret was directly computable from the two public wire values alone. v1.4.0 replaced it with **HKEX-GF**, a standard Diffie-Hellman construction over the multiplicative group of GF(2^n). See `SecurityProofs-1.md §3` for the formal proof.
 >
 > **v1.5.0 note:** FSCX is GF(2)-linear, making HSKE vulnerable to linear key-recovery attacks, and HKEX-GF is broken by Shor's algorithm. v1.5.0 adds **NL-FSCX** (non-linear extension breaking GF(2)-linearity and orbit periods) and **HKEX-RNL** (Ring-LWR key exchange conjectured quantum-resistant). See `SecurityProofs-1.md §6` (quantum analysis) and `SecurityProofs-2.md §11` (NL/PQC proofs) for analysis.
+>
+> **v1.8.8 note:** `herradura.h` C23/GCC 13+ compatibility fix — `ATOMIC_VAR_INIT` (deprecated in C17, removed in C23) replaced with direct `= 0` initialisation; no API change.
+>
+> **v1.8.7 note:** N=128 `HPKS-Stern-F` implementation in C (`__uint128_t`, T=8, 64 parity-check rows, rounds=8); all benchmark tables now cover all four sizes (32/64/128/256-bit) across C, Go, and Python.
 >
 > **v1.8.3 note:** Comprehensive cryptographic concepts primer (`docs/INTRODUCTION.md`) — plain-language guide to all core concepts (GF(2^n), FSCX, DH, Schnorr, El Gamal, quantum threats, Ring-LWR, Stern ZKP) with toy examples, verified references, and cross-links to TUTORIAL.md and the SecurityProofs documents.
 >
@@ -79,7 +83,7 @@ The suite builds protocols on top of HKEX-GF, FSCX_REVOLVE, and the v1.5.0 NL-FS
 
 **Code-based PQC (v1.5.18):**
 
-10. **HPKS-Stern-F** — Fiat-Shamir Stern ZKP signature (EUF-CMA ≤ SD($n$,$t$) + NL-FSCX v1 PRF): commit $(c_0, c_1, c_2)$; challenge $b \in \{0,1,2\}$ via NL-FSCX hash; response reveals permuted $r$, $y = e \oplus r$, or permutation $\pi$. Parameters (C/Go/Python): $N = n = 256$, $t = 16$, rounds $= 32$. Assembly/Arduino: $N = 32$, $t = 2$, rounds $= 4$.
+10. **HPKS-Stern-F** — Fiat-Shamir Stern ZKP signature (EUF-CMA ≤ SD($n$,$t$) + NL-FSCX v1 PRF): commit $(c_0, c_1, c_2)$; challenge $b \in \{0,1,2\}$ via NL-FSCX hash; response reveals permuted $r$, $y = e \oplus r$, or permutation $\pi$. Parameters (C/Go/Python): $N = n = 256$, $t = 16$, rounds $= 32$ (production default; benchmarks use 4–8 rounds for throughput measurement). Assembly/Arduino: $N = 32$, $t = 2$, rounds $= 4$.
 11. **HPKE-Stern-F** — Niederreiter KEM: $\mathit{ct} = H \cdot e'^T$; $K = \text{hash}(\mathit{seed}, e')$. Production decap requires a QC-MDPC syndrome decoder; demo uses known $e'$.
 
 Implementations are provided in C, Go, Python, ARM Thumb-2 assembly, NASM i386 assembly, and Arduino (all six targets at v1.5.19).
@@ -152,7 +156,7 @@ arduino-cli compile --fqbn arduino:avr:uno CryptosuiteTests/Herradura_tests.ino
 
 ---
 
-# Performance (v1.8.3, Orange Pi 5 — RK3588, Cortex-A76 @ 2.4 GHz)
+# Performance (v1.8.8, Orange Pi 5 — RK3588, Cortex-A76 @ 2.4 GHz)
 
 Benchmarks from `CryptosuiteTests/Herradura_tests.{c,go,py}` with `-t 1.5`.
 Columns correspond to operand bit-width; for HKEX-RNL the column header is the ring degree $n$.

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -1,7 +1,7 @@
 # Formal Cryptographic Analysis of the Herradura Cryptographic Suite
 
-**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §12 (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §12.5 NL-protocol rows added in v1.5.1.  HKEX-RNL secret sampler upgraded to CBD(eta=1) in v1.5.3 (§11.4.2, §11.6).  HKEX-RNL polynomial multiplication replaced with negacyclic NTT over $\mathbb{Z}_{65537}$ in v1.5.4 (O(n log n), ~32× speedup at n=256).  Peikert 1-bit reconciliation deployed in v1.5.16 (§11.4.2, §11.6) — HKEX-RNL correctness now guaranteed.
-**Last updated:** 2026-04-25 (v1.5.16)
+**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §6 (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §6 NL-protocol rows added in v1.5.1.  HKEX-RNL secret sampler upgraded to CBD(eta=1) in v1.5.3 (§11.4.2, §11.6).  HKEX-RNL polynomial multiplication replaced with negacyclic NTT over $\mathbb{Z}_{65537}$ in v1.5.4 (O(n log n), ~32× speedup at n=256).  Peikert 1-bit reconciliation deployed in v1.5.16 (§11.4.2, §11.6) — HKEX-RNL correctness now guaranteed.  HFSCX-256 Merkle-Damgård hash finalizer added to stern_hash in v1.6.0 (§11.9); domain-separation parameter added in v1.6.1 (§11.8.4, Theorem 17).  KDF domain constant `_RNL_KDF_DC` added in v1.8.0.  stern_gen_perm PRNG bias eliminated in v1.8.1; H-matrix precomputed once per sign/verify in v1.8.2.  N=128 HPKS-Stern-F implemented in v1.8.7.
+**Last updated:** 2026-05-25 (v1.8.8)
 
 ---
 

--- a/SecurityProofs-2.md
+++ b/SecurityProofs-2.md
@@ -192,6 +192,7 @@ The centered $\ell_1$-norm of $m^{-1}(x)$ scales as $\|m^{-1}\|_1 \approx n \cdo
 Both use the **same** $m_\text{blind}$.  ($\lfloor \cdot \rceil_p$ denotes rounding from $\mathbb{Z}/q\mathbb{Z}$ to $\mathbb{Z}/p\mathbb{Z}$.)  $\mathrm{CBD}(\eta)$ is the centered binomial distribution: each coefficient $s_i = \sum_{j=0}^{\eta-1}(a_j - b_j)$ where $a_j, b_j \xleftarrow{R} \{0,1\}$ independently.  Deployed with $\eta = 1$, giving $s_i \in \{-1, 0, 1\}$ with zero mean and $\Pr[s_i = \pm 1] = 1/4$.  This matches the Kyber/NIST baseline for proper Ring-LWR secret entropy and eliminates the mean bias of the previous uniform $\{0,1\}$ sampler.
 
 **Key agreement:**
+
 $$K_A = \left\lfloor s_A \cdot C_B \right\rceil_{p'} \approx s_A \cdot m_\text{blind} \cdot s_B \in \mathcal R_q$$
 $$K_B = \left\lfloor s_B \cdot C_A \right\rceil_{p'} \approx s_B \cdot m_\text{blind} \cdot s_A \in \mathcal R_q$$
 
@@ -679,15 +680,19 @@ This section formalises the security claims, identifies one residual hardening o
 Let $n = 256$, block size $b = 32$ bytes.  Write $F_1^r(s, m)$ for NL-FSCX v1 iterated $r$ times with state $s$ and message-block parameter $m$.  HFSCX-256 takes input bytes $D$ and an optional 256-bit key $K$; it produces a 256-bit digest as follows.
 
 **Compression function.**
+
 $$C(s, m) = F_1^{64}(s, m) \in \{0,1\}^{256}.$$
 
 **Initial state.**  Let $\text{IV-const}$ be the 32-byte ASCII constant `HFSCX-256/HERRADURA-SUITE\0\0\0\0\0\0\0` interpreted as a 256-bit integer.  Define
+
 $$s_0 = \begin{cases} \text{IV-const} & \text{(unkeyed)} \cr K \oplus \text{IV-const} & \text{(keyed MAC mode)} \end{cases}$$
 
 **Padding (ISO 7816-4 + finalization).**  Append `0x80` to $D$; zero-fill to a multiple of $b$; append a 32-byte finalization block $\mathit{fin}$:
+
 $$\mathit{fin} = \bigl(8 \cdot |D|\bigr) \oplus s_0 \pmod{2^{256}}.$$
 
 **Iteration.**  For padded message $D' = m_1 \| m_2 \| \cdots \| m_k$ (where the last block is $\mathit{fin}$):
+
 $$s_i = C(s_{i-1}, m_i), \qquad i = 1, \ldots, k.$$
 
 **Output.**  $\text{HFSCX-256}(D, K) = s_k$.
@@ -701,6 +706,7 @@ The security claims for HFSCX-256 are conditional on assumptions already used el
 **A2 (NL-FSCX v1 OWF, §11.8.3, Theorem 16).**  Given $y = F_1^{64}(s, m)$ for known $m$ and unknown $s$, recovering $s$ requires $\Omega(2^{n/2}) = \Omega(2^{128})$ classical operations and $\Omega(2^{n/2})$ quantum queries (Grover lower bound, supported by Theorem 13's degree-saturation argument and Corollary 2's Gröbner-immunity result).
 
 **A3 (Symmetric structure).**  $F_1(A, B) = F_1(B, A)$, since
+
 $$F_1(A, B) = M(A \oplus B) \oplus \mathrm{ROL}_{n/4}\bigl((A + B) \bmod 2^n\bigr)$$
 is symmetric under the swap $A \leftrightarrow B$.  Consequently, NL-FSCX v1 is non-bijective in $B$ as well as in $A$ (§11.5 Q3, by symmetry); $C(\cdot, m)$ is non-bijective in either input.
 
@@ -739,6 +745,7 @@ HFSCX-256's finalization block makes the published digest $s_k = C(s_{k-1}, \mat
 HFSCX-256 supports a keyed mode by setting $s_0 = K \oplus \text{IV-const}$.  This mode is used by `HerraduraCli` for the `HSKE-NL-A1-CTR-AEAD` authentication tag.  Two MAC constructions are evaluated.
 
 **(a) Raw keyed-IV MAC (deployed).**
+
 $$\mathrm{MAC}(K, D) = \text{HFSCX-256}(D, K).$$
 
 *Properties.*  Under A1, HFSCX-256 with secret IV is a PRF: the chain state at every step is unpredictable to an adversary without $K$.  EUF-CMA security follows from the PRF property by standard arguments [Bellare-Canetti-Krawczyk 1996, §3.2].
@@ -746,6 +753,7 @@ $$\mathrm{MAC}(K, D) = \text{HFSCX-256}(D, K).$$
 *Caveat.*  The security claim applies A1 to the entire chain.  If A1 holds for one $F_1^{64}$ application but degrades when chained over many blocks, the raw keyed-IV MAC weakens.  Empirical avalanche tests (§11.9.10 §2) show ideal key-bit diffusion (mean 128.09 / 256 output bits flipped, σ = 7.98) for the deployed parameters, but this is a sanity check, not a chain-length proof.
 
 **(b) HMAC-HFSCX-256 (recommended for cross-protocol key reuse).**
+
 $$\mathrm{HMAC}(K, D) = \text{HFSCX-256}\Bigl(\bigl(K \oplus \mathit{opad}\bigr) \| \text{HFSCX-256}\bigl((K \oplus \mathit{ipad}) \| D\bigr)\Bigr)$$
 
 with $\mathit{ipad} = \mathtt{0x36}$ repeated and $\mathit{opad} = \mathtt{0x5C}$ repeated, each 32 bytes.
@@ -777,6 +785,7 @@ The AEAD tag uses a distinct effective IV via the per-session key.  Cross-flow c
 ### 11.9.8 Davies-Meyer hardening (future work)
 
 The deployed compression $C(s, m) = F_1^{64}(s, m)$ does not use a Davies-Meyer feed-forward.  The Davies-Meyer alternative is
+
 $$C_{\text{DM}}(s, m) = F_1^{64}(s, m) \oplus s.$$
 
 **Benefits of switching.**

--- a/SecurityProofs-2.md
+++ b/SecurityProofs-2.md
@@ -682,7 +682,7 @@ Let $n = 256$, block size $b = 32$ bytes.  Write $F_1^r(s, m)$ for NL-FSCX v1 it
 $$C(s, m) = F_1^{64}(s, m) \in \{0,1\}^{256}.$$
 
 **Initial state.**  Let $\text{IV-const}$ be the 32-byte ASCII constant `HFSCX-256/HERRADURA-SUITE\0\0\0\0\0\0\0` interpreted as a 256-bit integer.  Define
-$$s_0 = \begin{cases} \text{IV-const} & \text{(unkeyed)} \\ K \oplus \text{IV-const} & \text{(keyed MAC mode)} \end{cases}$$
+$$s_0 = \begin{cases} \text{IV-const} & \text{(unkeyed)} \cr K \oplus \text{IV-const} & \text{(keyed MAC mode)} \end{cases}$$
 
 **Padding (ISO 7816-4 + finalization).**  Append `0x80` to $D$; zero-fill to a multiple of $b$; append a 32-byte finalization block $\mathit{fin}$:
 $$\mathit{fin} = \bigl(8 \cdot |D|\bigr) \oplus s_0 \pmod{2^{256}}.$$

--- a/SecurityProofs.md
+++ b/SecurityProofs.md
@@ -1,7 +1,7 @@
 # Formal Cryptographic Analysis of the Herradura Cryptographic Suite
 
-**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §12 (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §12.5 NL-protocol rows added in v1.5.1.  HKEX-RNL secret sampler upgraded to CBD(eta=1) in v1.5.3 (§11.4.2, §11.6).  HKEX-RNL polynomial multiplication replaced with negacyclic NTT over $\mathbb{Z}_{65537}$ in v1.5.4 (O(n log n), ~32× speedup at n=256).  Peikert 1-bit reconciliation deployed in v1.5.16 (§11.4.2, §11.6) — HKEX-RNL correctness now guaranteed.
-**Last updated:** 2026-04-25 (v1.5.16)
+**Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §6 of SecurityProofs-1.md (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §6 NL-protocol rows added in v1.5.1.  HKEX-RNL secret sampler upgraded to CBD(eta=1) in v1.5.3 (§11.4.2, §11.6).  HKEX-RNL polynomial multiplication replaced with negacyclic NTT over $\mathbb{Z}_{65537}$ in v1.5.4 (O(n log n), ~32× speedup at n=256).  Peikert 1-bit reconciliation deployed in v1.5.16 (§11.4.2, §11.6) — HKEX-RNL correctness now guaranteed.  HFSCX-256 finalizer added to stern_hash in v1.6.0; domain-separation parameter added in v1.6.1.  KDF domain constant added in v1.8.0.  N=128 HPKS-Stern-F implemented in v1.8.7.
+**Last updated:** 2026-05-25 (v1.8.8)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -3597,3 +3597,131 @@ Several benchmark rows still have `—` in the 64-bit, 128-bit, or 256-bit colum
 3. C — add multi-size benchmark loops; restructure C table; run benchmarks; update README C table.
 
 Status: **DONE** — Python/Go/C benchmarks extended to 64/128/256-bit; README tables restructured to 4-column format (32/64/128/256-bit).
+
+---
+
+### 62. README.md version header stale — v1.8.3 should be v1.8.8 (Documentation, Trivial)
+
+**Files:** `README.md`, lines 1 and 155.
+
+**Current state:**
+- Line 1: `# Herradura Cryptographic Suite (v1.8.3)`
+- Line 155: `# Performance (v1.8.3, Orange Pi 5 — RK3588, Cortex-A76 @ 2.4 GHz)`
+
+**Required:** Update both occurrences to `v1.8.8` (the current CHANGELOG version).
+
+**Also:** Add callout notes for v1.8.4–v1.8.8 under the existing `> **v1.8.3 note:**` block.
+Significant functional/compatibility changes worth noting:
+- v1.8.4–v1.8.6: KaTeX rendering fixes in SecurityProofs docs (documentation only; no API change).
+- v1.8.7: N=128 `HPKS-Stern-F` implementation in C; all benchmark tables now cover all four sizes (32/64/128/256-bit).
+- v1.8.8: `ATOMIC_VAR_INIT` removed from `herradura.h` for C23/GCC 13+ compatibility.
+
+**Fix:**
+1. Replace `(v1.8.3)` with `(v1.8.8)` in line 1.
+2. Replace `v1.8.3,` with `v1.8.8,` in line 155.
+3. Insert callout notes for v1.8.7 and v1.8.8 (the most functionally relevant releases after v1.8.3) above the `> **v1.8.3 note:**` line, following the existing note style.
+
+Status: **DONE** — title updated to v1.8.8, performance section updated to v1.8.8, v1.8.7 and v1.8.8 callout notes added.
+
+---
+
+### 63. Source file version headers stale — all say v1.8.0, should be v1.8.8 (Documentation, Trivial)
+
+**Root cause:** The source file header comments record the last version in which each file was substantially changed.  `herradura.h` and `herradura/herradura.go` were last updated in v1.8.0 (KDF domain constant), and the suite/test files were not touched in v1.8.1–v1.8.8 except for benchmark extensions in v1.8.7 and ATOMIC_VAR_INIT in v1.8.8.  The banner version in each file should track to the current release so that `grep v1.` gives a meaningful history.
+
+**Files and current version strings:**
+- `Herradura cryptographic suite.c` line 1: `v1.8.0`
+- `Herradura cryptographic suite.go` line 1: `v1.8.0`
+- `Herradura cryptographic suite.py` line 2: `v1.8.0`
+- `herradura.h` line 1: `v1.8.0` (needs v1.8.8 — `ATOMIC_VAR_INIT` fix)
+- `herradura/herradura.go` line 1: `v1.8.0`
+- `CryptosuiteTests/Herradura_tests.c` line 8 banner string: `v1.8.0` (also the `printf` on line 4270)
+- `CryptosuiteTests/Herradura_tests.go` line 2: `v1.8.0`
+- `CryptosuiteTests/Herradura_tests.py` line 2: `v1.8.0`
+
+**Fix per file:**
+- `herradura.h`: add `v1.8.8: ATOMIC_VAR_INIT removed (C23/GCC 13+ compatibility).` at top of changelog block; update header version to `v1.8.8`.
+- `CryptosuiteTests/Herradura_tests.c`: add `v1.8.7: 32-bit benchmark columns; N=128 HPKS-Stern-F (TODO #61 extension).`; update header version.
+- `CryptosuiteTests/Herradura_tests.go` and `.py`: add `v1.8.7: 32-bit benchmark columns extended.` entry.
+- Remaining files with no functional changes in v1.8.1–v1.8.8: update header version string only (no new changelog entry needed).
+
+Status: **DONE** — version strings updated to v1.8.8 in all 8 files; herradura.h and test files received new changelog entries.
+
+---
+
+### 64. Stale `SecurityProofs.md` references in source files — should point to split files (Documentation, Low)
+
+**Background:** The monolithic `SecurityProofs.md` was split into `SecurityProofs-1.md` (§1–§10) and `SecurityProofs-2.md` (§11–§11.9) to avoid GitHub's ~750 math-expression rendering limit.  `SecurityProofs.md` now serves only as a redirect index.  All §11.x section references in source-code comments should point directly to `SecurityProofs-2.md`; §11.4.2 references should also be updated.
+
+**Affected locations (9 occurrences):**
+
+| File | Line | Current reference | Corrected reference |
+|------|------|-------------------|---------------------|
+| `herradura.h` | 922 | `SecurityProofs.md §11.8.4` | `SecurityProofs-2.md §11.8.4` |
+| `Herradura cryptographic suite.py` | 32 | `SecurityProofs.md §11.8.4` | `SecurityProofs-2.md §11.8.4` |
+| `Herradura cryptographic suite.py` | 245 | `SecurityProofs.md §11.4` | `SecurityProofs-2.md §11.4` |
+| `Herradura cryptographic suite.py` | 254 | `SecurityProofs.md §11.8.4` | `SecurityProofs-2.md §11.8.4` |
+| `Herradura cryptographic suite.py` | 1079 | `SecurityProofs.md §11` | `SecurityProofs-2.md §11` |
+| `Herradura cryptographic suite.py` | 1125 | `SecurityProofs.md §11.8.4` | `SecurityProofs-2.md §11.8.4` |
+| `CryptosuiteTests/Herradura_tests.py` | 960 | `SecurityProofs.md §11.4.2` | `SecurityProofs-2.md §11.4.2` |
+| `herradura/herradura.go` | 451 | `SecurityProofs.md §11.4` | `SecurityProofs-2.md §11.4` |
+| `CryptosuiteTests/Herradura_tests.c` | 2182 | `SecurityProofs.md §11.4.2` | `SecurityProofs-2.md §11.4.2` |
+
+**Fix:** Simple text replacement in each file.  No logic changes.
+
+Status: **DONE** — all 9 occurrences updated; no remaining `SecurityProofs.md` references in source files.
+
+---
+
+### 65. Stale §12 references — quantum analysis is in SecurityProofs-1.md §6 (Documentation, Low)
+
+**Background:** When the SecurityProofs document was restructured, the old §12 "Quantum Attack Analysis" was renumbered to §6 in `SecurityProofs-1.md`.  Several documents still reference the non-existent §12.
+
+**Affected locations:**
+
+| File | Line | Current reference | Corrected reference |
+|------|------|-------------------|---------------------|
+| `SecurityProofs-1.md` | 3 | `§12 (merged from PQCanalysis.md…)`, `§12.5 NL-protocol rows` | `§6 (merged from PQCanalysis.md…)`, `§6.5 NL-protocol rows` |
+| `SecurityProofs.md` | 3 | same as above (identical status block) | same correction |
+| `CLAUDE.md` | 23 | `§12 quantum analysis` in repo structure table | `§6 quantum analysis` (in SecurityProofs-1.md) |
+| `docs/INTRODUCTION.md` | 654 | `→ SP2 §12 for a detailed quantum algorithm analysis` | `→ SP1 §6 for a detailed quantum algorithm analysis` |
+
+**Fix:**
+- `SecurityProofs-1.md` line 3: replace `§12` with `§6` and `§12.5` with `§6.5` in the status paragraph.
+- `SecurityProofs.md` line 3: same replacement.
+- `CLAUDE.md` line 23: replace `§12 quantum analysis` with `§6 quantum analysis (SecurityProofs-1.md)`.
+- `docs/INTRODUCTION.md` line 654: replace `SP2 §12` with `SP1 §6`.
+
+**Note:** Also verify that `SecurityProofs-1.md` §6.5 exists (or that §6 contains the NL-protocol rows that were in §12.5), and adjust if the sub-section numbering differs.
+
+Status: **DONE** — §6 has no sub-sections so `§12.5` was simplified to `§6`; all four files updated; no remaining §12 references in markdown files.
+
+---
+
+### 66. README HPKS-Stern-F parameter note — benchmark rounds vs. suite default rounds unclear (Documentation, Low)
+
+**File:** `README.md`, line 82 and benchmark rows (lines 176, 192, 208).
+
+**Issue:** Line 82 states "Parameters (C/Go/Python): $N = n = 256$, $t = 16$, rounds $= 32$."  This correctly describes the suite default (`SDF_ROUNDS = 32` in `herradura.h`).  However, the C benchmark row (line 176) is labelled `(N=n, rounds=8)` and the Go/Python rows (lines 192, 208) are labelled `(N=n, rounds=4)`, since the test suite uses reduced rounds for throughput measurement.  A reader who notices the mismatch between the `rounds = 32` in the protocol description and `rounds=8`/`rounds=4` in the benchmark labels may be confused.
+
+**Fix:** Add a parenthetical clarification on line 82 after the rounds parameter, e.g.:
+
+> rounds $= 32$ (suite default; benchmarks use reduced rounds for throughput measurement)
+
+Alternatively, add a footnote below the benchmark tables noting that reduced rounds are used for measurement speed.
+
+Status: **DONE** — parenthetical "(production default; benchmarks use 4–8 rounds for throughput measurement)" added after `rounds = 32` in the HPKS-Stern-F protocol description.
+
+---
+
+### 67. SecurityProofs-1.md/SecurityProofs.md status header is 14 months stale (Documentation, Low)
+
+**Files:** `SecurityProofs-1.md` line 4, `SecurityProofs.md` line 4.
+
+**Current state:** `**Last updated:** 2026-04-25 (v1.5.16)`
+
+**Issue:** The status block was last updated in April 2026 at v1.5.16.  The suite is now at v1.8.8 (May 2026) with significant additions: v1.6.0 HFSCX-256 finalizer, v1.6.1 domain separation, v1.7.3 NumPy acceleration, v1.8.0 KDF domain constant, v1.8.1 permutation bias fix, v1.8.2 H-matrix precomputation, v1.8.7 N=128 Stern-F.  None of these are reflected in the status paragraph.
+
+**Fix:** Update the `**Last updated:**` line to `2026-05-25 (v1.8.8)` and append the major milestones since v1.5.16 to the status paragraph.
+
+Status: **DONE** — status paragraph updated with v1.6.0–v1.8.7 milestones; "Last updated" bumped to 2026-05-25 (v1.8.8) in both SecurityProofs-1.md and SecurityProofs.md.

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -651,7 +651,7 @@ adds HKEX-RNL and the Stern protocols.
 Post-Quantum Cryptography Standardization Process," 2022.
 [(NIST IR 8413)](https://doi.org/10.6028/NIST.IR.8413-upd1)
 
-→ SP2 §12 for a detailed quantum algorithm analysis of each Herradura protocol.
+→ SP1 §6 for a detailed quantum algorithm analysis of each Herradura protocol.
 
 ---
 

--- a/herradura.h
+++ b/herradura.h
@@ -1,4 +1,5 @@
-/*  herradura.h — Herradura Cryptographic Suite, header-only shared library
+/*  herradura.h — Herradura Cryptographic Suite, header-only shared library v1.8.8
+    v1.8.8: ATOMIC_VAR_INIT removed — direct = 0 init for C23/GCC 13+ compatibility.
     v1.8.0: KDF domain constant — ba_rnl_kdf_seed: ROL(k,n/8) XOR _RNL_KDF_DC (TODO #38).
     v1.6.1: stern_hash DS parameter — closes QRO gap for Theorem 17 (TODO #36).
     v1.6.0: stern_hash HFSCX-256 finalizer — eliminates range compression (TODO #43).
@@ -919,7 +920,7 @@ static void rnl_agree(BitArray *out, const int32_t s[RNL_N],
 /* ─────────────────────────────────────────────────────────────────────────────
  * CODE-BASED PQC: HPKS-Stern-F / HPKE-Stern-F  (v1.5.18)
  * Stern 3-challenge ZKP + Fiat-Shamir in QROM.
- * Security: EUF-CMA <= q_H/T_SD + eps_PRF  (Theorem 17, SecurityProofs.md §11.8.4).
+ * Security: EUF-CMA <= q_H/T_SD + eps_PRF  (Theorem 17, SecurityProofs-2.md §11.8.4).
  * N=KEYBITS=256, n_rows=128, t=16, rounds=32  (production: >=219).
  * ───────────────────────────────────────────────────────────────────────────── */
 

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -1,4 +1,4 @@
-/*  package herradura — Herradura Cryptographic Suite shared library
+/*  package herradura — Herradura Cryptographic Suite shared library v1.8.8
     v1.8.0: KDF domain constant — RnlKdfSeed: ROL(k,n/8) XOR RnlKdfDC (TODO #38).
     v1.6.1: SternHash ds parameter — closes QRO gap for Theorem 17 (TODO #36).
     v1.6.0: SternHash HFSCX-256 finalizer — eliminates range compression (TODO #43).
@@ -448,7 +448,7 @@ func HskeNla1MacKey(seed, base *BitArray) *BitArray {
 // HKEX-RNL ring-arithmetic helpers (negacyclic Z_q[x]/(x^n+1))
 // ---------------------------------------------------------------------------
 
-// RNL protocol parameters (see SecurityProofs.md §11.4).
+// RNL protocol parameters (see SecurityProofs-2.md §11.4).
 const (
 	RnlQ   = 65537 // Fermat prime (2^16+1)
 	RnlP   = 4096  // public-key rounding modulus


### PR DESCRIPTION
## Summary

- **#62** — README title and performance section bumped from v1.8.3 to v1.8.8; v1.8.7 and v1.8.8 callout notes added.
- **#63** — Version headers updated to v1.8.8 in all 10 source/CLI files; `herradura.h` and test files received new changelog entries; `Herradura_tests.c/go/py` print banners updated.
- **#64** — 9 stale `SecurityProofs.md` references in source-code comments updated to point directly to `SecurityProofs-2.md` for §11.x sections.
- **#65** — §12 references (quantum analysis) corrected to §6 in `SecurityProofs-1.md`, `SecurityProofs.md`, `CLAUDE.md`, and `docs/INTRODUCTION.md`.
- **#66** — HPKS-Stern-F `rounds = 32` clarified as production default; benchmark reduced-round note added.
- **#67** — `SecurityProofs-1.md` and `SecurityProofs.md` status header extended with v1.6.0–v1.8.7 milestones; "Last updated" bumped to 2026-05-26 (v1.8.8).
- **KaTeX fix (§11.9.1 `s_0` block)** — `\\` → `\cr` in `\begin{cases}` row separator (Rule 9: CommonMark resolves `\\` → `\` before KaTeX).
- **KaTeX fix (Rule 5 — 9 blocks)** — Added missing blank lines before `$$` display blocks that followed prose directly in `SecurityProofs-2.md`. Affected: §11.4.2 Key agreement, §11.9.1 Compression/Initial state/Padding/Iteration, §11.9.2 A3 Symmetric structure, §11.9.4 MAC/HMAC, §11.9.5 Davies-Meyer alternative.

## Test plan

- [ ] Verify README renders correctly on GitHub (version header, callout notes, benchmark table)
- [ ] Verify `SecurityProofs-2.md §11.9.1` — `s_0` cases block renders both rows correctly
- [ ] Verify `SecurityProofs-2.md §11.4.2` — `K_A` / `K_B` key-agreement formulas render
- [ ] Verify `SecurityProofs-2.md §11.9.4` — MAC and HMAC formulas render
- [ ] Verify `SecurityProofs-1.md` status paragraph renders without KaTeX errors
- [ ] Confirm no remaining `SecurityProofs.md` (monolithic) references in source files
- [ ] Confirm no remaining `§12` references in markdown
- [ ] Build and run test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)