### PR TITLE
HFSCX-256 hash primitive, KDF CLI flag, and documentation updates (v1.8.9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3973,4 +3973,4 @@ In §3.3 HKEX-GF and §9 HKEX-RNL, add a brief note after each "shared secret" d
 
 **Files to modify:** `docs/INTRODUCTION.md`
 
-Status: **OPEN**
+Status: **DONE** — Part 4.5 (HFSCX-256 conceptual explanation: Merkle-Damgård construction, NL-FSCX v1 as compression function, keyed MAC, AEAD) inserted between Part 4 and Part 5; KDF derivation notes added to §3.3 and §9.4; HFSCX-256 row added to Part 11.1 protocol table; two new decision-tree branches added to Part 11.2; four glossary entries added to Part 12 (Merkle-Damgård, MAC, AEAD, HFSCX-256).

--- a/TODO.md
+++ b/TODO.md
@@ -3794,3 +3794,183 @@ digest (keyed) : <64-char hex>
 **Side fixes:** `_encode_rnl_response` in `HerraduraCli/herradura.py` had a pre-existing bug where the hint was packed as `b << i` (overlapping 2-bit values at 1-bit offsets) with `hint_nb = (len(hint)+7)//8`, causing `OverflowError` when any hint coefficient was 2 or 3 at the last position; the encoder and decoder were inconsistent (decoder read only 1 bit per coefficient).  Fixed to use 2 bits per coefficient throughout: `(b & 3) << (2*i)`, `hint_nb = (2*len(hint)+7)//8`, `(hint_int>>(2*i))&3`.  Also fixed `_RNL_KDF_DC_256` missing from `HerraduraCli/primitives.py` (added alongside `_HFSCX256_IV_BYTES`).  All 79 CLI tests pass after both fixes (previously the HKEX-RNL cross-party test was a pre-existing FAIL).
 
 Status: **DONE** — HFSCX-256 demo block added to all three suite `main()` programs; `--kdf hfscx-256` flag added to `kex` in C, Go, and Python CLIs; pre-existing Python hint-encoding bug and missing `_RNL_KDF_DC_256` re-export fixed as side effects; all 79 CLI tests pass.
+
+---
+
+### 69. Update `docs/TUTORIAL.md` for HFSCX-256 API and multi-size Stern-F parameters (Documentation, Medium)
+
+**Motivated by:** v1.8.9 (HFSCX-256 first-class demo in all three suite programs; `--kdf hfscx-256` flag in `kex` CLI) and v1.8.7 (N=128 HPKS-Stern-F in C; multi-size benchmark coverage at 32/64/128/256 bits).
+
+**Background:** `docs/TUTORIAL.md` was written at v1.8.3 and covers all protocols but omits HFSCX-256 entirely.  Since v1.8.9 the hash is now explicitly demonstrated in the suite output, is available as a `--kdf` option in `kex`, and is accessible via the same public API surface as the other primitives (`herradura.h`, `herradura/herradura.go`, `Herradura cryptographic suite.py`).  The parameter reference table also misrepresents Stern-F as having fixed `SDF_T = 16` / `SDF_ROUNDS = 32`, whereas C now supports N=32 (T=2, rounds=4), N=64 (T=4, rounds=8), and N=128 (T=8, rounds=8) in addition to the N=256 default.
+
+**Required changes:**
+
+#### 1. Add `HFSCX-256` sections to each language integration block
+
+Show the bare hash and keyed MAC API immediately after the Stern-F examples.
+
+**C:**
+```c
+/* Bare hash */
+uint8_t digest[32];
+uint8_t msg[] = "HFSCX-256 test";
+hfscx_256(msg, sizeof msg - 1, NULL, digest);
+
+/* Keyed MAC: iv = key XOR _HFSCX256_IV */
+uint8_t mac_iv[KEYBYTES];
+for (int i = 0; i < KEYBYTES; i++)
+    mac_iv[i] = alice_shared.b[i] ^ _HFSCX256_IV[i];
+hfscx_256(msg, sizeof msg - 1, mac_iv, digest);
+```
+
+**Go (`herradura` package):**
+```go
+data := []byte("HFSCX-256 test")
+
+// Bare hash
+digest := Hfscx256(data, nil)
+
+// Keyed MAC: iv = key XOR Hfscx256IV
+iv := make([]byte, 32)
+for i := range iv { iv[i] = aliceShared.Bytes()[i] ^ Hfscx256IV[i] }
+mac := Hfscx256(data, iv)
+```
+
+**Python:**
+```python
+import h  # the suite module
+
+data = b"HFSCX-256 test"
+
+# Bare hash
+digest = h.hfscx_256(data)
+
+# Keyed MAC
+mac_iv = h.BitArray(h.KEYBITS, alice_shared.uint ^ int.from_bytes(h._HFSCX256_IV_BYTES, 'big'))
+mac = h.hfscx_256(data, iv=mac_iv)
+```
+
+#### 2. Add `--kdf hfscx-256` note to Security Notes
+
+In the NL/PQC protocols subsection, add a bullet:
+
+> **HKEX-GF / HKEX-RNL raw shared secret:** The raw output of `hkex_gf_agree` / `rnl_agree` has non-uniform bit distribution (GF element or LWR reconciliation value). Pass `--kdf hfscx-256` to the `kex` CLI subcommand to post-hash the secret through HFSCX-256, producing a uniformly random 256-bit session key. Both parties must use the same flag.
+
+#### 3. Update the parameter reference table
+
+Add HFSCX-256 constants:
+
+| Parameter | C | Go | Python | Value |
+|---|---|---|---|---|
+| HFSCX-256 IV | `_HFSCX256_IV[32]` | `Hfscx256IV` | `_HFSCX256_IV_BYTES` | `b'HFSCX-256/HERRADURA-SUITE\x00…'` |
+
+Update the Stern-F rows to reflect that `SDF_T` and `SDF_ROUNDS` scale with N; the table values (T=16, rounds=32) are the N=256 defaults. Add a note:
+
+> Stern-F parameters scale with N: T = N/16, rows = N/4. C supports N=32 (T=2, rounds=4), N=64 (T=4, rounds=8), N=128 (T=8, rounds=8), and N=256 (T=16, rounds=32). Go and Python support all four sizes. Assembly/Arduino: N=32 only.
+
+#### 4. Add HSKE-NL-A1 (counter-mode) examples to C and Python sections
+
+The C section currently shows no NL encryption examples; Python shows only HSKE-NL-A2.  HSKE-NL-A1 is the recommended non-linear stream cipher and its nonce handling is non-obvious.
+
+**C (add after HPKS example):**
+```c
+/* HSKE-NL-A1: counter-mode stream cipher with nonce */
+BitArray key, nonce, plaintext, ciphertext, recovered;
+ba_rand(&key, urnd);
+ba_rand(&nonce, urnd);
+ba_rand(&plaintext, urnd);
+
+hske_nl_a1_encrypt(&plaintext, &key, &nonce, &ciphertext);   /* session base = key XOR nonce */
+hske_nl_a1_decrypt(&ciphertext, &key, &nonce, &recovered);
+/* ba_equal(&plaintext, &recovered) == 1 */
+```
+
+**Python (add after HSKE-NL-A2 example):**
+```python
+key   = h.BitArray.random(n)
+nonce = h.BitArray.random(n)
+pt    = h.BitArray.random(n)
+base  = h.BitArray(n, key.uint ^ nonce.uint)
+seed  = base.rotated(n // 8)
+ct    = h.nl_fscx_revolve_v1(seed, h.BitArray(n, base.uint ^ 0), n // 4)  # counter=0
+dec   = h.nl_fscx_revolve_v1(seed, h.BitArray(n, base.uint ^ 0), n // 4)
+assert (pt.uint ^ ct.uint) == (ct.uint ^ dec.uint)  # XOR symmetry check
+```
+(Note: the suite wraps this in `hske_nl_a1_encrypt`; the raw call is shown here for clarity.)
+
+**Files to modify:** `docs/TUTORIAL.md`
+
+Status: **DONE** — HFSCX-256 sections (bare hash + keyed MAC) added to C, Go, and Python integration blocks; HSKE-NL-A1 counter-mode examples added to C, Go, and Python; hash primitive row added to protocol reference; parameter table updated with `_HFSCX256_IV` constants and Stern-F multi-size note; KDF security bullet added to Security Notes.
+
+---
+
+### 70. Update `docs/INTRODUCTION.md` for HFSCX-256 concepts (Documentation, Medium)
+
+**Motivated by:** v1.8.9 (HFSCX-256 is now a first-class primitive with suite demo output and CLI integration). `docs/INTRODUCTION.md` was written at v1.8.3 and makes no mention of HFSCX-256, Merkle-Damgård construction, or the AEAD streaming mode — all of which are part of the deployed suite.
+
+**Background:** A reader who runs any of the three suite programs now sees a `--- HFSCX-256 [HASH]` output block, but INTRODUCTION.md provides no conceptual grounding for what that means. The Part 11 suite table lists 11 protocols but omits HFSCX-256 as a hash primitive. The decision tree has no branch for "need to hash or MAC data". The glossary has no entries for Merkle-Damgård, MAC, or AEAD.
+
+**Required changes:**
+
+#### 1. Add HFSCX-256 conceptual explanation
+
+Insert as a new **Part 4.5** (between "FSCX and HSKE" and "Non-linearity") or as a subsection **§4.5** within Part 4, covering:
+
+- **Why a hash function is needed:** Raw DH shared secrets (e.g. GF elements from HKEX-GF) have algebraic structure — not all 256-bit values appear equally often. A hash "whitens" the output so that downstream protocols see a uniformly random key.
+- **Merkle-Damgård construction in plain English:** Split the message into 32-byte blocks. Start from a fixed IV. Feed each block through a compression function with the previous chaining value. Final state is the hash. One toy example: 3 blocks → compress(compress(compress(IV, B0), B1), B2).
+- **Why NL-FSCX v1 is used as the compression function:** It is already a one-way function (non-bijective in A); iterating it n/4 times provides enough diffusion. The fixed IV provides domain separation.
+- **Keyed MAC variant:** XOR the key into the initial chaining state (replace IV with `key XOR IV`). This ties the output to knowledge of the key.
+- **AEAD (HSKE-NL-A1-CTR):** Briefly mention that HFSCX-256 is used as the authentication tag in the streaming CTR-mode AEAD (`encfile` CLI command); the cipher provides confidentiality and the MAC provides integrity.
+- **Cross-reference:** → TUT §HFSCX-256 for API usage. → SP2 §11.2 for the NL-FSCX one-wayness argument.
+
+Toy example (2-block message):
+```
+IV    = HFSCX-256/HERRADURA-SUITE (fixed 32 bytes)
+B0    = first 32 bytes of message
+B1    = second 32 bytes (padded with 0x80… if needed)
+hash  = NL-FSCX-v1-revolve(NL-FSCX-v1-revolve(IV, B0, n/4), B1, n/4)
+```
+
+#### 2. Update Part 11.1 protocol reference table
+
+Add a row for HFSCX-256:
+
+| HFSCX-256 | Hash/MAC | NL-FSCX v1 one-wayness | Grover (halves collision resistance) | SP2 §11.2 | §HFSCX-256 |
+
+Adjust the table header to add a "Hash" column in the first column scope.
+
+#### 3. Update Part 11.2 decision tree
+
+Add a branch:
+```
+Need to hash data or authenticate a message?
+└── HFSCX-256 (bare digest) or HFSCX-256-MAC (keyed)
+```
+
+Also add under key exchange:
+```
+Need to derive a uniformly random key from a DH or Ring-LWR output?
+└── Post-hash with HFSCX-256 (--kdf hfscx-256 in CLI)
+```
+
+#### 4. Update Part 12 glossary
+
+Add four entries:
+
+- **Merkle-Damgård construction.** A way to build a hash function for arbitrary-length messages from a fixed-length compression function. The message is padded to a multiple of the block size, then each block is fed through the compression function together with the previous chaining value. The final chaining value is the hash. Used in MD5, SHA-1, and SHA-256; also the design of HFSCX-256.
+
+- **MAC (Message Authentication Code).** A keyed hash: both the message and a secret key are inputs, and only someone who knows the key can produce or verify the tag. Provides integrity and authenticity (but not non-repudiation). HFSCX-256-MAC uses the key as the initial chaining state.
+
+- **AEAD (Authenticated Encryption with Associated Data).** A mode that combines confidentiality (encryption) with integrity (a MAC over the ciphertext and any associated metadata). An attacker who tampers with the ciphertext causes decryption to fail before any plaintext is produced. HSKE-NL-A1-CTR with HFSCX-256-MAC implements AEAD for the `encfile` CLI command.
+
+- **HFSCX-256.** A 256-bit hash function built on NL-FSCX v1 as a Merkle-Damgård compression function, using the fixed IV `HFSCX-256/HERRADURA-SUITE`. Used as a KDF (post-hash for DH shared secrets), a MAC (keyed by XOR-ing the key into the IV), and an AEAD tag in streaming encryption.
+
+#### 5. Add KDF note to Part 3 (key exchange) and Part 9 (Ring-LWR)
+
+In §3.3 HKEX-GF and §9 HKEX-RNL, add a brief note after each "shared secret" description:
+
+> **Key derivation:** The raw shared secret `g^{ab}` (or the Ring-LWR reconciliation value) retains algebraic structure and should be post-hashed before use as a symmetric key. HFSCX-256 provides this step: `sk = HFSCX-256(raw_secret_bytes)`. In the CLI, pass `--kdf hfscx-256` to `kex` to apply this step automatically.
+
+**Files to modify:** `docs/INTRODUCTION.md`
+
+Status: **OPEN**

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -263,6 +263,13 @@ gf_pow(0x03, ?) = 0x8F — the discrete logarithm in GF(2^8).  (Easily done for
 → TUT §HKEX-GF for API usage.
 → Part 8 of this document for the quantum threat.
 
+**Key derivation note:** The raw shared secret `sk` is a GF(2^n) element with
+non-uniform bit distribution — not all 256-bit values appear with equal probability.
+Before using it as a symmetric key, post-hash it through HFSCX-256 to produce a
+uniformly random 256-bit output: `final_key = HFSCX-256(sk_bytes)`.  In the CLI,
+`--kdf hfscx-256` on the `kex` subcommand applies this step automatically.
+See Part 4.5 for the construction.
+
 ### 3.4 Forward secrecy
 
 If Alice and Bob use fresh random values a, b for every session, a later compromise
@@ -377,6 +384,108 @@ the NL-FSCX mixing step is added to break the linearity; see Part 5.
 
 **Reference:** D. Stinson, *Cryptography: Theory and Practice*, 4th ed., CRC Press,
 2018, chapter 2 (stream ciphers and pseudo-randomness).
+
+---
+
+## Part 4.5 — HFSCX-256: a hash function from NL-FSCX
+
+### 4.5.1 Why the suite needs a hash function
+
+A good **hash function** takes input of any length and produces a fixed-size output
+that looks random — any change to the input produces a completely different output.
+Cryptographic hash functions are used for:
+
+- **Key derivation:** post-processing a raw DH shared secret to remove algebraic
+  structure (see the note at §3.3 and §9.4).
+- **Data integrity:** computing a digest so that any tampering is detectable.
+- **Message authentication (MAC):** mixing a secret key into the digest to prove both
+  integrity and knowledge of the key.
+- **Pre-hash signing:** reducing a large file to 32 bytes before signing with HPKS,
+  HPKS-NL, or HPKS-Stern-F (via `--digest hfscx-256` in the CLI).
+
+### 4.5.2 Merkle-Damgård construction in plain English
+
+Most standard hash functions (SHA-256, SHA-3's predecessors, MD5) are built on the
+**Merkle-Damgård (MD) construction**.  It converts a fixed-length **compression
+function** into a hash for messages of any length:
+
+1. **Pad** the message to a multiple of the block size.  HFSCX-256 uses ISO 7816-4
+   padding: append byte `0x80`, then zero bytes until the length is a multiple of
+   32 bytes, then append one final 32-byte block containing the original bit-length
+   (Merkle-Damgård strengthening).
+2. **Initialize** a 32-byte chaining variable from a fixed **IV** (initial value).
+3. **Chain** each 32-byte block through the compression function:
+   ```
+   state = compress(state, block)
+   ```
+4. The final state is the hash.
+
+**Toy 2-block example** (the message fits in one block after padding):
+
+```
+IV    = "HFSCX-256/HERRADURA-SUITE\x00\x00\x00\x00\x00\x00\x00"  (32 bytes, fixed)
+B₀    = padded message block  (0x80 + zeros fills to 32 bytes)
+B₁    = length block          (zeros || bit_length as 8-byte big-endian)
+
+state = compress(IV, B₀)
+hash  = compress(state, B₁)    ← final 32-byte digest
+```
+
+The length block prevents **length-extension attacks**: appending extra data to an
+existing message produces a different hash rather than extending the old one.
+
+**Reference:** I. Damgård, "A Design Principle for Hash Functions," *CRYPTO 1989*,
+LNCS 435, pp. 416–427.
+[(Springer)](https://doi.org/10.1007/0-387-34805-0_39)
+
+### 4.5.3 NL-FSCX v1 as the compression function
+
+**HFSCX-256** instantiates the Merkle-Damgård construction with NL-FSCX v1 as the
+compression function, iterated 64 steps (= n/4):
+
+```
+compress(state, block) = nl_fscx_revolve_v1(state, block, 64)
+```
+
+NL-FSCX v1 is already used as a one-way function in HPKS-NL and HKEX-RNL: recovering
+the input from the output requires inverting 64 steps of a non-linear mixing
+operation — a property that makes it a sound compression function.
+
+The IV is the ASCII constant `HFSCX-256/HERRADURA-SUITE` zero-padded to 32 bytes.
+Starting from a public, fixed IV means the hash is deterministic and domain-separated
+from other NL-FSCX v1 uses in the suite.
+
+The C, Go, and Python implementations share the same IV and chaining logic, so the
+same message produces byte-identical digests in all three languages.
+
+→ SP2 §11.2 for the NL-FSCX v1 one-wayness argument.
+→ TUT §HFSCX-256 for API usage (bare hash and keyed MAC examples).
+
+### 4.5.4 Keyed MAC variant
+
+XOR the secret key into the IV before chaining:
+
+```
+mac_iv = key XOR IV
+hash   = HFSCX-256(message, initial_state = mac_iv)
+```
+
+The key binds the initial chaining state, making the output infeasible to compute
+without knowing the key.  It is also XOR'd into the Merkle-Damgård length block,
+preventing a fixed-point collapse where different keys could produce identical hashes
+for empty input.
+
+### 4.5.5 AEAD: authenticated encryption for files
+
+The `encfile`/`decfile` CLI commands combine HSKE-NL-A1 counter-mode encryption
+with HFSCX-256-MAC to form an **AEAD** (Authenticated Encryption with Associated
+Data) scheme named HSKE-NL-A1-CTR:
+
+1. Encrypt each 32-byte block with a keystream from NL-FSCX v1 (counter mode).
+2. Append an HFSCX-256-MAC tag over the nonce, plaintext length, and entire ciphertext.
+
+Decryption verifies the tag *before* producing any plaintext — a single tampered byte
+causes the tag check to fail and nothing is returned.
 
 ---
 
@@ -771,6 +880,10 @@ finalises the shared secret:
   sk   = nl_fscx_revolve_v1(seed, kA, n/4)
 ```
 
+Alternatively, post-hash the raw reconciled value through HFSCX-256 for a
+well-defined, uniform 256-bit key: `sk = HFSCX-256(kA_bytes)`.  In the CLI, pass
+`--kdf hfscx-256` to `kex`; both parties must use the same flag.  See Part 4.5.
+
 **Reference:** C. Peikert, "Lattice Cryptography for the Internet," *SCN 2014*, LNCS
 8642, pp. 197–219 (introduces the 1-bit reconciliation used here).
 [(Springer)](https://doi.org/10.1007/978-3-319-10879-7_11)
@@ -920,6 +1033,7 @@ For a modern code-based signature, see NIST FIPS 205 (SLH-DSA / SPHINCS+), 2024.
 | HPKE-NL | NL/PQC | NL-FSCX + DLP | Partially quantum-hard | SP1 §11.8 | §HPKE-NL |
 | HPKS-Stern-F | Code-based | Syndrome Decoding (NP-hard) | Conjectured quantum-hard | SP1 §8 | §HPKS-Stern |
 | HPKE-Stern-F | Code-based | Syndrome Decoding (NP-hard) | Conjectured quantum-hard | SP1 §8.2 | §HPKE-Stern |
+| HFSCX-256 | Hash / MAC | NL-FSCX v1 one-wayness | Grover only (halves collision resistance) | SP2 §11.2 | §HFSCX-256 |
 
 ### 11.2 Decision tree: which protocol should I use?
 
@@ -927,6 +1041,9 @@ For a modern code-based signature, see NIST FIPS 205 (SLH-DSA / SPHINCS+), 2024.
 Need to exchange a key?
 ├── Quantum safety required → HKEX-RNL
 └── Classical only (legacy/constrained device) → HKEX-GF
+
+Need to derive a uniform symmetric key from a DH or Ring-LWR exchange?
+└── Post-hash with HFSCX-256 (--kdf hfscx-256 in CLI, or call hfscx_256 directly)
 
 Need to encrypt data symmetrically?
 ├── Post-quantum + non-linear → HSKE-NL-A1 (stream) or HSKE-NL-A2 (permutation)
@@ -941,6 +1058,9 @@ Need public-key (asymmetric) encryption?
 ├── Code-based PQC → HPKE-Stern-F
 ├── NL/PQC → HPKE-NL
 └── Classical → HPKE
+
+Need to hash data or authenticate a message?
+└── HFSCX-256 (bare digest) or HFSCX-256-MAC (keyed: iv = key XOR IV)
 ```
 
 ### 11.3 What the security proofs prove vs. what they assume
@@ -1057,6 +1177,29 @@ to generate small secret polynomial coefficients with low noise.
 **Peikert reconciliation.** A 1-bit-per-coefficient hint that lets two parties whose
 Ring-LWR values are close (but not equal due to rounding) agree on exactly the same
 bit string.
+
+**Merkle-Damgård construction.** A method for building a hash function for arbitrary-length
+messages from a fixed-length compression function.  The message is padded to a multiple
+of the block size; each block is fed through the compression function together with the
+previous chaining value; the final chaining value is the hash.  Adding a length block at
+the end prevents length-extension attacks.  Used in MD5, SHA-1, SHA-256, and HFSCX-256.
+
+**MAC (Message Authentication Code).** A keyed hash: both the message and a secret key
+are inputs, and only someone who knows the key can produce or verify the tag.  Provides
+integrity and authenticity (but not non-repudiation, since the key is shared).
+HFSCX-256-MAC is computed by XOR-ing the key into the hash IV before chaining.
+
+**AEAD (Authenticated Encryption with Associated Data).** A mode that combines
+confidentiality (encryption) with integrity (a MAC over the ciphertext and any
+associated metadata).  An attacker who tampers with the ciphertext causes decryption
+to fail before any plaintext is produced.  HSKE-NL-A1-CTR with HFSCX-256-MAC
+implements AEAD for the `encfile`/`decfile` CLI commands.
+
+**HFSCX-256.** A 256-bit hash function built on NL-FSCX v1 as a Merkle-Damgård
+compression function, using the fixed IV `HFSCX-256/HERRADURA-SUITE\x00…`.  Used as
+a KDF (post-hash for DH shared secrets), a MAC (keyed via IV XOR key), and an AEAD
+authentication tag in streaming file encryption.  Output is 32 bytes, identical across
+the C, Go, and Python implementations.
 
 ---
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -2,7 +2,7 @@
 
 This guide shows how to use the Herradura suite as a library in your own C, Go, or Python project.
 
-The suite implements four protocol families:
+The suite implements four protocol families plus a hash primitive:
 
 | Protocol | Classical | NL/PQC variant | Code-based PQC |
 |----------|-----------|----------------|----------------|
@@ -10,6 +10,7 @@ The suite implements four protocol families:
 | Symmetric encryption | HSKE | HSKE-NL-A1, HSKE-NL-A2 | — |
 | Schnorr signature | HPKS | HPKS-NL | HPKS-Stern-F |
 | El Gamal encryption | HPKE | HPKE-NL | HPKE-Stern-F |
+| Hash / MAC | — | HFSCX-256 | — |
 
 **Security note:** The classical protocols (HKEX-GF, HSKE, HPKS, HPKE) are vulnerable to quantum
 attacks. Use the NL/PQC or code-based variants for new deployments. See [Security notes](#security-notes).
@@ -111,6 +112,33 @@ hpke_encrypt(&plaintext,  &alice_pub,  &R_ephem, &ciphertext, urnd);
 hpke_decrypt(&ciphertext, &R_ephem, &alice_priv, &recovered);
 ```
 
+### HSKE-NL-A1 counter-mode encryption (NL/PQC)
+
+Counter-mode stream cipher based on NL-FSCX v1.  A fresh random nonce must be
+transmitted alongside the ciphertext so the recipient can reproduce the keystream.
+
+```c
+BitArray key;       /* 256-bit key (e.g. from HKEX-GF or HKEX-RNL) */
+BitArray plaintext;
+BitArray N_a1, base_a1, seed_a1, ks, ciphertext, recovered;
+
+ba_rand(&key, urnd);
+ba_rand(&plaintext, urnd);
+
+ba_rand(&N_a1, urnd);                        /* fresh per-session nonce     */
+ba_xor(&base_a1, &key, &N_a1);              /* session base = K XOR N      */
+ba_rnl_kdf_seed(&seed_a1, &base_a1);         /* seed = ROL(base,n/8) XOR DC */
+
+/* Counter = 0 for first block; XOR counter into base_a1 for subsequent blocks */
+nl_fscx_revolve_v1_ba(&ks, &seed_a1, &base_a1, I_VALUE);  /* keystream block 0 */
+ba_xor(&ciphertext, &plaintext, &ks);       /* encrypt */
+ba_xor(&recovered,  &ciphertext, &ks);      /* decrypt */
+/* ba_equal(&plaintext, &recovered) == 1 */
+
+explicit_bzero(&seed_a1, sizeof(seed_a1));
+explicit_bzero(&base_a1, sizeof(base_a1));
+```
+
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
 
 ```c
@@ -157,6 +185,27 @@ BitArray msg;
 ba_rand(&msg, urnd);
 hpks_stern_f_sign(&sig, &msg, &e, &seed, urnd);           /* sign   */
 int ok = hpks_stern_f_verify(&sig, &msg, &seed, syndr);   /* verify */
+```
+
+### HFSCX-256 hash and MAC
+
+Merkle-Damgård hash built on NL-FSCX v1; returns 32 bytes.  Pass `iv = NULL`
+for a bare digest; pass `iv = key XOR _HFSCX256_IV` for a keyed MAC.
+
+```c
+#include <string.h>
+
+const uint8_t msg[] = "hello";
+uint8_t digest[KEYBYTES];
+
+/* Bare hash */
+hfscx_256(msg, sizeof msg - 1, NULL, digest);
+
+/* Keyed MAC: iv = key XOR _HFSCX256_IV */
+uint8_t mac_iv[KEYBYTES];
+for (int i = 0; i < KEYBYTES; i++)
+    mac_iv[i] = alice_shared.b[i] ^ _HFSCX256_IV[i];
+hfscx_256(msg, sizeof msg - 1, mac_iv, digest);
 ```
 
 ### Complete runnable example
@@ -234,6 +283,24 @@ recovered  := FscxRevolve(ciphertext, aliceShared, rValue)
 /* plaintext.Equal(recovered) */
 ```
 
+### HSKE-NL-A1 counter-mode encryption (NL/PQC)
+
+```go
+import "math/big"
+
+key       := NewRandBitArray(n)
+plaintext := NewRandBitArray(n)
+
+nA1    := NewRandBitArray(n)
+baseA1 := NewBitArray(n, new(big.Int).Xor(&key.Val, &nA1.Val))
+bA1    := NewBitArray(n, new(big.Int).Xor(&baseA1.Val, big.NewInt(0))) /* counter = 0 */
+ks     := NlFscxRevolveV1(RnlKdfSeed(baseA1), bA1, n/4)
+ct     := NewBitArray(n, new(big.Int).Xor(&plaintext.Val, &ks.Val))
+dec    := NewBitArray(n, new(big.Int).Xor(&ct.Val, &ks.Val))
+/* dec.Equal(plaintext) */
+/* Transmit nA1 alongside ct so the recipient can reproduce the keystream. */
+```
+
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
 
 ```go
@@ -259,6 +326,23 @@ seed, e, syn := SternFKeygen(n)
 msg := NewRandBitArray(n)
 sig := HpksSternFSign(msg, e, seed, SdfRounds)
 ok  := HpksSternFVerify(msg, sig, seed, syn)
+```
+
+### HFSCX-256 hash and MAC
+
+```go
+data := []byte("hello")
+
+/* Bare hash */
+digest := Hfscx256(data, nil)
+
+/* Keyed MAC: iv = key XOR Hfscx256IV */
+keyBytes := aliceShared.Bytes()
+macIV := make([]byte, 32)
+for i := range macIV {
+    macIV[i] = keyBytes[i] ^ Hfscx256IV[i]
+}
+mac := Hfscx256(data, macIV)
 ```
 
 ### Complete runnable example
@@ -316,6 +400,22 @@ recovered  = h.fscx_revolve(ciphertext, alice_shared, h.R_VALUE)
 assert plaintext == recovered
 ```
 
+### HSKE-NL-A1 counter-mode encryption (NL/PQC)
+
+```python
+key   = h.BitArray.random(n)
+nonce = h.BitArray.random(n)
+pt    = h.BitArray.random(n)
+
+base  = h.BitArray(n, key.uint ^ nonce.uint)
+seed  = h.BitArray(n, base.rotated(n // 8).uint ^ h._RNL_KDF_DC_256)
+ks    = h.nl_fscx_revolve_v1(seed, h.BitArray(n, base.uint ^ 0), n // 4)  # counter=0
+ct    = h.BitArray(n, pt.uint ^ ks.uint)
+dec   = h.BitArray(n, ct.uint ^ ks.uint)
+assert dec == pt
+# Transmit nonce alongside ct so the recipient can reproduce the keystream.
+```
+
 ### HSKE-NL-A2 symmetric encryption (NL/PQC)
 
 ```python
@@ -353,6 +453,19 @@ seed, e_int, syndrome = h.stern_f_keygen(n)
 msg = h.BitArray.random(n)
 sig = h.hpks_stern_f_sign(msg, e_int, seed, syndrome, n)
 ok  = h.hpks_stern_f_verify(msg, sig, seed, syndrome, n)
+```
+
+### HFSCX-256 hash and MAC
+
+```python
+data = b"hello"
+
+# Bare hash
+digest = h.hfscx_256(data)
+
+# Keyed MAC: iv = key XOR IV
+mac_iv = h.BitArray(n, alice_shared.uint ^ int.from_bytes(h._HFSCX256_IV_BYTES, 'big'))
+mac = h.hfscx_256(data, iv=mac_iv)
 ```
 
 ### NumPy acceleration
@@ -403,6 +516,18 @@ See [`docs/examples/python/hello_herradura.py`](examples/python/hello_herradura.
 | HPKS-Stern-F | SD(N,t) + NL-FSCX v1 PRF | Demo params (rounds=32); production needs rounds≥219 |
 | HPKE-Stern-F | SD(N,t) | Demo only; decap requires QC-MDPC decoder for production |
 
+### Hash primitive
+
+| Primitive | Hard problem | Output |
+|-----------|-------------|--------|
+| HFSCX-256 | NL-FSCX v1 one-wayness | 256 bits (32 bytes) |
+
+Merkle-Damgård construction: each 32-byte message block is fed through
+`nl_fscx_revolve_v1(state, block, 64)` with the previous state as the chaining
+variable.  ISO 7816-4 padding appends `0x80` then zeros to a 32-byte boundary,
+followed by a length block.  The domain IV is the 32-byte ASCII string
+`HFSCX-256/HERRADURA-SUITE\0\0\0\0\0\0\0`.
+
 ### C high-level wrappers (added in v1.7.4)
 
 ```c
@@ -444,9 +569,13 @@ int  hpks_stern_f_verify (const SternSig *sig, const BitArray *msg,
 | RLWR reconciliation pp | `RNL_PP` | `RnlPP` | `RNLPP` | 4 |
 | RLWR polynomial degree | `RNL_N` | (= key bits) | (= `KEYBITS`) | 256 |
 | RLWR secret distribution | `RNL_ETA` | — | `RNLB` | 1 (CBD) |
-| Stern error weight | `SDF_T` | `SdfT` | `SDFT` | 16 |
-| Stern ZKP rounds (demo) | `SDF_ROUNDS` | `SdfRounds` | `SDFR` | 32 |
+| Stern error weight | `SDF_T` | `SdfT` | `SDFT` | 16 (N=256; T=N/16) |
+| Stern ZKP rounds (demo) | `SDF_ROUNDS` | `SdfRounds` | `SDFR` | 32 (N=256) |
 | GF generator | `GF_GEN` (BitArray) | `GfGen = 3` | `GF_GEN = 3` | 3 |
+| HFSCX-256 domain IV | `_HFSCX256_IV[32]` | `Hfscx256IV` | `_HFSCX256_IV_BYTES` | `b'HFSCX-256/HERRADURA-SUITE\x00…'` |
+
+Stern-F parameters scale with N: T = N/16, rows = N/4.  C/Go/Python support
+N ∈ {32, 64, 128, 256}; assembly and Arduino targets are fixed at N=32 (T=2, rounds=4).
 
 ---
 
@@ -463,6 +592,12 @@ models that exclude quantum adversaries.
 
 ### NL/PQC protocols (HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL)
 
+- **HKEX-GF / HKEX-RNL raw shared secret:** The raw output of `hkex_gf_agree`
+  (a GF(2^n) element) and `rnl_agree` (a Ring-LWR reconciliation value) both
+  retain algebraic structure and non-uniform bit distribution.  Post-hash through
+  HFSCX-256 before using the value as a symmetric key.  In the CLI, pass
+  `--kdf hfscx-256` to `kex`; in library code call `hfscx_256` / `Hfscx256` /
+  `hfscx_256` directly.  Both parties must apply the same step.
 - **HKEX-RNL** is conjectured quantum-resistant, based on Ring-LWR hardness.
   It has not been formally reduced from NIST-standardised parameters.
 - **HKEX-RNL unauthenticated hint:** The Peikert reconciliation hint vector


### PR DESCRIPTION
## Summary

- **HFSCX-256 hash/MAC/KDF** (`--kdf hfscx-256` CLI flag): Merkle-Damgård hash over NL-FSCX v1, demo blocks added to all suite files (C, Go, Python), keyed MAC and AEAD tag in `encfile`/`decfile` (TODO #68)
- **Documentation gap-fill**: `docs/TUTORIAL.md` updated with HFSCX-256 API examples (C/Go/Python), HSKE-NL-A1 counter-mode examples, Stern-F multi-size parameter note, and KDF security note (TODO #69); `docs/INTRODUCTION.md` updated with new Part 4.5 (Merkle-Damgård, compression function, keyed MAC, AEAD), KDF derivation notes in §3.3/§9.4, updated protocol table and decision tree, and four new glossary entries (TODO #70)
- **Math rendering fixes**: Rule 5 blank-line and `\begin{cases}` row-separator violations corrected in `SecurityProofs-2.md`; README changelog/version-note policy enforced in `CLAUDE.md`

## Test plan

- [ ] Run suite programs and verify HFSCX-256 demo block output is consistent across C, Go, and Python
- [ ] Run `HerraduraCli` with `--kdf hfscx-256` on `kex` and verify derived key differs from raw shared secret
- [ ] Run `encfile`/`decfile` CLI round-trip and verify MAC tag catches any ciphertext tampering
- [ ] Review `docs/TUTORIAL.md` HFSCX-256 and HSKE-NL-A1 code snippets against actual API signatures in `herradura.h` / `herradura/herradura.go`
- [ ] Review `docs/INTRODUCTION.md` Part 4.5 for conceptual accuracy; verify cross-references to SP2 §11.2 and TUT §HFSCX-256 resolve correctly
- [ ] Verify SecurityProofs-2.md math renders without errors on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)