### PR TITLE
Add HFSCX-256 KDF to kex CLI and hash demo to suite files (TODO #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.8.9] - 2026-05-26
+
+### Feature — HFSCX-256 KDF for `kex` and hash demo in suite programs (TODO #68)
+
+**`--kdf hfscx-256` flag added to `kex` subcommand** (all three CLIs: C `herradura_cli.c`, Go `herradura_cli.go`, Python `herradura.py`).
+
+When `--kdf hfscx-256` is specified, the raw shared secret is post-hashed through HFSCX-256 before being written to the SESSION KEY PEM.  This applies to both HKEX-GF (the raw $g^{ab}$ field element) and HKEX-RNL (the Ring-LWR reconciliation value, after the LSB→MSB reversal that converts it to canonical big-endian form).  The KDF produces a uniformly distributed 256-bit key and removes the algebraic structure present in raw GF($2^n$) DH values.
+
+Both parties must supply `--kdf hfscx-256` to derive the same final key.
+
+**HFSCX-256 demo block added to all three suite `main()` programs** (`Herradura cryptographic suite.c`, `.go`, `.py`).
+
+A new protocol block inserted after the HPKE-Stern-F demonstration (before the Eve bypass tests) shows the hash primitive in action:
+
+- Bare digest of `"HFSCX-256 test vector"` — deterministic cross-language value `fd84942b119b4cd7b7697e27db7c611b14b192f5fd67fd1ce4c76a3b0abf3d3d`.
+- Keyed digest using `preshared XOR _HFSCX256_IV` as the MAC key.
+- Confirmation that the two digests differ and that the output is 32 bytes.
+
+**Side fixes (pre-existing bugs corrected as part of this work):**
+
+- **Python hint encoding bug (`HerraduraCli/herradura.py`):** `_encode_rnl_response` packed the 2-bit Peikert hint coefficients at 1-bit offsets (`hint_int |= b << i`, `hint_nb = (len(hint)+7)//8`), causing `OverflowError` when any hint value was 2 or 3 at the last coefficient position, and producing an inconsistent round-trip (decoder read only 1 bit/coeff).  Fixed to 2 bits per coefficient: `(b & 3) << (2 * i)`, `hint_nb = (2 * len(hint) + 7) // 8`, decoder `(hint_int >> (2 * i)) & 3`.  This also resolved the pre-existing HKEX-RNL cross-party test failure in `CliTest/test_encrypt.sh`.
+- **Missing re-export in `HerraduraCli/primitives.py`:** `_RNL_KDF_DC_256` was imported by `herradura.py` but never re-exported from `primitives.py`; added `_RNL_KDF_DC_256 = _s._RNL_KDF_DC_256`.
+
+All 79 CLI tests pass (7 suites, 0 FAIL) after these changes.
+
+**Files changed:** `Herradura cryptographic suite.c`, `Herradura cryptographic suite.go`, `Herradura cryptographic suite.py`, `HerraduraCli/herradura_cli.c`, `HerraduraCli/herradura_cli.go`, `HerraduraCli/herradura.py`, `HerraduraCli/primitives.py`, `TODO.md`, `CHANGELOG.md`, `README.md`.
+
+---
+
 ## [1.8.8] - 2026-05-24
 
 ### Fix — Remove deprecated `ATOMIC_VAR_INIT` (C23 compatibility, Armbian/GCC 13+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ SecurityProofsCode/                                 — standalone Python proof/
 SecurityProofs.md                                   — split index (redirects to SecurityProofs-1.md §1–§10 and SecurityProofs-2.md §11–§11.9; quantum analysis is in SecurityProofs-1.md §6)
 ```
 
+## Changelog and README Policy
+
+All notable changes are documented in `CHANGELOG.md` only.  Do **not** add version notes, release blurbs, or change summaries to `README.md`.  The README describes the current state of the project; the CHANGELOG tracks its history.  When a feature or fix is completed, add a new versioned entry to `CHANGELOG.md` and update the version number in the `README.md` title line — nothing else.
+
 ## Build Commands
 
 ### C

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -510,6 +510,30 @@ int main(void)
             puts("- HPKE-Stern-F key agreement FAILED (N=256)");
     }
 
+    /* --- HFSCX-256 [HASH -- Merkle-Damgård over NL-FSCX v1; 256-bit output] */
+    printf("\n--- HFSCX-256 [HASH \xe2\x80\x94 Merkle-Damg\xc3\xa5rd over NL-FSCX v1; 256-bit output]\n");
+    {
+        static const uint8_t tv[] = "HFSCX-256 test vector";
+        uint8_t bare_out[32], keyed_out[32], mac_iv[32];
+        int i, same;
+        hfscx_256(tv, sizeof(tv) - 1, NULL, bare_out);
+        /* Keyed MAC: iv = preshared XOR _HFSCX256_IV */
+        for (i = 0; i < 32; i++) mac_iv[i] = preshared.b[i] ^ _HFSCX256_IV[i];
+        hfscx_256(tv, sizeof(tv) - 1, mac_iv, keyed_out);
+        printf("digest (bare)  : ");
+        for (i = 0; i < 32; i++) printf("%02x", bare_out[i]);
+        putchar('\n');
+        printf("digest (keyed) : ");
+        for (i = 0; i < 32; i++) printf("%02x", keyed_out[i]);
+        putchar('\n');
+        printf("+ hash length correct (%d bytes)\n", (int)sizeof(bare_out));
+        same = 1;
+        for (i = 0; i < 32; i++) if (bare_out[i] != keyed_out[i]) { same = 0; break; }
+        puts(same ? "- keyed == bare (unexpected!)" :
+                    "+ keyed \xe2\x89\xa0 bare (key influences output)");
+        explicit_bzero(mac_iv, sizeof(mac_iv));
+    }
+
     /* *** EVE bypass TESTS *** */
     printf("\n\n*** EVE bypass TESTS\n");
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -249,6 +249,35 @@ func main() {
 		fmt.Println("- HPKE-Stern-F key agreement FAILED")
 	}
 
+	// ── HFSCX-256 ───────────────────────────────────────────────────────────
+	fmt.Println("\n--- HFSCX-256 [HASH — Merkle-Damgård over NL-FSCX v1; 256-bit output]")
+	{
+		tv := []byte("HFSCX-256 test vector")
+		bareOut := Hfscx256(tv, nil)
+		// Keyed MAC: iv = preshared XOR Hfscx256IV
+		presBytes := preshared.Bytes() // 32 bytes big-endian
+		macIV := make([]byte, 32)
+		for i := range macIV {
+			macIV[i] = presBytes[i] ^ Hfscx256IV[i]
+		}
+		keyedOut := Hfscx256(tv, macIV)
+		fmt.Printf("digest (bare)  : %x\n", bareOut)
+		fmt.Printf("digest (keyed) : %x\n", keyedOut)
+		fmt.Printf("+ hash length correct (%d bytes)\n", len(bareOut))
+		same := true
+		for i := range bareOut {
+			if bareOut[i] != keyedOut[i] {
+				same = false
+				break
+			}
+		}
+		if !same {
+			fmt.Println("+ keyed ≠ bare (key influences output)")
+		} else {
+			fmt.Println("- keyed == bare (unexpected!)")
+		}
+	}
+
 	// ── Eve bypass tests ─────────────────────────────────────────────────────
 	fmt.Println("\n\n*** EVE bypass TESTS")
 

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1350,6 +1350,18 @@ def main():
     else:
         print("- HPKE-Stern-F key agreement FAILED (n=256)")
 
+    # ── HFSCX-256 ────────────────────────────────────────────────────────────
+    print("\n--- HFSCX-256 [HASH — Merkle-Damgård over NL-FSCX v1; 256-bit output]")
+    _tv = b"HFSCX-256 test vector"
+    _bare = hfscx_256(_tv)
+    _mac_iv = BitArray(KEYBITS, preshared.uint ^ int.from_bytes(_HFSCX256_IV_BYTES, 'big'))
+    _keyed  = hfscx_256(_tv, iv=_mac_iv)
+    print(f"digest (bare)  : {_bare.hex()}")
+    print(f"digest (keyed) : {_keyed.hex()}")
+    print(f"+ hash length correct ({len(_bare)} bytes)")
+    print("+ keyed ≠ bare (key influences output)" if _bare != _keyed
+          else "- keyed == bare (unexpected!)")
+
     # ── Eve bypass tests ─────────────────────────────────────────────────────
     print(f"\n\n*** EVE bypass TESTS")
 

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -5,6 +5,7 @@
 #   python3 herradura.py genpkey --algo hkex-gf  --bits 256 --out alice.pem
 #   python3 herradura.py pkey    --in alice.pem --pubout --out alice_pub.pem
 #   python3 herradura.py kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --out sk.pem
+#   python3 herradura.py kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --kdf hfscx-256 --out sk.pem
 #   python3 herradura.py enc     --algo hske      --key sk.pem --in msg.bin --out cipher.pem
 #   python3 herradura.py dec     --algo hske      --key sk.pem --in cipher.pem --out plain.bin
 #   python3 herradura.py sign    --algo hpks      --key sig.pem --in msg.bin --out s.pem
@@ -227,8 +228,8 @@ def _encode_rnl_response(K_int, C_B_poly, hint, n):
     C_packed, C_nb = pack_poly(C_B_poly, 2)
     hint_int = 0
     for i, b in enumerate(hint):
-        hint_int |= b << i
-    hint_nb = max(1, (len(hint) + 7) // 8)
+        hint_int |= (b & 3) << (2 * i)   # 2 bits per coeff; matches decoder's (hint_int>>(2*i))&3
+    hint_nb = max(1, (2 * len(hint) + 7) // 8)
     der = der_seq(der_int(K_int,    K_nb),
                   der_int(C_packed, C_nb),
                   der_int(hint_int, hint_nb),
@@ -258,7 +259,7 @@ def _decode_rnl_response(path):
         raise ValueError(f"Expected HKEX-RNL RESPONSE PEM, got {label!r}")
     K_int, C_packed, hint_int, n, hint_len = ints
     C_B_poly = unpack_poly(C_packed, n, 2)
-    hint = [(hint_int >> i) & 1 for i in range(hint_len)]
+    hint = [(hint_int >> (2 * i)) & 3 for i in range(hint_len)]
     return K_int, C_B_poly, hint, n
 
 
@@ -535,9 +536,16 @@ def cmd_pkey(args):
 # ---------------------------------------------------------------------------
 
 def cmd_kex(args):
-    algo      = args.algo
-    our_path  = args.our
+    algo       = args.algo
+    our_path   = args.our
     their_path = args.their
+    use_kdf    = getattr(args, 'kdf', 'none') == 'hfscx-256'
+
+    def _apply_kdf(k_int, nbits):
+        if not use_kdf:
+            return k_int
+        raw = k_int.to_bytes(nbits // 8, 'big')
+        return int.from_bytes(hfscx_256(raw), 'big')
 
     if algo == 'hkex-gf':
         our_algo,   our_ints   = _decode_privkey(our_path)
@@ -545,7 +553,7 @@ def cmd_kex(args):
         priv_int, _, nbits = our_ints
         pub_int = their_ints[0]
         poly    = GF_POLY.get(nbits, GF_POLY[256])
-        sk_int  = gf_pow(pub_int, priv_int, poly, nbits)
+        sk_int  = _apply_kdf(gf_pow(pub_int, priv_int, poly, nbits), nbits)
         _write_file(args.out, _encode_session_key(sk_int, nbits))
 
     elif algo == 'hkex-rnl':
@@ -564,7 +572,8 @@ def cmd_kex(args):
                 sys.exit(f"Ring size mismatch: ours n={n}, theirs n={n_their}")
             C_B    = _rnl_derive_C(m_A, s_B, n)
             K_B, hint = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n, n)
-            _write_file(args.out, _encode_rnl_response(K_B.uint, C_B, hint, n))
+            K_B_int = _apply_kdf(K_B.uint, n)
+            _write_file(args.out, _encode_rnl_response(K_B_int, C_B, hint, n))
 
         elif their_label == _LABEL_RNL_RESP:
             # ── STEP 2: Alice completes the handshake ───────────────────────
@@ -576,7 +585,7 @@ def cmd_kex(args):
             if n != n_resp:
                 sys.exit(f"Ring size mismatch: ours n={n}, response n={n_resp}")
             K_A = _rnl_agree(s_A, C_B, RNLQ, RNLP, RNLPP, n, n, hint)
-            _write_file(args.out, _encode_session_key(K_A.uint, n))
+            _write_file(args.out, _encode_session_key(_apply_kdf(K_A.uint, n), n))
 
         else:
             sys.exit(
@@ -1011,6 +1020,9 @@ def build_parser():
     kx.add_argument('--our',   required=True)
     kx.add_argument('--their', required=True)
     kx.add_argument('--out',   required=True)
+    kx.add_argument('--kdf', default='none', choices=['none', 'hfscx-256'],
+                    help='Post-hash raw shared secret with HFSCX-256 (default: none). '
+                         'Both sides must use the same --kdf flag.')
 
     # enc
     en = sub.add_parser('enc', help='Encrypt')

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -7,6 +7,7 @@
  *   herradura_cli pkey    --in alice.pem --pubout --out alice_pub.pem
  *   herradura_cli pkey    --in alice.pem --text
  *   herradura_cli kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --out sk.pem
+ *   herradura_cli kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --kdf hfscx-256 --out sk.pem
  *   herradura_cli kex     --algo hkex-rnl --our bob.pem   --their alice_pub.pem --out bob_resp.pem
  *   herradura_cli kex     --algo hkex-rnl --our alice.pem --their bob_resp.pem  --out sk.pem
  *
@@ -413,12 +414,15 @@ static void cmd_pkey(int argc, char **argv)
 
 static void cmd_kex(int argc, char **argv)
 {
-    const char *algo      = get_arg(argc, argv, "--algo");
-    const char *our_path  = get_arg(argc, argv, "--our");
+    const char *algo       = get_arg(argc, argv, "--algo");
+    const char *our_path   = get_arg(argc, argv, "--our");
     const char *their_path = get_arg(argc, argv, "--their");
-    const char *out_path  = get_arg(argc, argv, "--out");
+    const char *out_path   = get_arg(argc, argv, "--out");
+    const char *kdf        = get_arg(argc, argv, "--kdf");
     if (!algo || !our_path || !their_path || !out_path)
         die("kex: --algo, --our, --their, --out required");
+    if (kdf && strcmp(kdf, "hfscx-256") != 0)
+        dief("kex: unsupported --kdf value: %s", kdf);
 
     FILE *urnd = fopen("/dev/urandom", "rb");
     if (!urnd) die("cannot open /dev/urandom");
@@ -436,6 +440,14 @@ static void cmd_kex(int argc, char **argv)
         gf_pow_ba(&sk, &pub_theirs, &priv);
         pem_key_free(&our); pem_key_free(&their);
 
+        /* Apply KDF if requested: sk = HFSCX-256(sk) */
+        if (kdf) {
+            uint8_t kdf_out[32];
+            hfscx_256(sk.b, KEYBYTES, NULL, kdf_out);
+            memcpy(sk.b, kdf_out, 32);
+            explicit_bzero(kdf_out, sizeof(kdf_out));
+        }
+
         const uint8_t *sk_start; size_t sk_len;
         ba_min_bytes(&sk, &sk_start, &sk_len);
         uint8_t isk[DER_INT_LEN(KEYBYTES)], in[8]; size_t lsk, ln;
@@ -443,6 +455,7 @@ static void cmd_kex(int argc, char **argv)
         der_i_n256(in, &ln);
         const uint8_t *it[2] = {isk, in}; size_t il[2] = {lsk, ln};
         seq_and_write(it, il, 2, PEM_SESSION_KEY, out_path);
+        explicit_bzero(&sk, sizeof(sk));
         fclose(urnd); return;
     }
 
@@ -482,6 +495,14 @@ static void cmd_kex(int argc, char **argv)
             BitArray K_B_rev; int ri_k;
             for (ri_k = 0; ri_k < KEYBYTES; ri_k++)
                 K_B_rev.b[ri_k] = K_B.b[KEYBYTES-1-ri_k];
+
+            /* Apply KDF if requested: K_B_rev = HFSCX-256(K_B_rev) */
+            if (kdf) {
+                uint8_t kdf_out[32];
+                hfscx_256(K_B_rev.b, KEYBYTES, NULL, kdf_out);
+                memcpy(K_B_rev.b, kdf_out, 32);
+                explicit_bzero(kdf_out, sizeof(kdf_out));
+            }
 
             uint8_t hint_rev[RNL_N / 8];
             { int ri; for (ri = 0; ri < RNL_N/8; ri++) hint_rev[ri] = hint[RNL_N/8-1-ri]; }
@@ -533,6 +554,15 @@ static void cmd_kex(int argc, char **argv)
             BitArray K_A_rev; int ri_ka;
             for (ri_ka = 0; ri_ka < KEYBYTES; ri_ka++)
                 K_A_rev.b[ri_ka] = K_A.b[KEYBYTES-1-ri_ka];
+
+            /* Apply KDF if requested: K_A_rev = HFSCX-256(K_A_rev) */
+            if (kdf) {
+                uint8_t kdf_out[32];
+                hfscx_256(K_A_rev.b, KEYBYTES, NULL, kdf_out);
+                memcpy(K_A_rev.b, kdf_out, 32);
+                explicit_bzero(kdf_out, sizeof(kdf_out));
+            }
+
             const uint8_t *ka_start; size_t ka_len;
             ba_min_bytes(&K_A_rev, &ka_start, &ka_len);
             uint8_t ik[DER_INT_LEN(KEYBYTES)], in[8]; size_t lk, ln;
@@ -1338,10 +1368,12 @@ static void usage(void)
 "  pkey --in FILE (--pubout | --text) [--out FILE]\n"
 "    Extract public key (--pubout) or print fields in hex (--text).\n"
 "\n"
-"  kex --algo ALGO --our PRIV --their PUB --out FILE\n"
+"  kex --algo ALGO --our PRIV --their PUB --out FILE [--kdf hfscx-256]\n"
 "    Key exchange.  Algorithms: hkex-gf hkex-rnl\n"
 "    HKEX-RNL is 2-round: Bob runs step 1 (--their=alice_pub.pem),\n"
 "    Alice runs step 2 (--their=bob_resp.pem).\n"
+"    --kdf hfscx-256: post-hash the raw shared secret with HFSCX-256.\n"
+"    Both sides must use the same --kdf flag to derive the same final key.\n"
 "\n"
 "  enc --algo ALGO (--key SK | --pubkey PUB) --in FILE [--out FILE]\n"
 "    Encrypt.  Symmetric (--key): hske hske-nla1 hske-nla2\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -528,16 +528,30 @@ func cmdPkey(args []string) {
 // ── kex ──────────────────────────────────────────────────────────────────────
 
 func cmdKex(args []string) {
-	fs := flag.NewFlagSet("kex", flag.ExitOnError)
-	algo  := fs.String("algo", "", "Algorithm (hkex-gf|hkex-rnl)")
-	our   := fs.String("our", "", "Our private key file")
+	fs  := flag.NewFlagSet("kex", flag.ExitOnError)
+	algo := fs.String("algo", "", "Algorithm (hkex-gf|hkex-rnl)")
+	our  := fs.String("our", "", "Our private key file")
 	their := fs.String("their", "", "Their public key or response file")
-	out   := fs.String("out", "-", "Output path")
+	out  := fs.String("out", "-", "Output path")
+	kdf  := fs.String("kdf", "", "KDF applied to raw shared secret (hfscx-256)")
 	fs.Parse(args)
 
 	if *algo == "" || *our == "" || *their == "" {
 		fmt.Fprintln(os.Stderr, "kex: --algo, --our, --their required")
 		os.Exit(1)
+	}
+	if *kdf != "" && *kdf != "hfscx-256" {
+		fmt.Fprintf(os.Stderr, "kex: unsupported --kdf value %q\n", *kdf)
+		os.Exit(1)
+	}
+
+	// applyKDF returns a new BitArray with HFSCX-256 applied when --kdf is set.
+	applyKDF := func(ba *BitArray, n int) *BitArray {
+		if *kdf != "hfscx-256" {
+			return ba
+		}
+		digest := Hfscx256(ba.Bytes(), nil)
+		return NewBitArray(n, new(big.Int).SetBytes(digest))
 	}
 
 	switch *algo {
@@ -560,7 +574,7 @@ func cmdKex(args []string) {
 		}
 
 		sk   := GfPow(pub, priv, poly, n)
-		skBA := NewBitArray(n, sk)
+		skBA := applyKDF(NewBitArray(n, sk), n)
 		pem, err := encodeSessionKey(skBA, n)
 		if err != nil {
 			die("kex", err)
@@ -591,8 +605,9 @@ func cmdKex(args []string) {
 			ms  := RnlPolyMul(m_A, s_B, RnlQ, n)
 			C_B := RnlRound(ms, RnlQ, RnlP)
 
-			// Compute K_B and reconciliation hint
+			// Compute K_B and reconciliation hint; apply KDF to K_B if requested.
 			K_B, hint := RnlAgree(s_B, C_A, RnlQ, RnlP, RnlPP, n, n, nil)
+			K_B = applyKDF(K_B, n)
 
 			pem, err := encodeRNLResponse(K_B, C_B, hint, n)
 			if err != nil {
@@ -626,6 +641,7 @@ func cmdKex(args []string) {
 			}
 
 			K_A, _ := RnlAgree(s_A, C_B, RnlQ, RnlP, RnlPP, n, n, hintBuf)
+			K_A = applyKDF(K_A, n)
 			pem, err := encodeSessionKey(K_A, n)
 			if err != nil {
 				die("kex", err)
@@ -1585,7 +1601,7 @@ func usage() {
 Commands:
   genpkey  --algo ALGO [--bits N] [--out FILE]
   pkey     --in FILE (--pubout | --text) [--out FILE]
-  kex      --algo ALGO --our FILE --their FILE [--out FILE]
+  kex      --algo ALGO --our FILE --their FILE [--kdf hfscx-256] [--out FILE]
   enc      --algo ALGO (--key FILE | --pubkey FILE) --in FILE [--out FILE]
   dec      --algo ALGO --key FILE --in FILE [--out FILE]
   sign     --algo ALGO --key FILE --in FILE [--digest hfscx-256] [--out FILE]

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -27,6 +27,7 @@ gf_mul                 = _s.gf_mul
 gf_pow                 = _s.gf_pow
 hfscx_256              = _s.hfscx_256
 _HFSCX256_IV_BYTES     = _s._HFSCX256_IV_BYTES
+_RNL_KDF_DC_256        = _s._RNL_KDF_DC_256
 
 # ── Ring-LWR / HKEX-RNL ─────────────────────────────────────────────────────
 _rnl_keygen         = _s._rnl_keygen

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Herradura Cryptographic Suite (v1.8.8)
+# Herradura Cryptographic Suite (v1.8.9)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 
 > **v1.4.0 note:** The original HKEX key exchange (based directly on FSCX_REVOLVE) was classically broken — the shared secret was directly computable from the two public wire values alone. v1.4.0 replaced it with **HKEX-GF**, a standard Diffie-Hellman construction over the multiplicative group of GF(2^n). See `SecurityProofs-1.md §3` for the formal proof.
 >
 > **v1.5.0 note:** FSCX is GF(2)-linear, making HSKE vulnerable to linear key-recovery attacks, and HKEX-GF is broken by Shor's algorithm. v1.5.0 adds **NL-FSCX** (non-linear extension breaking GF(2)-linearity and orbit periods) and **HKEX-RNL** (Ring-LWR key exchange conjectured quantum-resistant). See `SecurityProofs-1.md §6` (quantum analysis) and `SecurityProofs-2.md §11` (NL/PQC proofs) for analysis.
+>
+> **v1.8.9 note:** `--kdf hfscx-256` flag added to the `kex` subcommand in all three CLIs (C, Go, Python) — post-hashes the raw HKEX-GF or HKEX-RNL shared secret through HFSCX-256, producing a uniformly distributed 256-bit key. HFSCX-256 standalone demo block added to all three suite `main()` programs.
 >
 > **v1.8.8 note:** `herradura.h` C23/GCC 13+ compatibility fix — `ATOMIC_VAR_INIT` (deprecated in C17, removed in C23) replaced with direct `= 0` initialisation; no API change.
 >
@@ -156,7 +158,7 @@ arduino-cli compile --fqbn arduino:avr:uno CryptosuiteTests/Herradura_tests.ino
 
 ---
 
-# Performance (v1.8.8, Orange Pi 5 — RK3588, Cortex-A76 @ 2.4 GHz)
+# Performance (v1.8.9, Orange Pi 5 — RK3588, Cortex-A76 @ 2.4 GHz)
 
 Benchmarks from `CryptosuiteTests/Herradura_tests.{c,go,py}` with `-t 1.5`.
 Columns correspond to operand bit-width; for HKEX-RNL the column header is the ring degree $n$.

--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 
-> **v1.4.0 note:** The original HKEX key exchange (based directly on FSCX_REVOLVE) was classically broken — the shared secret was directly computable from the two public wire values alone. v1.4.0 replaced it with **HKEX-GF**, a standard Diffie-Hellman construction over the multiplicative group of GF(2^n). See `SecurityProofs-1.md §3` for the formal proof.
->
-> **v1.5.0 note:** FSCX is GF(2)-linear, making HSKE vulnerable to linear key-recovery attacks, and HKEX-GF is broken by Shor's algorithm. v1.5.0 adds **NL-FSCX** (non-linear extension breaking GF(2)-linearity and orbit periods) and **HKEX-RNL** (Ring-LWR key exchange conjectured quantum-resistant). See `SecurityProofs-1.md §6` (quantum analysis) and `SecurityProofs-2.md §11` (NL/PQC proofs) for analysis.
->
-> **v1.8.9 note:** `--kdf hfscx-256` flag added to the `kex` subcommand in all three CLIs (C, Go, Python) — post-hashes the raw HKEX-GF or HKEX-RNL shared secret through HFSCX-256, producing a uniformly distributed 256-bit key. HFSCX-256 standalone demo block added to all three suite `main()` programs.
->
-> **v1.8.8 note:** `herradura.h` C23/GCC 13+ compatibility fix — `ATOMIC_VAR_INIT` (deprecated in C17, removed in C23) replaced with direct `= 0` initialisation; no API change.
->
-> **v1.8.7 note:** N=128 `HPKS-Stern-F` implementation in C (`__uint128_t`, T=8, 64 parity-check rows, rounds=8); all benchmark tables now cover all four sizes (32/64/128/256-bit) across C, Go, and Python.
->
-> **v1.8.3 note:** Comprehensive cryptographic concepts primer (`docs/INTRODUCTION.md`) — plain-language guide to all core concepts (GF(2^n), FSCX, DH, Schnorr, El Gamal, quantum threats, Ring-LWR, Stern ZKP) with toy examples, verified references, and cross-links to TUTORIAL.md and the SecurityProofs documents.
->
-> **v1.7.4 note:** Developer integration tutorial (`docs/TUTORIAL.md`) — per-protocol API recipes in C, Go, and Python; `herradura.h` Protocol Layer wrappers; public Python aliases `hkex_rnl_keygen`/`hkex_rnl_agree`; runnable examples in `docs/examples/`. Full CSPRNG and constant-time audit (SA-01–SA-09): nine findings resolved across all six language targets.
->
-> **v1.5.40 note:** Constant-time audit (TODO #41): `stern_apply_perm` / `SternApplyPerm` made branchless across all targets (C, Go, ARM Thumb-2, NASM i386, Arduino) using arithmetic mask `-(bit)` to eliminate data-dependent branches that leaked the Hamming weight of secret error vectors. Python reference implementation documented as non-CT; `SecurityProofsCode/stern_ct_demo.py` added to demonstrate the timing correlation empirically.
->
-> **v1.5.23 note:** HerraduraCli — an OpenSSL-style Python CLI (`HerraduraCli/`) exposing all non-broken Herradura protocols via `genpkey`, `pkey`, `kex`, `enc`, `dec`, `sign`, and `verify` subcommands. Keys and ciphertexts use PEM-wrapped minimal DER. A `CliTest/` shell test suite covers key generation, encrypt/decrypt round-trips, sign/verify, and HKEX-GF/HKEX-RNL key-agreement correctness.
->
-> **v1.5.22 note:** NASM i386 HKEX-RNL now produces correct non-zero session keys (triple-division bug in `rnl_round` fixed). `rnl_cbd_poly` reads 4 coefficients per byte for η=1 (was 1 byte/coeff, discarding 75% of entropy). Go test [14] HKEX-RNL expanded from n∈{32,64} to n∈{32,64,128,256}, matching C and Python test coverage.
->
-> **v1.5.20 note:** Python tests and suite expanded to cover all four standard key sizes (32, 64, 128, 256 bits) for GF, HKEX-RNL, and Stern-F protocols. `hpke_stern_f_decap` now supports a known-e' fast path in addition to brute-force; N=256 HPKE-Stern-F demo added to the Python suite. C test [17] loops {32,64,256} and test [18] covers N=32 brute-force and N=64 known-e'. C suite now demos both N=32 brute-force and N=256 known-e' for HPKE-Stern-F. `bn_*` parameterised big-endian arithmetic layer added to C tests, extending Schnorr and HPKS-NL tests to 256-bit. NTT inner loops now use Fermat-prime fast modulo (`rnl_mulmodq`/`rnlMulModQ`), eliminating hardware divides in the HKEX-RNL hot path (+17.6% on n=32 in C).
->
-> **v1.5.18 note:** HPKS-NL and HPKE-NL remain quantum-vulnerable because their security still depends on the GF(2^n)* discrete-log base that Shor's algorithm breaks. v1.5.18 adds **HPKS-Stern-F** (Fiat-Shamir Stern ZKP signature) and **HPKE-Stern-F** (Niederreiter KEM), whose security reduces to Syndrome Decoding (NP-complete) and the NL-FSCX v1 PRF. See `SecurityProofs-2.md §11.8.4` for the formal reduction (Theorem 17).
-
 ---
 
 # FSCX — The Core Primitive

--- a/TODO.md
+++ b/TODO.md
@@ -3725,3 +3725,72 @@ Status: **DONE** — parenthetical "(production default; benchmarks use 4–8 ro
 **Fix:** Update the `**Last updated:**` line to `2026-05-25 (v1.8.8)` and append the major milestones since v1.5.16 to the status paragraph.
 
 Status: **DONE** — status paragraph updated with v1.6.0–v1.8.7 milestones; "Last updated" bumped to 2026-05-25 (v1.8.8) in both SecurityProofs-1.md and SecurityProofs.md.
+
+---
+
+### 68. Add HFSCX-256 KDF step to `kex` CLI and standalone hash demo to suite files (Feature, Medium)
+
+**Rationale:** HFSCX-256 is implemented in all three language implementations (C `herradura.h` static function, Go `herradura/herradura.go` exported `Hfscx256`, Python suite-level `hfscx_256`), and the `dgst` subcommand (standalone file digest) and `sign`/`verify --digest hfscx-256` (pre-hash before signing) are already present in all three CLIs.  Two gaps remain:
+
+1. **No KDF step in `kex`.**  The `kex` subcommand stores the raw Diffie-Hellman output (`g^{ab}` for HKEX-GF; the Ring-LWR reconciliation value for HKEX-RNL) directly as the session key without passing it through a KDF.  Raw GF(2^n) DH values have non-uniform bit distribution and retain algebraic structure; a `--kdf hfscx-256` flag would post-hash the raw shared secret through HFSCX-256 (`sk_out = HFSCX-256(raw_sk)`) before writing the SESSION KEY PEM, producing a uniformly random 256-bit key with full domain separation.
+
+2. **No standalone hash demo in the suite programs.**  The C, Go, and Python suite `main()` programs demonstrate all protocol primitives (HKEX-GF, HSKE, HPKS, HPKE, NL variants, Stern-F) but never call `hfscx_256` / `Hfscx256` directly, so the hash primitive is invisible to a reader running the suite.
+
+**Current state:**
+
+- `dgst` subcommand: **already implemented** in all three CLIs (`herradura_cli.c`, `herradura_cli.go`, `herradura.py`) — reads a file and writes the HFSCX-256 hex digest or PEM.
+- `sign`/`verify --digest hfscx-256`: **already implemented** in all three CLIs.
+- `kex --kdf`: **missing** in all three CLIs (C, Go, Python).
+- Suite demo HFSCX-256 block: **missing** in all three suite `main()` programs (`Herradura cryptographic suite.c`, `Herradura cryptographic suite.go`, `Herradura cryptographic suite.py`).
+
+**Library-call status (informational):**
+
+| Language | Function | Location | Accessible |
+|---|---|---|---|
+| C | `hfscx_256(data, len, iv, out)` | `herradura.h` (static) | yes — any TU that includes the header |
+| Go | `Hfscx256(data, iv []byte) []byte` | `herradura/herradura.go` (exported) | yes — any importer of `herradurakex/herradura` |
+| Python | `hfscx_256(data, *, iv=None) -> bytes` | `Herradura cryptographic suite.py` | yes — imported by `HerraduraCli/primitives.py` |
+
+No new library functions are needed; the API surface is complete.
+
+**Plan:**
+
+**A. Add `--kdf hfscx-256` flag to `kex` in all three CLIs.**
+
+Affects `HerraduraCli/herradura_cli.c`, `HerraduraCli/herradura_cli.go`, `HerraduraCli/herradura.py`.
+
+For each CLI:
+- Add `--kdf` optional parameter (default: `none`; accepted values: `none`, `hfscx-256`).
+- After computing the raw shared secret but before encoding the SESSION KEY PEM, if `--kdf hfscx-256` is set, replace `raw_sk` with `HFSCX-256(raw_sk_bytes)` (bare hash, no IV/key).
+- Update the help string and the usage comment at the top of each file.
+- Both sides of an exchange must use the same `--kdf` flag to derive the same final key.
+
+Example usage (matching OpenSSL `openssl kdf` style):
+```
+herradura_cli kex --algo hkex-gf --our alice.pem --their bob_pub.pem --kdf hfscx-256 --out sk.pem
+```
+
+**B. Add HFSCX-256 standalone demo block to each suite `main()`.**
+
+Affects `Herradura cryptographic suite.c`, `Herradura cryptographic suite.go`, `Herradura cryptographic suite.py`.
+
+Insert a new protocol block (after HPKE-Stern-F, before Eve bypass tests) that:
+1. Hashes a fixed test vector (e.g. the ASCII bytes `"HFSCX-256 test vector"`) and prints the hex digest.
+2. Hashes the same test vector keyed with the session key `sk` and prints the keyed digest.
+3. Verifies that the bare and keyed digests differ (trivially true for non-zero keys).
+4. Prints one line confirming the hash length is 32 bytes (256 bits).
+
+Format mirrors existing blocks:
+```
+--- HFSCX-256 [HASH — Merkle-Damgård over NL-FSCX v1; 256-bit output]
+digest (bare)  : <64-char hex>
+digest (keyed) : <64-char hex>
++ hash length correct (32 bytes)
++ keyed != bare (key influences output)
+```
+
+**Scope note:** Assembly (ARM, i386, AVR) and Arduino implementations are out of scope; those targets do not have a CLI layer and lack heap allocation for the padding buffer.
+
+**Side fixes:** `_encode_rnl_response` in `HerraduraCli/herradura.py` had a pre-existing bug where the hint was packed as `b << i` (overlapping 2-bit values at 1-bit offsets) with `hint_nb = (len(hint)+7)//8`, causing `OverflowError` when any hint coefficient was 2 or 3 at the last position; the encoder and decoder were inconsistent (decoder read only 1 bit per coefficient).  Fixed to use 2 bits per coefficient throughout: `(b & 3) << (2*i)`, `hint_nb = (2*len(hint)+7)//8`, `(hint_int>>(2*i))&3`.  Also fixed `_RNL_KDF_DC_256` missing from `HerraduraCli/primitives.py` (added alongside `_HFSCX256_IV_BYTES`).  All 79 CLI tests pass after both fixes (previously the HKEX-RNL cross-party test was a pre-existing FAIL).
+
+Status: **DONE** — HFSCX-256 demo block added to all three suite `main()` programs; `--kdf hfscx-256` flag added to `kex` in C, Go, and Python CLIs; pre-existing Python hint-encoding bug and missing `_RNL_KDF_DC_256` re-export fixed as side effects; all 79 CLI tests pass.


### PR DESCRIPTION
## Summary

- Add `--kdf hfscx-256` flag to the `kex` subcommand in C, Go, and Python CLIs — post-hashes the raw DH/RNL shared secret through HFSCX-256 before writing the SESSION KEY PEM, removing algebraic structure from the raw GF(2^n) output
- Add HFSCX-256 standalone demo block (bare + keyed digest, cross-language test vector `fd84942b…`) to each suite `main()` (C, Go, Python)
- Fix pre-existing Python bug in `_encode_rnl_response`: hint packed at 1 bit/coeff instead of 2; encoder/decoder inconsistent; caused `OverflowError` and HKEX-RNL cross-party test failures
- Fix missing `_RNL_KDF_DC_256` re-export in `HerraduraCli/primitives.py`
- Update CHANGELOG (new entry v1.8.9) and README (version bump)
- Remove all version-note blockquotes from README (change history now lives exclusively in CHANGELOG); add changelog/README policy to CLAUDE.md

## Test plan

- [x] All 7 `bash CliTest/test_encrypt.sh` tests pass (including HKEX-RNL cross-party, previously a FAIL)
- [x] `--kdf hfscx-256` verified end-to-end for HKEX-GF and HKEX-RNL in all three CLIs — both sides produce matching keys
- [x] HFSCX-256 demo block produces identical `fd84942b...` bare digest in C, Go, and Python (cross-language consistency confirmed)
- [x] Keyed digest differs from bare digest in all three languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)