### PR TITLE
Fix stale security claims; add TODO #72-74

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ HKEX-GF is a standard Diffie-Hellman key exchange over the multiplicative group 
 | 32  | $x^{32}+x^{22}+x^2+x+1$ (`0x00400007`) | demo only |
 | 64  | $x^{64}+x^4+x^3+x+1$ (`0x1B`) | ~40 bits |
 | 128 | $x^{128}+x^7+x^2+x+1$ (`0x87`) | ~60–80 bits |
-| 256 | $x^{256}+x^{10}+x^5+x^2+1$ (`0x425`) | ~128 bits (recommended) |
+| 256 | $x^{256}+x^{10}+x^5+x^2+1$ (`0x425`) | ~80–90 bits (FFS L[1/3]; deprecated NIST/ENISA — see §9.2.4) |
 
 ---
 

--- a/SecurityProofs-1.md
+++ b/SecurityProofs-1.md
@@ -1,7 +1,7 @@
 # Formal Cryptographic Analysis of the Herradura Cryptographic Suite
 
 **Status:** Formal proof of insecurity complete; HKEX-GF fix implemented in v1.4.0.  NL-FSCX non-linearity and PQC extensions implemented in v1.5.0 (§11).  Full quantum algorithm analysis in §6 (merged from PQCanalysis.md, v1.4.1).  Deployed-parameter verification and §6 NL-protocol rows added in v1.5.1.  HKEX-RNL secret sampler upgraded to CBD(eta=1) in v1.5.3 (§11.4.2, §11.6).  HKEX-RNL polynomial multiplication replaced with negacyclic NTT over $\mathbb{Z}_{65537}$ in v1.5.4 (O(n log n), ~32× speedup at n=256).  Peikert 1-bit reconciliation deployed in v1.5.16 (§11.4.2, §11.6) — HKEX-RNL correctness now guaranteed.  HFSCX-256 Merkle-Damgård hash finalizer added to stern_hash in v1.6.0 (§11.9); domain-separation parameter added in v1.6.1 (§11.8.4, Theorem 17).  KDF domain constant `_RNL_KDF_DC` added in v1.8.0.  stern_gen_perm PRNG bias eliminated in v1.8.1; H-matrix precomputed once per sign/verify in v1.8.2.  N=128 HPKS-Stern-F implemented in v1.8.7.
-**Last updated:** 2026-05-25 (v1.8.8)
+**Last updated:** 2026-06-03 (v1.8.10)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -4059,3 +4059,93 @@ Status: **DONE** (2026-06-03)
 | HFSCX-256 | No new generic Merkle-Damgård attacks beyond known length-extension / multi-collision. No published cryptanalysis of NL-FSCX v1 compression function. | No new threat; collision bound 2^128 remains valid. | None. |
 | Quantum algorithms | NIST SP 800-235 draft (2024) is the current reference. No new speedups beyond Grover / BKZ-hybrid through 2025. No quantum speedup for syndrome decoding beyond √-speedup for ISD. | Grover halving for symmetric primitives unchanged. Shor still breaks all GF(2^n)* DLP. BKZ-quantum hybrid for lattices unchanged at ~core-SVP. | None. |
 
+---
+
+### 72. Davies-Meyer feed-forward for HFSCX-256 (Security/Correctness, Low)
+
+**Rationale:** The deployed compression function $C(s, m) = F_1^{64}(s, m)$ lacks a
+Davies-Meyer feed-forward.  The Davies-Meyer variant $C_{\text{DM}}(s, m) = F_1^{64}(s, m)
+\oplus s$ provides provable fixed-point hardness and free-start collision hardness that the
+current construction lacks (§11.9.8).  The three prerequisites for bundling this change —
+TODO #37 (`_rnl_lift` centered rounding), TODO #38 (KDF domain constant), and TODO #39
+(2-bit Peikert reconciliation) — are all DONE, removing the last stated blocker.
+
+**Scope:**
+- Add XOR feed-forward to the `F_1^{64}` compression step in HFSCX-256 across all six
+  language targets (Python, C, Go, ARM, i386, Arduino).
+- Update `SecurityProofsCode/hfscx_256_analysis.py` tests that measure fixed-point counts
+  and collision rates.
+- Bump the construction name to `HFSCX-256-DM` and update §11.9.1 compression-function
+  definition in SecurityProofs-2.md.
+- This is a **wire-format breaking change**: all existing HFSCX-256 digests, pre-hashed
+  signatures, and AEAD tags become incompatible.  Plan for a version bump and migration
+  note in CHANGELOG.md.
+
+**Security gain:** Aligns with PGV-1 (one of the 12 provably-secure Davies-Meyer-family
+compression functions [Black-Rogaway-Shrimpton 2002]).  Fixed-point hardness: finding
+$s$ with $F_1^{64}(s, m) = 0$ requires $\Omega(2^{n/2})$ work (preimage of zero under A2).
+
+**Suggested approach:** Implement and test in a single batch across all targets; bundle
+with any other breaking wire-format changes scheduled for v2.0.
+
+Status: **PENDING**
+
+---
+
+### 73. Per-slot domain-separation tags for Assembly/Arduino Stern-F (Security, Low)
+
+**Rationale:** The 256-bit language targets (Python, C, Go) carry per-slot DS tags
+(ds=1 for $c_0$, ds=2 for $c_1$, ds=3 for $c_2$, ds=4 for the KEM key) through the
+`_stern_hash` / `stern_hash` / `SternHash` functions, providing independent random oracles
+for each commitment slot as required by Unruh's QROM Fiat-Shamir transform (§11.9.9,
+TODO #36 — DONE v1.6.1).
+
+The 32-bit ARM/i386/Arduino toy-demo implementations (`stern_hash1_32`, `stern_hash2_32`)
+currently use structural distinctness (different item counts) instead of explicit DS tags.
+At n=32 this limits same-slot collision probability to $\leq 2^{-32}$ — negligible for
+toy parameters — but it leaves a gap relative to the full QRO argument.
+
+**Scope:**
+- Add a `ds` parameter to `stern_hash1_32` and `stern_hash2_32` in the ARM
+  (`Herradura cryptographic suite.s`, `CryptosuiteTests/Herradura_tests.s`),
+  i386 (`.asm` equivalents), and Arduino (`.ino`) implementations.
+- Pass ds=1/2/3/4 at each call site (commit, verify, KEM encap/decap).
+- Verify sign+verify and encap+decap still pass for the n=32 demo after the change.
+
+**Note:** This is a hardening item for the toy demo; it does not affect the n=256
+production targets.  No wire-format change for the 256-bit targets.
+
+Status: **PENDING**
+
+---
+
+### 74. NL-FSCX v1 OWF — independent cryptanalysis required before production deployment (Research, High)
+
+**Rationale:** Both Option A (HPKS-WOTS-F, Theorem 16) and Option B (HPKS/HPKE-Stern-F,
+Theorem 17 PRF reduction) ultimately reduce security to the **NL-FSCX v1 one-way function
+assumption**: given $y = F_1^{64}(s, m)$ for known $m$, recovering $s$ requires
+$\Omega(2^{n/2})$ work.  This assumption is **new** and has not been reduced to a studied
+hard problem (§11.8.3, honest limitation).  Corollary 2 rules out Gröbner-basis algebraic
+attacks; the degree-saturation argument (Theorem 13) and exhaustive Walsh evidence at small
+$n$ support the assumption — but they do not constitute a formal proof or external validation.
+
+**Scope:** This is a research task, not a code task.
+
+1. **Literature survey:** Search IACR ePrint, FSE/ToSC, and Crypto/Eurocrypt proceedings
+   for any published cryptanalysis of NL-FSCX v1 or structurally similar carry-injected
+   XOR-rotation primitives.
+2. **Dedicated cryptanalysis attempt:** Apply known techniques — algebraic degree analysis
+   beyond Theorem 13, differential/linear cryptanalysis, meet-in-the-middle on the carry
+   channel, SAT/MILP formulations — to $F_1^r$ for $r \in \{2, 4, 8, 16, 64\}$ at $n=32$.
+3. **Formal reduction (aspirational):** Attempt to reduce NL-FSCX v1 OWF to a known hard
+   problem (e.g., Learning Parity with Noise, approximate short integer solution, or a
+   bounded-carry variant of LWE).
+4. **Document findings** in SecurityProofs-2.md §11.8.3 and update Theorem 16's honest
+   limitation paragraph.
+
+**Risk:** Until external cryptanalysis validates or refutes the OWF assumption,
+HPKS-Stern-F / HPKE-Stern-F should be considered research-quality software.  BIKE and HQC
+(NIST alternates) rest on the quasi-cyclic syndrome decoding assumption, which has received
+far more external scrutiny.
+
+Status: **PENDING**


### PR DESCRIPTION
## Summary

- **README.md**: corrected n=256 HKEX-GF classical security from `~128 bits (recommended)` to `~80–90 bits (FFS L[1/3]; deprecated NIST/ENISA — see §9.2.4)` — inconsistency introduced by the TODO #71 security proof corrections in v1.8.10
- **SecurityProofs-1.md**: bumped `Last updated` from 2026-05-25 (v1.8.8) to 2026-06-03 (v1.8.10)
- **TODO.md**: added three new items surfaced by reviewing SecurityProofs notes:
  - **#72** Davies-Meyer feed-forward for HFSCX-256 — wraps `F_1^{64}` with `⊕ s`; all blockers (#37, #38, #39) now DONE; wire-format breaking change, target v2.0
  - **#73** Per-slot DS tags for Assembly/Arduino Stern-F — aligns 32-bit toy demo with the full QRO argument already in place for 256-bit targets
  - **#74** NL-FSCX v1 OWF independent cryptanalysis — research task required before production deployment of HPKS/HPKE-Stern-F

All three new items preserve NL-FSCX v1 as the core primitive (verified).

## Test plan

- [x] KaTeX validation: SecurityProofs-1.md 773 OK / 0 FAIL (no math changed)
- [x] Documentation-only changes — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)