### PR TITLE
ZKP-RNL + ZKP-NL full suite implementation (TODO #77) — v1.9.13

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "bgIsolation": "none"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,287 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.13] - 2026-06-06
+
+### Feature — ZKP documentation Batch 9: TUTORIAL.md ZKP Protocols section + SecurityProofs-3.md §11.10.4 implementation subsection (TODO #77, Batch 9)
+
+Adds comprehensive ZKP documentation completing TODO #77.
+
+**`docs/TUTORIAL.md`** — new top-level `## ZKP Protocols` section:
+- When to use ZKP-RNL vs. ZKP-NL vs. HPKS-Stern-F (use-case guidance).
+- ZKP-RNL API walk-through (keygen → sign → verify) with C, Go, and Python snippets.
+- ZKP-NL API walk-through (keygen → prove → verify) with C, Go, and Python snippets.
+- CLI usage: `genpkey hkex-rnl`, `sign --algo rnl-sigma`, `verify --algo rnl-sigma`;
+  `genpkey hpks-zkp-nl`, `sign --algo nl-zkboo --rounds 4`, `verify --algo nl-zkboo`.
+- Proof-size and performance comparison table (ZKP-RNL vs ZKP-NL vs HPKS-Stern-F vs ML-DSA-44).
+- `### ZKP protocols` subsection added to Protocol reference.
+
+**`SecurityProofs-3.md`** — new §11.10.4 Suite Implementation subsection:
+- Function-name table per language target (C / Go / Python / ARM / NASM / Arduino).
+- Implemented proof-size table.
+- Comparison of ZKP-RNL 1,056 B vs HPKS-Stern-F 78 KB vs ML-DSA-44 2,420 B.
+- Note: ZKP-NL at n=256 (920 KB) awaits ZKB++ (§11.10.6 open direction 3).
+- Updated §11.10.1 applicability matrix: "Prototype" → "Implemented v1.9.x".
+- Updated §11.10.5 comparison table: implementation status notes.
+- Renumbered: old §11.10.4 Comparison → §11.10.5; old §11.10.5 Open → §11.10.6.
+
+**Files changed:**
+- `docs/TUTORIAL.md` — new ZKP Protocols section; ZKP entry in Protocol reference; Contents entry 4 added (5→6→7 renumber)
+- `SecurityProofs-3.md` — §11.10.4 new; §11.10.4→§11.10.5; §11.10.5→§11.10.6; applicability matrix + comparison table updated
+- `TODO.md` — Batch 9 marked DONE v1.9.13; Status updated
+- `README.md` — version bumped to v1.9.13
+
+---
+
+## [1.9.12] - 2026-06-06
+
+### Feature — ZKP CLI test suite Batch 8: CliTest ZKP-RNL + ZKP-NL shell tests (TODO #77, Batch 8)
+
+Adds five CliTest shell scripts covering ZKP-RNL and ZKP-NL sign/verify through all three CLI implementations, with cross-language interop verification.  Also fixes Python CLI output consistency (`"Proof OK"` → `"Signature OK"` for `rnl-sigma` and `nl-zkboo` verify to match C and Go output).
+
+**New scripts:**
+- `CliTest/test_zkp_rnl.sh` — Python CLI `genpkey hkex-rnl` → `sign rnl-sigma` → `verify rnl-sigma`; correct-msg PASS, wrong-msg reject, wrong-pubkey reject.
+- `CliTest/test_zkp_nl.sh` — Python CLI `genpkey hpks-zkp-nl` → `sign nl-zkboo --rounds 4` → `verify nl-zkboo`; correct PASS, wrong-msg reject, wrong-pubkey reject.
+- `CliTest/test_c_zkp_rnl.sh` — C CLI same ZKP-RNL round-trip.
+- `CliTest/test_go_zkp_rnl.sh` — Go CLI same ZKP-RNL round-trip.
+- `CliTest/test_zkp_interop.sh` — Full 6-direction cross-language interop for ZKP-RNL (Python↔C↔Go) and ZKP-NL (Python↔C↔Go); `--rounds 4` for speed.
+
+**Python CLI fix:** `cmd_verify` for `rnl-sigma` and `nl-zkboo` now prints `"Signature OK"` on success (was `"Proof OK"`), consistent with C and Go.
+
+**Files changed:**
+- `CliTest/test_zkp_rnl.sh` — new
+- `CliTest/test_zkp_nl.sh` — new
+- `CliTest/test_c_zkp_rnl.sh` — new
+- `CliTest/test_go_zkp_rnl.sh` — new
+- `CliTest/test_zkp_interop.sh` — new
+- `HerraduraCli/herradura.py` — "Proof OK" → "Signature OK" for ZKP verify
+- `TODO.md` — Batch 8 marked DONE v1.9.12
+- `README.md` — version bumped to v1.9.12
+
+---
+
+## [1.9.11] - 2026-06-06
+
+### Feature — ZKP test suite Batch 7: CryptosuiteTests ZKP-RNL + ZKP-NL security tests + benchmarks (TODO #77, Batch 7)
+
+Adds ZKP correctness and tamper-rejection security tests plus throughput benchmarks to all three compiled test targets.  Tests call the production library functions (not self-contained stubs).
+
+**`CryptosuiteTests/Herradura_tests.c`** — v1.9.11:
+- `[21] ZKP-RNL` — `rnl_sigma_sign` + `rnl_sigma_verify` completeness + wrong-message tamper at n∈{32,256}.
+- `[22] ZKP-NL` — `zkp_nl_prove` + `zkp_nl_verify` completeness + commitment-flip tamper at n∈{32,64}, R=16 rounds.
+- `[33] bench_zkp_rnl` — sign+verify throughput at n=256.
+- `[34] bench_zkp_nl` — prove+verify throughput at n=32, R=16.
+- Benchmarks renumbered [21]–[30] → [23]–[32].
+
+**`CryptosuiteTests/Herradura_tests.go`** — v1.9.11:
+- `[20] testZkpRnlCorrectness` + `[21] testZkpNlCorrectness`; `[32] benchZkpRnl` + `[33] benchZkpNl`.
+- Benchmarks renumbered [20]–[29] → [22]–[31].
+
+**`CryptosuiteTests/Herradura_tests.py`** — v1.9.11:
+- `[20] test_zkp_rnl_correctness` + `[21] test_zkp_nl_correctness`; `[32]`/`[33]` benchmarks.
+- Benchmarks renumbered [20]–[29] → [22]–[31].
+
+**Files changed:**
+- `CryptosuiteTests/Herradura_tests.c` — new tests [21][22], benches [33][34], renumbered [23]–[32]
+- `CryptosuiteTests/Herradura_tests.go` — new tests [20][21], benches [32][33], renumbered [22]–[31]
+- `CryptosuiteTests/Herradura_tests.py` — new tests [20][21], benches [32][33], renumbered [22]–[31]
+- `TODO.md` — Batch 7 marked DONE v1.9.11
+- `README.md` — version bumped to v1.9.11
+
+---
+
+## [1.9.10] - 2026-06-05
+
+### Feature — ZKP library Batch 6: Arduino ZKP-RNL + ZKBoo demo (TODO #77, Batch 6)
+
+Adds ZKP-RNL Ring-LWR Σ-protocol and minimal ZKBoo MPC-in-the-head demo to the Arduino suite (`Herradura cryptographic suite.ino`, v1.9.10).  All allocation is via `static long` / `static uint8_t` arrays — no heap, no `malloc`.  Targets Arduino Mega (8 KB SRAM).
+
+**New `#define` constants** — `SIGMA_GAMMA=4096`, `SIGMA_T=4`, `SIGMA_BOUND=4092`, `SIGMA_SLACK=32`, `SIGMA_RANGE=8193`; `ZKP_NL_N=8`, `ZKP_NL_R=4`.
+
+**New ZKP-RNL functions (module-scope statics):**
+- `sig_y`, `sig_w`, `sig_c`, `sig_z` — shared prover/verifier poly scratch (32 `long` each).
+- `sig_tmp0`–`sig_tmp4` — additional poly scratch shared between sign and verify.
+- `sigma_challenge(m, C_pub, w, msg)` — derives `SIGMA_T`-sparse ternary challenge into `sig_c` via chained `hfscx_32` seed expansion.
+- `rnl_sigma_sign(m, s, C_pub, msg) → int` — rejection-sampling prover; up to 200 attempts; fills `sig_w`, `sig_c`, `sig_z`.
+- `rnl_sigma_verify(m, C_pub, msg) → int` — three-step verifier: (1) ‖z‖∞ ≤ SIGMA_BOUND; (2) challenge consistency; (3) ‖m·z − c·lift(C) − w‖∞ ≤ SIGMA_SLACK.
+
+**New ZKBoo functions:**
+- `zkp_nl_f1_8(A, B)` — scalar F1(A,B) at 8 bits: FSCX_8(A,B) XOR ROL8((A+B) mod 256, 2).
+- `zkp_eval(s0,s1,s2, t0,t1,t2, B, o0,o1,o2, gva,gvb,gvc)` — 3-party ripple-carry evaluation of F1 at 8 bits; gate views encoded as `ai|(ci<<1)|(ao<<2)`.
+- `zkp_nl_prove_8(A, B, y, msg)` — Fiat-Shamir prover; stores proof in module-level statics `zkp_coms`, `zkp_e`, `zkp_sh1/2`, `zkp_tp1/2`, `zkp_out1/2`, `zkp_gv1/2`.
+- `zkp_nl_verify_8(B, y, msg) → int` — recomputes Fiat-Shamir challenges; checks commitments and AND-gate consistency for revealed parties p1=(e+1)%3, p2=(e+2)%3.
+
+**`loop()` changes:** HKEX-RNL key arrays (`m_blind`, `s_A`, `C_A`, etc.) lifted to `loop()`-scope statics for reuse by the ZKP-RNL demo. Two new demo blocks added before `delay(10000)`.
+
+---
+
+## [1.9.9] - 2026-06-05
+
+### Feature — ZKP library Batch 5: NASM i386 `rnl_sigma_sign_32` / `rnl_sigma_verify_32` (TODO #77, Batch 5)
+
+Adds ZKP-RNL Ring-LWR Σ-protocol sign and verify to the NASM i386 assembly suite (`Herradura cryptographic suite.asm`, v1.9.9). Reuses existing `rnl_poly_mul` (NTT-based), `hfscx_32` (DM-hash), and `rnl_lift` subroutines.
+
+**New `%define` constants** — `SIGMA_GAMMA=4096`, `SIGMA_T=4`, `SIGMA_BOUND=4092`, `SIGMA_SLACK=32`, `SIGMA_RANGE=8193`.
+
+**New `.bss` arrays** — `sig_y`, `sig_w`, `sig_c`, `sig_z` (128 B each), `sig_pos` (16 B for t=4 positions), `sigma_yq_tmp`, `sigma_liftc_tmp`, `sigma_mz_tmp`, `sigma_cw_tmp` (128 B each).
+
+**New functions:**
+- `sigma_fold_poly_32(eax=seed, ebx=poly_ptr) → eax=seed` — folds 32 coefficients into seed via hfscx_32; ESI/ECX preserved across hfscx_32 calls.
+- `sigma_challenge_32(eax=m_ptr, ebx=C_ptr, ecx=w_ptr, edx=msg)` — local stack frame; derives sparse ternary challenge into `sig_c` via chained hfscx_32 seed expansion (t=4 nonzero positions, ±1 signs).
+- `rnl_sigma_sign_32(eax=msg) → eax=0 ok / eax=-1 fail` — rejection-sampling prover with local stack frame; up to 200 attempts; fills `sig_w`, `sig_c`, `sig_z`; uses globals `rnl_s_A`, `rnl_m_blind`, `rnl_C_A` from HKEX-RNL.
+- `rnl_sigma_verify_32(eax=msg) → eax=1 ok / eax=0 fail` — three-step verifier with local stack frame: (1) ‖z‖∞ ≤ SIGMA_BOUND=4092; (2) recomputed challenge matches stored; (3) ‖m·z − c·lift(C) − w‖∞ ≤ SIGMA_SLACK=32; saves/restores EBP around `rnl_lift` call.
+
+**Demo block added to `_start`** — prints header, calls `rnl_sigma_sign_32(0xDEADB00B)` then `rnl_sigma_verify_32`, reports pass/fail before exit.
+
+---
+
+## [1.9.8] - 2026-06-05
+
+### Feature — ZKP library Batch 4: ARM Thumb-2 `rnl_sigma_sign_32` / `rnl_sigma_verify_32` (TODO #77, Batch 4)
+
+Adds ZKP-RNL Ring-LWR Σ-protocol sign and verify to the ARM Thumb-2 assembly suite (`Herradura cryptographic suite.s`, v1.9.8). Reuses existing `rnl_poly_mul` (NTT-based) and `hfscx_32` (DM-hash) subroutines.
+
+**New `.equ` constants** — `SIGMA_GAMMA`, `SIGMA_T`, `SIGMA_BOUND`, `SIGMA_SLACK`, `SIGMA_RANGE` (n=32 parameters).
+
+**New `.bss` arrays** — `sig_y`, `sig_w`, `sig_c`, `sig_z` (128 B each), `sig_pos` (16 B), `sigma_yq_tmp`, `sigma_liftc_tmp`, `sigma_mz_tmp`, `sigma_cw_tmp` (128 B each).
+
+**New functions:**
+- `sigma_fold_poly_32(r0=seed, r1=poly) → r0=seed` — chains 32 coefficients into seed via hfscx_32.
+- `sigma_challenge_32(r0=m, r1=C, r2=w, r3=msg)` — derives sparse ternary challenge into `sig_c` using chained hfscx_32 seed, t=4 positions, sign bits.
+- `rnl_sigma_sign_32(r0=msg) → r0=0 ok / 0xFFFFFFFF=fail` — rejection-sampling prover; fills `sig_w`, `sig_c`, `sig_z`; uses globals `rnl_s_A`, `rnl_m_blind`, `rnl_C_A` from HKEX-RNL.
+- `rnl_sigma_verify_32(r0=msg) → r0=1 ok / r0=0 fail` — three-step verifier: (1) ‖z‖∞ ≤ SIGMA_BOUND; (2) recomputed c′ = stored c; (3) ‖m·z − c·lift(C) − w‖∞ ≤ SIGMA_SLACK.
+
+**Demo block added to `main()`** — prints header, message scalar, calls sign then verify, reports pass/fail.
+
+---
+
+## [1.9.7] - 2026-06-05
+
+### Feature — ZKP library Batch 3: Go package + Go CLI (TODO #77, Batch 3)
+
+Adds ZKP-RNL (Ring-LWR Σ-protocol) and ZKP-NL (NL-FSCX ZKBoo) to the `herradurakex/herradura` Go package and extends `herradura_cli_go` with `sign`/`verify` subcommands for both proofs.
+
+**New exported functions in `herradura/herradura.go`:**
+- `ZkpRnlParams(n)` — returns (gamma, t) for ZKP-RNL at bit-width n.
+- `RnlSigmaSign(s, m, C, n, msg)` — ZKP-RNL prover with rejection sampling; returns (w, c, z, err).
+- `RnlSigmaVerify(m, C, n, msg, w, c, z)` — three-check ZKP-RNL verifier (‖z‖∞, FS challenge, rounding slack).
+- `ZkpNlKeygen(n)` — generates (A, B, y=nl_fscx_v1(A,B), err) as uint32.
+- `ZkpNlProve(A, B, y, n, rounds, msg)` — MPC-in-the-head ZKBoo prover; returns []ZkpNlRound.
+- `ZkpNlVerify(B, y, n, rounds, msg, proof)` — verifies ZKBoo proof; re-evaluates p1 AND gates.
+- `ZkpNlRound` struct — per-round ZKBoo proof with Com0/Com1/Com2 [32]byte, E int, ViewP1/ViewP2 []byte.
+
+**New PEM label constants in `herradura/codec.go`:**
+- `PemZkpRnlProof`, `PemZkpNlPriv`, `PemZkpNlPub`, `PemZkpNlProof`.
+
+**Extensions to `HerraduraCli/herradura_cli.go`:**
+- `genpkey --algo hpks-zkp-nl` — generates ZKP-NL keypair (raw binary PEM).
+- `pkey --in zkpnl.pem (--pubout | --text)` — extracts public key or prints fields for ZKP-NL keys.
+- `sign --algo rnl-sigma --key rnl.pem --in msg` — ZKP-RNL Σ-protocol signature.
+- `sign --algo nl-zkboo --key zkpnl.pem --in msg` — ZKBoo proof (demo rounds=4).
+- `verify --algo rnl-sigma --pubkey rnl_pub.pem --sig proof.pem` — verify ZKP-RNL proof.
+- `verify --algo nl-zkboo --pubkey zkpnl_pub.pem --sig proof.pem` — verify ZKBoo proof.
+
+**Demo blocks added to `Herradura cryptographic suite.go`:**
+- ZKP-RNL proof at n=32; ZKP-NL proof at n=8, R=4.
+
+---
+
+## [1.9.6] - 2026-06-05
+
+### Feature — ZKP library Batch 2: C header-only library + C CLI (TODO #77, Batch 2)
+
+Adds the Ring-LWR Σ-protocol (ZKP-RNL) and NL-FSCX ZKBoo (ZKP-NL) as static inline functions in `herradura.h` and as `sign`/`verify` subcommands in `herradura_cli.c`.  Python↔C bidirectional PEM interoperability verified.
+
+**New static functions in `herradura.h`:**
+- `sigma_params(n, &gamma, &t)` — ZKP-RNL parameter selector (γ, t) by polynomial dimension.
+- `sigma_poly_mul_n(h, f, g, n, q)` — O(n²) negacyclic multiplication for n ≠ RNL_N=256 (used for small-n demo; NTT path used for n=256).
+- `sigma_poly_bytes(out, poly, n)` — serialize n coefficients as n×4 big-endian bytes (matches Python `_sigma_poly_bytes`).
+- `sigma_challenge(m, Cp, w, n, q, t, msg, mlen, c_out)` — Fiat-Shamir sparse-ternary challenge derivation; uses `hfscx_256` with seed||"pos" / seed||"sgn" counter expansion.
+- `rnl_sigma_sign(s, m, Cp, n, msg, mlen, urnd, w_out, c_out, z_out)` — ZKP-RNL prover with rejection sampling; returns 0 or -1.
+- `rnl_sigma_verify(m, Cp, n, msg, mlen, w, c, z)` — three-check verifier (‖z‖∞ bound, FS challenge, rounding slack); returns 1/0.
+- `ZkpNlRound` struct — per-round ZKBoo proof: three 32-byte commitments, hidden-party index, and two heap-allocated party views.
+- `zkp_nl_proof_free(proof, rounds)` — free heap memory in a ZkpNlRound array.
+- `zkp_nl_rol(x, r, n)` — n-bit cyclic left-rotate.
+- `zkp_nl_commit(out, j, p, tape, out_share, nb)` — HFSCX-256 commitment: hash(j(4B)||p(1B)||tape(32B)||out_share(nb B)).
+- `zkp_nl_prg_bit(tape, gate_id)` — deterministic PRG bit from tape and gate index.
+- `zkp_nl_eval_3p(...)` — 3-party ZKBoo evaluation of nl_fscx_v1(A,B); carries the AND-gate chain; fills output shares and per-party gate-view bytes.
+- `zkp_nl_pack_view` / `zkp_nl_unpack_view` — view buffer serialize/deserialize.
+- `zkp_nl_f1(A, B, n)` — scalar evaluation of nl_fscx_v1 for keygen.
+- `zkp_nl_keygen(n, urnd, A_out, B_out, y_out)` — ZKBoo keypair generation.
+- `zkp_nl_prove(A, B, y, n, rounds, msg, mlen, urnd)` — heap-allocated ZkpNlRound proof array; fully Fiat-Shamir compiled.
+- `zkp_nl_verify(B, y, n, rounds, msg, mlen, proof)` — commitment check + AND-gate re-evaluation.
+- Constants: `SIGMA_MAX_ATTEMPTS` (1000), `ZKP_NL_DEFAULT_N` (8), `ZKP_NL_DEMO_ROUNDS` (4), `ZKP_NL_PROD_ROUNDS` (219), `ZKP_NL_MAX_N` (32).
+
+**New PEM label macros in `HerraduraCli/herradura_codec.h`:**
+- `PEM_ZKP_RNL_PROOF`, `PEM_ZKP_NL_PRIV`, `PEM_ZKP_NL_PUB`, `PEM_ZKP_NL_PROOF`.
+
+**Extended `HerraduraCli/herradura_cli.c`:**
+- Helper `zkp_raw_pem_read` — reads raw-binary (non-DER) PEM; label check before `pem_key_load`.
+- Helper `zkp_pem_peek_label` — reads label without allocating DER parse result.
+- Helpers `zkp_nl_pack_proof` / `zkp_nl_unpack_proof` — serialize/deserialize ZkpNlRound arrays matching Python `encode_zkp_nl_proof` / `decode_zkp_nl_proof`.
+- `genpkey --algo hpks-zkp-nl` — writes `HERRADURA ZKP-NL PRIVATE KEY` PEM (raw binary: 4B n | nb A | nb B | nb y).
+- `pkey --in zkpnl.pem --pubout` — detects `ZKP-NL PRIVATE KEY` label via peek; writes `HERRADURA ZKP-NL PUBLIC KEY`.
+- `sign --algo rnl-sigma --key hkex-rnl.pem` — derives C_p from privkey, calls `rnl_sigma_sign`, writes `HERRADURA ZKP-RNL PROOF` PEM.
+- `sign --algo nl-zkboo --key zkpnl.pem` — early-exit before `pem_key_load`; calls `zkp_nl_prove` at `ZKP_NL_PROD_ROUNDS=219`.
+- `verify --algo rnl-sigma --pubkey hkex-rnl-pub.pem` — calls `rnl_sigma_verify`.
+- `verify --algo nl-zkboo --pubkey zkpnl-pub.pem` — early-exit; calls `zkp_nl_verify`.
+
+**Extended `Herradura cryptographic suite.c` `main()`:**
+- ZKP-RNL demo block (n=256 keypair; sign + verify).
+- ZKP-NL demo block (n=8, R=ZKP_NL_DEMO_ROUNDS=4; keygen, prove, verify, free).
+
+---
+
+## [1.9.5] - 2026-06-05
+
+### Feature — ZKP library Batch 1: Python suite + codec + CLI (TODO #77, Batch 1)
+
+Implements the Ring-LWR Σ-protocol (HPKS-ZKP-RNL) and NL-FSCX ZKBoo (HPKS-ZKP-NL) as first-class library functions, DER/PEM wire format, and OpenSSL-style CLI subcommands.  Derived from the reference prototype in `SecurityProofsCode/zkp_pqc_exploration.py`.
+
+**New library functions in `Herradura cryptographic suite.py`:**
+- `rnl_sigma_sign(s_poly, m_poly, C_poly, n, msg_bytes)` → `(w, c, z)` — Lyubashevsky rejection-sampling prover; Fiat-Shamir message binding via `hfscx_256`.
+- `rnl_sigma_verify(m_poly, C_poly, n, msg_bytes, w, c, z)` → `bool` — three-check verifier (‖z‖∞, FS challenge, rounding slack).
+- `zkp_nl_keygen(n)` → `(A, B, y)` — ZKBoo keypair where `y = nl_fscx_v1(A, B)`.
+- `zkp_nl_prove(A, B, y, n, rounds, msg_bytes)` → proof list — 3-party MPC-in-the-head with per-party tapes, AND-gate carry chain, Fiat-Shamir challenge.
+- `zkp_nl_verify(B, y, n, rounds, msg_bytes, proof_rounds)` → `bool` — commitment check + AND-gate consistency re-evaluation.
+- Helper constants: `_SIGMA_GAMMA`, `_SIGMA_T`, `_SIGMA_MAX_ATTEMPTS`, `_ZKP_NL_DEFAULT_N` (8), `_ZKP_NL_DEMO_ROUNDS` (4), `_ZKP_NL_PROD_ROUNDS` (219).
+
+**New codec functions in `HerraduraCli/codec.py`:**
+- `encode_zkp_rnl_proof` / `decode_zkp_rnl_proof` — PEM label `HERRADURA ZKP-RNL PROOF`; raw binary: 4B n + n×4B w (s32-be) + n×4B c (u32-be) + n×4B z (s32-be).
+- `encode_zkp_nl_privkey` / `decode_zkp_nl_privkey` — PEM label `HERRADURA ZKP-NL PRIVATE KEY`; stores (A, B, y, n) so `pkey --pubout` works without re-evaluation.
+- `encode_zkp_nl_pubkey` / `decode_zkp_nl_pubkey` — PEM label `HERRADURA ZKP-NL PUBLIC KEY`.
+- `encode_zkp_nl_proof` / `decode_zkp_nl_proof` — PEM label `HERRADURA ZKP-NL PROOF`; round-length-prefixed views.
+
+**New CLI in `HerraduraCli/herradura.py` and `primitives.py`:**
+- `genpkey --algo hpks-zkp-nl [--bits N]` — generates ZKP-NL keypair.
+- `pkey --in priv.pem --pubout` — extracts ZKP-NL public key.
+- `sign --algo rnl-sigma --key hkex-rnl.pem --in msg.bin --out proof.pem` — Ring-LWR Σ-proof.
+- `sign --algo nl-zkboo --key zkpnl.pem --in msg.bin --out proof.pem [--rounds R]` — NL-FSCX ZKBoo proof (default R=219).
+- `verify --algo rnl-sigma --pubkey hkex-rnl-pub.pem --in msg.bin --sig proof.pem`.
+- `verify --algo nl-zkboo --pubkey zkpnl-pub.pem --in msg.bin --sig proof.pem`.
+
+**Files changed:**
+- `Herradura cryptographic suite.py` — new ZKP constants and 8 new functions; updated public API docstring and suite demo.
+- `HerraduraCli/codec.py` — 8 new encode/decode functions + self-test additions.
+- `HerraduraCli/primitives.py` — new re-exports for ZKP functions and constants.
+- `HerraduraCli/herradura.py` — `hpks-zkp-nl` key type, `rnl-sigma`/`nl-zkboo` sign/verify subcommands, updated `build_parser`.
+- `TODO.md` — TODO #77 Batch 1 marked done.
+- `README.md` — version bumped to v1.9.5.
+
+---
+
+## [1.9.4-p1] - 2026-06-05
+
+### Research — New application directions catalogue (TODO #78)
+
+Ten candidate applications of the Herradura primitives catalogued in `TODO.md` with construction sketches, implementation distances, and open questions: FPE (78.A), tweakable block cipher (78.B), NL-FSCX ratchet (78.C), PQC PAKE (78.D), non-Abelian KEx (78.E), VDF limited model (78.F), OPRF (78.G), masking-friendly implementation (78.H), ring/group signature (78.I), and HFSCX-256 accumulator (78.J). Recommended first implementations: 78.B (tweakable cipher), 78.A (FPE), 78.J (accumulator).
+
+**Files changed:**
+- `TODO.md` — TODO #78 added with 10 sub-items and summary table
+- `.claude/settings.json` — `bgIsolation: none` so background sessions edit devtest directly
+
+---
+
 ## [1.9.4] - 2026-06-04
 
 ### Research — Zero-knowledge proof exploration for PQC algorithms (TODO #76)

--- a/CliTest/test_c_zkp_rnl.sh
+++ b/CliTest/test_c_zkp_rnl.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# CliTest/test_c_zkp_rnl.sh — C CLI: ZKP-RNL (Ring-LWR Sigma-protocol) sign/verify round-trip
+set -euo pipefail
+
+CLI="$(dirname "$0")/../HerraduraCli/herradura_cli"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg2.bin"
+
+# ── ZKP-RNL (n=256, C CLI) ───────────────────────────────────────────────────
+"$CLI" genpkey --algo hkex-rnl --out "$TMP/rnl.pem"
+"$CLI" pkey    --in "$TMP/rnl.pem" --pubout --out "$TMP/rnl_pub.pem"
+"$CLI" sign    --algo rnl-sigma --key "$TMP/rnl.pem" \
+               --in "$TMP/msg.bin" --out "$TMP/rnl_sig.pem"
+
+check_verify "C rnl-sigma verify correct msg" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+check_reject "C rnl-sigma verify wrong msg" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/rnl_sig.pem"
+
+# Wrong pubkey rejection
+"$CLI" genpkey --algo hkex-rnl --out "$TMP/rnl_other.pem"
+"$CLI" pkey    --in "$TMP/rnl_other.pem" --pubout --out "$TMP/rnl_other_pub.pem"
+check_reject "C rnl-sigma verify wrong pubkey" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_other_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_go_zkp_rnl.sh
+++ b/CliTest/test_go_zkp_rnl.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# CliTest/test_go_zkp_rnl.sh — Go CLI: ZKP-RNL (Ring-LWR Sigma-protocol) sign/verify round-trip
+set -euo pipefail
+
+CLI="$(dirname "$0")/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg2.bin"
+
+# ── ZKP-RNL (n=256, Go CLI) ──────────────────────────────────────────────────
+"$CLI" genpkey --algo hkex-rnl --out "$TMP/rnl.pem"
+"$CLI" pkey    --in "$TMP/rnl.pem" --pubout --out "$TMP/rnl_pub.pem"
+"$CLI" sign    --algo rnl-sigma --key "$TMP/rnl.pem" \
+               --in "$TMP/msg.bin" --out "$TMP/rnl_sig.pem"
+
+check_verify "Go rnl-sigma verify correct msg" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+check_reject "Go rnl-sigma verify wrong msg" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/rnl_sig.pem"
+
+# Wrong pubkey rejection
+"$CLI" genpkey --algo hkex-rnl --out "$TMP/rnl_other.pem"
+"$CLI" pkey    --in "$TMP/rnl_other.pem" --pubout --out "$TMP/rnl_other_pub.pem"
+check_reject "Go rnl-sigma verify wrong pubkey" \
+    "$CLI" verify --algo rnl-sigma --pubkey "$TMP/rnl_other_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_zkp_interop.sh
+++ b/CliTest/test_zkp_interop.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# CliTest/test_zkp_interop.sh — Cross-language ZKP interop: Python↔C↔Go sign/verify
+# ZKP-RNL: Python sign → C verify; C sign → Go verify; Go sign → Python verify
+# ZKP-NL:  Python sign → Python verify (proof format is large; cross-lang verify same)
+set -euo pipefail
+
+CLI_PY="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+CLI_C="$(dirname "$0")/../HerraduraCli/herradura_cli"
+CLI_GO="$(dirname "$0")/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg2.bin"
+
+# ---------------------------------------------------------------------------
+# ZKP-RNL interop — rnl-sigma: same hkex-rnl PEM format across all three CLIs
+# ---------------------------------------------------------------------------
+
+# Python keygen (shared across all cross-lang tests)
+$CLI_PY genpkey --algo hkex-rnl --out "$TMP/py_rnl.pem"
+$CLI_PY pkey    --in "$TMP/py_rnl.pem" --pubout --out "$TMP/py_rnl_pub.pem"
+
+# Python sign → C verify
+$CLI_PY sign  --algo rnl-sigma --key "$TMP/py_rnl.pem" \
+              --in "$TMP/msg.bin" --out "$TMP/py_sig.pem"
+check_verify "Python rnl-sigma sign → C verify" \
+    "$CLI_C" verify --algo rnl-sigma --pubkey "$TMP/py_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/py_sig.pem"
+check_reject "Python rnl-sigma sign → C verify (wrong msg)" \
+    "$CLI_C" verify --algo rnl-sigma --pubkey "$TMP/py_rnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/py_sig.pem"
+
+# Python sign → Go verify
+check_verify "Python rnl-sigma sign → Go verify" \
+    "$CLI_GO" verify --algo rnl-sigma --pubkey "$TMP/py_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/py_sig.pem"
+
+# C keygen + sign → Python verify
+"$CLI_C" genpkey --algo hkex-rnl --out "$TMP/c_rnl.pem"
+"$CLI_C" pkey    --in "$TMP/c_rnl.pem" --pubout --out "$TMP/c_rnl_pub.pem"
+"$CLI_C" sign    --algo rnl-sigma --key "$TMP/c_rnl.pem" \
+                 --in "$TMP/msg.bin" --out "$TMP/c_sig.pem"
+check_verify "C rnl-sigma sign → Python verify" \
+    $CLI_PY verify --algo rnl-sigma --pubkey "$TMP/c_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/c_sig.pem"
+
+# C sign → Go verify
+check_verify "C rnl-sigma sign → Go verify" \
+    "$CLI_GO" verify --algo rnl-sigma --pubkey "$TMP/c_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/c_sig.pem"
+
+# Go keygen + sign → Python verify
+"$CLI_GO" genpkey --algo hkex-rnl --out "$TMP/go_rnl.pem"
+"$CLI_GO" pkey    --in "$TMP/go_rnl.pem" --pubout --out "$TMP/go_rnl_pub.pem"
+"$CLI_GO" sign    --algo rnl-sigma --key "$TMP/go_rnl.pem" \
+                  --in "$TMP/msg.bin" --out "$TMP/go_sig.pem"
+check_verify "Go rnl-sigma sign → Python verify" \
+    $CLI_PY verify --algo rnl-sigma --pubkey "$TMP/go_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/go_sig.pem"
+
+# Go sign → C verify
+check_verify "Go rnl-sigma sign → C verify" \
+    "$CLI_C" verify --algo rnl-sigma --pubkey "$TMP/go_rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/go_sig.pem"
+
+# ---------------------------------------------------------------------------
+# ZKP-NL interop — nl-zkboo: Python sign → C verify; C sign → Go verify
+# Use rounds=4 for speed; proof PEM format is shared
+# ---------------------------------------------------------------------------
+
+# Python ZKP-NL keygen
+$CLI_PY genpkey --algo hpks-zkp-nl --out "$TMP/py_zkpnl.pem"
+$CLI_PY pkey    --in "$TMP/py_zkpnl.pem" --pubout --out "$TMP/py_zkpnl_pub.pem"
+
+# Python sign → C verify
+$CLI_PY sign  --algo nl-zkboo --key "$TMP/py_zkpnl.pem" \
+              --rounds 4 --in "$TMP/msg.bin" --out "$TMP/py_zkpnl_proof.pem"
+check_verify "Python nl-zkboo sign → C verify" \
+    "$CLI_C" verify --algo nl-zkboo --pubkey "$TMP/py_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/py_zkpnl_proof.pem"
+check_reject "Python nl-zkboo sign → C verify (wrong msg)" \
+    "$CLI_C" verify --algo nl-zkboo --pubkey "$TMP/py_zkpnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/py_zkpnl_proof.pem"
+
+# Python sign → Go verify
+check_verify "Python nl-zkboo sign → Go verify" \
+    "$CLI_GO" verify --algo nl-zkboo --pubkey "$TMP/py_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/py_zkpnl_proof.pem"
+
+# C ZKP-NL keygen + sign → Python verify
+"$CLI_C" genpkey --algo hpks-zkp-nl --out "$TMP/c_zkpnl.pem"
+"$CLI_C" pkey    --in "$TMP/c_zkpnl.pem" --pubout --out "$TMP/c_zkpnl_pub.pem"
+"$CLI_C" sign    --algo nl-zkboo --key "$TMP/c_zkpnl.pem" \
+                 --in "$TMP/msg.bin" --out "$TMP/c_zkpnl_proof.pem"
+check_verify "C nl-zkboo sign → Python verify" \
+    $CLI_PY verify --algo nl-zkboo --pubkey "$TMP/c_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/c_zkpnl_proof.pem"
+
+# C sign → Go verify
+check_verify "C nl-zkboo sign → Go verify" \
+    "$CLI_GO" verify --algo nl-zkboo --pubkey "$TMP/c_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/c_zkpnl_proof.pem"
+
+# Go ZKP-NL keygen + sign → Python verify
+"$CLI_GO" genpkey --algo hpks-zkp-nl --out "$TMP/go_zkpnl.pem"
+"$CLI_GO" pkey    --in "$TMP/go_zkpnl.pem" --pubout --out "$TMP/go_zkpnl_pub.pem"
+"$CLI_GO" sign    --algo nl-zkboo --key "$TMP/go_zkpnl.pem" \
+                  --in "$TMP/msg.bin" --out "$TMP/go_zkpnl_proof.pem"
+check_verify "Go nl-zkboo sign → Python verify" \
+    $CLI_PY verify --algo nl-zkboo --pubkey "$TMP/go_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/go_zkpnl_proof.pem"
+
+# Go sign → C verify
+check_verify "Go nl-zkboo sign → C verify" \
+    "$CLI_C" verify --algo nl-zkboo --pubkey "$TMP/go_zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/go_zkpnl_proof.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_zkp_nl.sh
+++ b/CliTest/test_zkp_nl.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# CliTest/test_zkp_nl.sh — Python CLI: ZKP-NL (NL-FSCX ZKBoo) sign/verify round-trip
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg2.bin"
+
+# ── ZKP-NL (hpks-zkp-nl, rounds=4 for speed) ─────────────────────────────────
+$CLI genpkey --algo hpks-zkp-nl --out "$TMP/zkpnl.pem"
+$CLI pkey    --in "$TMP/zkpnl.pem" --pubout --out "$TMP/zkpnl_pub.pem"
+$CLI sign    --algo nl-zkboo --key "$TMP/zkpnl.pem" \
+             --rounds 4 --in "$TMP/msg.bin" --out "$TMP/zkpnl_proof.pem"
+
+check_verify "nl-zkboo verify correct msg" \
+    $CLI verify --algo nl-zkboo --pubkey "$TMP/zkpnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/zkpnl_proof.pem"
+
+check_reject "nl-zkboo verify wrong msg" \
+    $CLI verify --algo nl-zkboo --pubkey "$TMP/zkpnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/zkpnl_proof.pem"
+
+# Wrong pubkey rejection
+$CLI genpkey --algo hpks-zkp-nl --out "$TMP/zkpnl_other.pem"
+$CLI pkey    --in "$TMP/zkpnl_other.pem" --pubout --out "$TMP/zkpnl_other_pub.pem"
+check_reject "nl-zkboo verify wrong pubkey" \
+    $CLI verify --algo nl-zkboo --pubkey "$TMP/zkpnl_other_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/zkpnl_proof.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CliTest/test_zkp_rnl.sh
+++ b/CliTest/test_zkp_rnl.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# CliTest/test_zkp_rnl.sh — Python CLI: ZKP-RNL (Ring-LWR Sigma-protocol) sign/verify round-trip
+set -euo pipefail
+
+CLI="python3 $(dirname "$0")/../HerraduraCli/herradura.py"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+check_verify() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Signature OK"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected 'Signature OK' (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+check_reject() {
+    local label="$1"; shift
+    local output rc
+    output=$("$@" 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && echo "$output" | grep -q "Verification FAILED"; then
+        echo "PASS $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL $label: expected rejection (rc=$rc); got: $output"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012346' > "$TMP/msg2.bin"
+
+# ── ZKP-RNL (n=256, default) ─────────────────────────────────────────────────
+$CLI genpkey --algo hkex-rnl --out "$TMP/rnl.pem"
+$CLI pkey    --in "$TMP/rnl.pem" --pubout --out "$TMP/rnl_pub.pem"
+$CLI sign    --algo rnl-sigma --key "$TMP/rnl.pem" \
+             --in "$TMP/msg.bin" --out "$TMP/rnl_sig.pem"
+
+check_verify "rnl-sigma verify correct msg" \
+    $CLI verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+check_reject "rnl-sigma verify wrong msg" \
+    $CLI verify --algo rnl-sigma --pubkey "$TMP/rnl_pub.pem" \
+    --in "$TMP/msg2.bin" --sig "$TMP/rnl_sig.pem"
+
+# Wrong pubkey rejection: signature from one key must not verify under another
+$CLI genpkey --algo hkex-rnl --out "$TMP/rnl_other.pem"
+$CLI pkey    --in "$TMP/rnl_other.pem" --pubout --out "$TMP/rnl_other_pub.pem"
+check_reject "rnl-sigma verify wrong pubkey" \
+    $CLI verify --algo rnl-sigma --pubkey "$TMP/rnl_other_pub.pem" \
+    --in "$TMP/msg.bin" --sig "$TMP/rnl_sig.pem"
+
+echo ""
+echo "Results: $PASS PASS / $FAIL FAIL"
+[ "$FAIL" -eq 0 ]

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,13 +4,15 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.8.8
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.11
+    v1.9.11: ZKP-RNL + ZKP-NL security tests [21][22] and benchmarks [33][34] (TODO #77 Batch 7);
+            benchmarks renumbered [23]-[34].
     v1.8.7: 32-bit benchmark columns added; N=128 HPKS-Stern-F implemented (TODO #61 extension).
     v1.8.0: KDF domain constant — ba_rnl_kdf_seed replaces ba_rol_k at all HSKE-NL-A1/HKEX-RNL seed sites (TODO #38).
     v1.6.1: stern_hash_ba DS parameter — closes QRO gap for Theorem 17 (TODO #36).
     v1.6.0: stern_hash_ba + stern_hash_64 HFSCX-256 finalizer (TODO #43).
     v1.5.43: F_stern range compression HyperLogLog test [20] (TODO #42 Step 1);
-             benchmarks renumbered [21]-[30].
+             benchmarks renumbered [21]-[30] (now [23]-[34]).
     v1.5.25: herradura.h shared library + HFSCX-256 KAV test [19]; benchmarks renumbered [20]-[29].
     v1.5.23: HerraduraCli OpenSSL-style CLI (TODO #25); CliTest shell test suite.
     v1.5.20: 256-bit NL-FSCX v2 BitArray functions; tests expanded to full multi-size:
@@ -61,17 +63,21 @@
       [18] HPKE-Stern-F correctness: encap+decap, N=32, t=2 (brute-force)  [CODE-BASED PQC].
       [19] HFSCX-256 known-answer vectors  [PQC-EXT].
       [20] F_stern(K,·) range compression at n=32 (HyperLogLog, TODO #42 Step 1)  [CODE-BASED PQC].
-      [21] FSCX throughput (256-bit).
-      [22] HKEX-GF gf_pow throughput (32-bit).
-      [23] HKEX-GF full handshake (32-bit).
-      [24] HSKE round-trip (256-bit).
-      [25] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
-      [26] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
-      [26b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
-      [27] HSKE-NL-A1 counter-mode throughput (32-bit).
-      [28] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
-      [29] HKEX-RNL full handshake throughput (n=32).
-      [30] HPKS-Stern-F sign+verify throughput (N=256, t=16, rounds=4)  [CODE-BASED PQC].
+      [21] ZKP-RNL completeness + tamper-rejection (n=32, 256)  [PQC-EXT].
+      [22] ZKP-NL completeness + tamper-rejection (n=32, 64)  [PQC-EXT].
+      [23] FSCX throughput (256-bit).
+      [24] HKEX-GF gf_pow throughput (32-bit).
+      [25] HKEX-GF full handshake (32-bit).
+      [26] HSKE round-trip (256-bit).
+      [27] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
+      [28] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
+      [28b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
+      [29] HSKE-NL-A1 counter-mode throughput (32-bit).
+      [30] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
+      [31] HKEX-RNL full handshake throughput (n=32).
+      [32] HPKS-Stern-F sign+verify throughput (N=256, t=16, rounds=4)  [CODE-BASED PQC].
+      [33] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
+      [34] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -3455,14 +3461,14 @@ static void test_fstern_range_n32(void)
            " see TODO #42 Step 2\n");
 }
 
-/* [30] HPKS-Stern-F sign+verify throughput (N=32/64/256) */
+/* [32] HPKS-Stern-F sign+verify throughput (N=32/64/256) */
 static void bench_hpks_stern_f(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[30] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
+    printf("[32] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
     /* N=32 */
     { static SternSig32T bsig32;
       uint32_t seed32 = stern32_rand_seed(), e32 = stern32_rand_error(), msg32;
@@ -3539,6 +3545,87 @@ static void bench_hpks_stern_f(void)
     putchar('\n');
 }
 
+static const uint8_t zkp_msg[]  = "Herradura ZKP test";
+static const uint8_t zkp_msg2[] = "Herradura ZKP tamper";
+
+/* [33] ZKP-RNL sign+verify throughput (n=256) */
+static void bench_zkp_rnl(void)
+{
+    struct timespec t0, t1;
+    long long ops;
+    double secs;
+    static const int n = 256;
+    int32_t m_base[256], a_rand[256], m_blind[256];
+    int32_t s[256], C[256];
+    int32_t w[256], c_poly[256], z[256];
+    int i;
+    printf("[33] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
+    rnl_m_poly_n(m_base, n);
+    rnl_rand_poly_n(a_rand, n);
+    rnl_poly_add_n(m_blind, m_base, a_rand, n);
+    rnl_keygen_n(s, C, m_blind, n);
+    /* warm-up */
+    for (i = 0; i < 2; i++) {
+        if (rnl_sigma_sign(s, m_blind, C, n,
+                           zkp_msg, sizeof(zkp_msg) - 1, urnd_fp,
+                           w, c_poly, z) == 0)
+            rnl_sigma_verify(m_blind, C, n,
+                             zkp_msg, sizeof(zkp_msg) - 1, w, c_poly, z);
+    }
+    ops = 0; clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        if (rnl_sigma_sign(s, m_blind, C, n,
+                           zkp_msg, sizeof(zkp_msg) - 1, urnd_fp,
+                           w, c_poly, z) == 0)
+            rnl_sigma_verify(m_blind, C, n,
+                             zkp_msg, sizeof(zkp_msg) - 1, w, c_poly, z);
+        ops++; clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
+    printf("    n=%3d  sign+verify  ", n);
+    print_rate(ops, secs); putchar('\n');
+    putchar('\n');
+}
+
+/* [34] ZKP-NL prove+verify throughput (n=32, rounds=16) */
+static void bench_zkp_nl(void)
+{
+    struct timespec t0, t1;
+    long long ops;
+    double secs;
+    static const int n      = 32;
+    static const int rounds = 16;
+    uint32_t A, B, y;
+    ZkpNlRound *proof;
+    int i;
+    printf("[34] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
+           n, rounds);
+    zkp_nl_keygen(n, urnd_fp, &A, &B, &y);
+    /* warm-up */
+    for (i = 0; i < 2; i++) {
+        proof = zkp_nl_prove(A, B, y, n, rounds,
+                             zkp_msg, sizeof(zkp_msg) - 1, urnd_fp);
+        if (proof) {
+            zkp_nl_verify(B, y, n, rounds,
+                          zkp_msg, sizeof(zkp_msg) - 1, proof);
+            zkp_nl_proof_free(proof, rounds);
+        }
+    }
+    ops = 0; clock_gettime(CLOCK_MONOTONIC, &t0);
+    do {
+        proof = zkp_nl_prove(A, B, y, n, rounds,
+                             zkp_msg, sizeof(zkp_msg) - 1, urnd_fp);
+        if (proof) {
+            zkp_nl_verify(B, y, n, rounds,
+                          zkp_msg, sizeof(zkp_msg) - 1, proof);
+            zkp_nl_proof_free(proof, rounds);
+        }
+        ops++; clock_gettime(CLOCK_MONOTONIC, &t1);
+    } while ((secs = elapsed_sec(&t0, &t1)) < g_bench_sec);
+    printf("    n=%2d  rounds=%d  prove+verify  ", n, rounds);
+    print_rate(ops, secs); putchar('\n');
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
 /* Security test [19]: HFSCX-256 known-answer vectors                 */
 /* ------------------------------------------------------------------ */
@@ -3585,17 +3672,102 @@ static void test_hfscx_256_kav(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [21]-[30]                                   */
+/* Security tests [21]-[22]: ZKP-RNL and ZKP-NL                      */
 /* ------------------------------------------------------------------ */
 
-/* [21] FSCX throughput (64/128/256-bit) */
+/* [21] ZKP-RNL Sigma-protocol completeness + tamper-rejection */
+static void test_zkp_rnl_correctness(void)
+{
+    static const int zkp_rnl_sizes[] = {32, 256};
+    int si;
+    printf("[21] ZKP-RNL Sigma-protocol completeness + tamper-rejection  [PQC-EXT]\n");
+    for (si = 0; si < 2; si++) {
+        int n = zkp_rnl_sizes[si];
+        int N = g_rounds > 0 ? g_rounds : 5;
+        int ok_verify = 0, ok_tamper = 0, i;
+        struct timespec t0;
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        for (i = 0; i < N; i++) {
+            int32_t m_base[256], a_rand[256], m_blind[256];
+            int32_t s[256], C[256];
+            int32_t w[256], c_poly[256], z[256];
+            rnl_m_poly_n(m_base, n);
+            rnl_rand_poly_n(a_rand, n);
+            rnl_poly_add_n(m_blind, m_base, a_rand, n);
+            rnl_keygen_n(s, C, m_blind, n);
+            if (rnl_sigma_sign(s, m_blind, C, n,
+                               zkp_msg, sizeof(zkp_msg) - 1, urnd_fp,
+                               w, c_poly, z) == 0) {
+                if (rnl_sigma_verify(m_blind, C, n,
+                                     zkp_msg, sizeof(zkp_msg) - 1,
+                                     w, c_poly, z))
+                    ok_verify++;
+                if (!rnl_sigma_verify(m_blind, C, n,
+                                      zkp_msg2, sizeof(zkp_msg2) - 1,
+                                      w, c_poly, z))
+                    ok_tamper++;
+            } else {
+                N = i + 1; break;
+            }
+            if (g_time_limit > 0.0 && time_exceeded(&t0)) { N = i + 1; break; }
+        }
+        printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
+               n, ok_verify, N, ok_tamper, N,
+               (ok_verify == N && ok_tamper == N) ? "PASS" : "FAIL");
+    }
+    putchar('\n');
+}
+
+/* [22] ZKP-NL (ZKBoo) completeness + tamper-rejection */
+static void test_zkp_nl_correctness(void)
+{
+    static const int zkp_nl_sizes[] = {32, 64};
+    static const int zkp_nl_rounds  = 16;
+    int si;
+    printf("[22] ZKP-NL (ZKBoo) completeness + tamper-rejection  [PQC-EXT]\n");
+    for (si = 0; si < 2; si++) {
+        int n = zkp_nl_sizes[si];
+        int N = g_rounds > 0 ? g_rounds : 5;
+        int ok_verify = 0, ok_tamper = 0, i;
+        struct timespec t0;
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        for (i = 0; i < N; i++) {
+            uint32_t A, B, y;
+            ZkpNlRound *proof;
+            zkp_nl_keygen(n, urnd_fp, &A, &B, &y);
+            proof = zkp_nl_prove(A, B, y, n, zkp_nl_rounds,
+                                 zkp_msg, sizeof(zkp_msg) - 1, urnd_fp);
+            if (!proof) { N = i + 1; break; }
+            if (zkp_nl_verify(B, y, n, zkp_nl_rounds,
+                              zkp_msg, sizeof(zkp_msg) - 1, proof))
+                ok_verify++;
+            /* tamper: flip one bit in com_1[0] */
+            proof[0].com_1[0] ^= 1;
+            if (!zkp_nl_verify(B, y, n, zkp_nl_rounds,
+                               zkp_msg, sizeof(zkp_msg) - 1, proof))
+                ok_tamper++;
+            zkp_nl_proof_free(proof, zkp_nl_rounds);
+            if (g_time_limit > 0.0 && time_exceeded(&t0)) { N = i + 1; break; }
+        }
+        printf("    n=%2d  rounds=%d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
+               n, zkp_nl_rounds, ok_verify, N, ok_tamper, N,
+               (ok_verify == N && ok_tamper == N) ? "PASS" : "FAIL");
+    }
+    putchar('\n');
+}
+
+/* ------------------------------------------------------------------ */
+/* Performance benchmarks [23]-[34]                                   */
+/* ------------------------------------------------------------------ */
+
+/* [23] FSCX throughput (64/128/256-bit) */
 static void bench_fscx_throughput(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[21] FSCX throughput  [CLASSICAL]\n");
+    printf("[23] FSCX throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), tmp;
       for (i = 0; i < 10; i++) { tmp = fscx32(a, b); a = tmp; }
@@ -3639,7 +3811,7 @@ static void bench_gf_pow_throughput(void)
     long long ops;
     double secs;
     int i;
-    printf("[22] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
+    printf("[24] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t base = rand32() | 1, exp = rand32() | 1, tmp;
       for (i = 0; i < 5; i++) { tmp = gf_pow_32(base, exp); base = tmp | 1; }
@@ -3684,7 +3856,7 @@ static void bench_hkex_gf_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[23] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
+    printf("[25] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, b = rand32()|1, C, C2, skA, skB;
       for (i = 0; i < 5; i++) {
@@ -3750,7 +3922,7 @@ static void bench_hske_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[24] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
+    printf("[26] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t pt, key, enc, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -3817,7 +3989,7 @@ static void bench_hpke_el_gamal_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[25] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
+    printf("[27] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, r = rand32()|1, pt = rand32();
       uint32_t C = gf_pow_32(GF_GEN32, a), R, ek, E, dk;
@@ -3892,17 +4064,17 @@ static void bench_hpke_el_gamal_roundtrip(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [24]-[27]: PQC extension                    */
+/* Performance benchmarks [28]-[31]: PQC extension                    */
 /* ------------------------------------------------------------------ */
 
-/* [26] NL-FSCX v1 revolve (64/128/256-bit) + [26b] v2 enc+dec (64/128/256-bit) */
+/* [28] NL-FSCX v1 revolve (64/128/256-bit) + [28b] v2 enc+dec (64/128/256-bit) */
 static void bench_nl_fscx_revolve(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[26] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
+    printf("[28] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32();
       for (i = 0; i < 10; i++) a = nl_fscx_revolve_v1_32(a, b, NL_I32);
@@ -3938,7 +4110,7 @@ static void bench_nl_fscx_revolve(void)
       printf("    bits=256  v1 n/4 steps  "); print_rate(ops, secs); putchar('\n'); }
     putchar('\n');
 
-    printf("[26b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]\n");
+    printf("[28b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), E;
       for (i = 0; i < 5; i++) {
@@ -3996,7 +4168,7 @@ static void bench_hske_nl_a1_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[27] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
+    printf("[29] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K, P, ks, sink = 0;
       K = rand32(); P = rand32();
@@ -4082,7 +4254,7 @@ static void bench_hske_nl_a2_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[28] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
+    printf("[30] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K = rand32(), P = rand32(), E, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4144,7 +4316,7 @@ static void bench_hkex_rnl_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[29] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
+    printf("[31] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
     /* n=32 (rnl32 fast path) */
     { rnl32_poly_t m_base, a_rand, m_blind;
       int32_t s_A[RNL_N32], c_A[RNL_N32], s_B[RNL_N32], c_B[RNL_N32];
@@ -4268,7 +4440,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.8.8 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.9.11 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);
@@ -4307,6 +4479,10 @@ int main(int argc, char *argv[])
     puts("--- Security Tests: Hash (HFSCX-256) ---\n");
     test_hfscx_256_kav();
 
+    puts("--- Security Tests: ZKP (Ring-LWR Sigma + NL-FSCX ZKBoo) ---\n");
+    test_zkp_rnl_correctness();
+    test_zkp_nl_correctness();
+
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();
     bench_gf_pow_throughput();
@@ -4318,6 +4494,8 @@ int main(int argc, char *argv[])
     bench_hske_nl_a2_roundtrip();
     bench_hkex_rnl_handshake();
     bench_hpks_stern_f();
+    bench_zkp_rnl();
+    bench_zkp_nl();
 
     fclose(urnd_fp);
     return 0;

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,6 @@
-/*  Herradura KEx — Security & Performance Tests (Go) v1.8.8
+/*  Herradura KEx — Security & Performance Tests (Go) v1.9.11
+    v1.9.11: ZKP-RNL + ZKP-NL security tests [20][21] and benchmarks [32][33] (TODO #77 Batch 7);
+            benchmarks renumbered [22]-[33].
     v1.8.7: 32-bit benchmark columns; benchHpksSternF loops over all sizes (TODO #61 extension).
     v1.8.0: KDF domain constant (TODO #38) — RnlKdfSeed applied to all HSKE-NL-A1 and HKEX-RNL seed sites.
     v1.6.1: SternHash ds parameter (TODO #36).
@@ -692,11 +694,11 @@ func testHpkeSternFCorrectness() {
 }
 
 // ---------------------------------------------------------------------------
-// Performance benchmarks [20-29]
+// Performance benchmarks [22-33]
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[20] FSCX throughput  [CLASSICAL]")
+	fmt.Println("[22] FSCX throughput  [CLASSICAL]")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -710,7 +712,7 @@ func benchFscx() {
 }
 
 func benchHkexGFPow() {
-	fmt.Println("[21] HKEX-GF gf_pow throughput  [CLASSICAL]")
+	fmt.Println("[23] HKEX-GF gf_pow throughput  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -725,7 +727,7 @@ func benchHkexGFPow() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[22] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
+	fmt.Println("[24] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -744,7 +746,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[23] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+	fmt.Println("[25] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		rv   := rVal(size)
@@ -763,7 +765,7 @@ func benchHskeRoundTrip() {
 }
 
 func benchHpkeRoundTrip() {
-	fmt.Println("[24] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
+	fmt.Println("[26] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g    := big.NewInt(GfGen)
@@ -789,7 +791,7 @@ func benchHpkeRoundTrip() {
 }
 
 func benchNlFscxRevolve() {
-	fmt.Println("[25] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+	fmt.Println("[27] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
 		a  := randBA(size)
@@ -800,7 +802,7 @@ func benchNlFscxRevolve() {
 		fmt.Printf("    bits=%3d  v1 n/4 steps             : %s  (%d ops in %.2fs)\n",
 			size, fmtRate(ops, elapsed), ops, elapsed.Seconds())
 	}
-	fmt.Println("[25b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
+	fmt.Println("[27b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		rv := rVal(size)
 		a  := randBA(size)
@@ -816,7 +818,7 @@ func benchNlFscxRevolve() {
 }
 
 func benchHskeNlA1RoundTrip() {
-	fmt.Println("[26] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+	fmt.Println("[28] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		sink := randBA(size)
@@ -836,7 +838,7 @@ func benchHskeNlA1RoundTrip() {
 }
 
 func benchHskeNlA2RoundTrip() {
-	fmt.Println("[27] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+	fmt.Println("[29] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
 	for _, size := range sizes {
 		rv   := rVal(size)
 		sink := randBA(size)
@@ -853,7 +855,7 @@ func benchHskeNlA2RoundTrip() {
 }
 
 func benchHkexRnlHandshake() {
-	fmt.Println("[28] HKEX-RNL handshake throughput  [PQC-EXT]")
+	fmt.Println("[30] HKEX-RNL handshake throughput  [PQC-EXT]")
 	fmt.Printf("     (ring sizes %v; NTT O(n log n) per exchange)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := RnlMPoly(nRnl)
@@ -872,7 +874,7 @@ func benchHkexRnlHandshake() {
 }
 
 func benchHpksSternF() {
-	fmt.Printf("[29] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
+	fmt.Printf("[31] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
 	for _, size := range sizes {
 		seed, e, syn := SternFKeygen(size)
 		msg := randBA(size)
@@ -883,6 +885,114 @@ func benchHpksSternF() {
 		fmt.Printf("    bits=%3d  sign+verify              : %s  (%d ops in %.2fs)\n",
 			size, fmtRate(ops, elapsed), ops, elapsed.Seconds())
 	}
+	fmt.Println()
+}
+
+// ---------------------------------------------------------------------------
+// Security tests [20]-[21]: ZKP-RNL and ZKP-NL
+// ---------------------------------------------------------------------------
+
+var zkpMsg  = []byte("Herradura ZKP test")
+var zkpMsg2 = []byte("Herradura ZKP tamper")
+
+func testZkpRnlCorrectness() {
+	fmt.Println("[20] ZKP-RNL Sigma-protocol completeness + tamper-rejection  [PQC-EXT]")
+	zkpRnlSizes := []int{32, 256}
+	for _, n := range zkpRnlSizes {
+		N := testRounds(5)
+		okVerify, okTamper := 0, 0
+		t0 := time.Now()
+		mBase := RnlMPoly(n)
+		for i := 0; i < N; i++ {
+			aRand  := RnlRandPoly(n, RnlQ)
+			mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
+			s, C   := RnlKeygen(mBlind, n, RnlQ, RnlP)
+			w, c, z, err := RnlSigmaSign(s, mBlind, C, n, zkpMsg)
+			if err != nil { N = i + 1; break }
+			if RnlSigmaVerify(mBlind, C, n, zkpMsg, w, c, z) {
+				okVerify++
+			}
+			if !RnlSigmaVerify(mBlind, C, n, zkpMsg2, w, c, z) {
+				okTamper++
+			}
+			if timeExceeded(t0) { N = i + 1; break }
+		}
+		status := "PASS"
+		if okVerify != N || okTamper != N { status = "FAIL" }
+		fmt.Printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
+			n, okVerify, N, okTamper, N, status)
+	}
+	fmt.Println()
+}
+
+func testZkpNlCorrectness() {
+	fmt.Println("[21] ZKP-NL (ZKBoo) completeness + tamper-rejection  [PQC-EXT]")
+	zkpNlSizes  := []int{32, 64}
+	zkpNlRounds := 16
+	for _, n := range zkpNlSizes {
+		N := testRounds(5)
+		okVerify, okTamper := 0, 0
+		t0 := time.Now()
+		for i := 0; i < N; i++ {
+			A, B, y, err := ZkpNlKeygen(n)
+			if err != nil { N = i + 1; break }
+			proof, err := ZkpNlProve(A, B, y, n, zkpNlRounds, zkpMsg)
+			if err != nil { N = i + 1; break }
+			if ZkpNlVerify(B, y, n, zkpNlRounds, zkpMsg, proof) {
+				okVerify++
+			}
+			// tamper: flip one bit in com_1[0]
+			proof[0].Com1[0] ^= 1
+			if !ZkpNlVerify(B, y, n, zkpNlRounds, zkpMsg, proof) {
+				okTamper++
+			}
+			if timeExceeded(t0) { N = i + 1; break }
+		}
+		status := "PASS"
+		if okVerify != N || okTamper != N { status = "FAIL" }
+		fmt.Printf("    n=%2d  rounds=%d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
+			n, zkpNlRounds, okVerify, N, okTamper, N, status)
+	}
+	fmt.Println()
+}
+
+// ---------------------------------------------------------------------------
+// Performance benchmarks [32]-[33]: ZKP
+// ---------------------------------------------------------------------------
+
+func benchZkpRnl() {
+	const n = 256
+	fmt.Printf("[32] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
+	mBase  := RnlMPoly(n)
+	aRand  := RnlRandPoly(n, RnlQ)
+	mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
+	s, C   := RnlKeygen(mBlind, n, RnlQ, RnlP)
+	ops, elapsed := bench("", func() {
+		w, c, z, err := RnlSigmaSign(s, mBlind, C, n, zkpMsg)
+		if err == nil {
+			RnlSigmaVerify(mBlind, C, n, zkpMsg, w, c, z)
+		}
+	})
+	fmt.Printf("    n=%3d  sign+verify              : %s  (%d ops in %.2fs)\n",
+		n, fmtRate(ops, elapsed), ops, elapsed.Seconds())
+	fmt.Println()
+}
+
+func benchZkpNl() {
+	const (
+		n      = 32
+		rounds = 16
+	)
+	fmt.Printf("[33] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
+	A, B, y, _ := ZkpNlKeygen(n)
+	ops, elapsed := bench("", func() {
+		proof, err := ZkpNlProve(A, B, y, n, rounds, zkpMsg)
+		if err == nil {
+			ZkpNlVerify(B, y, n, rounds, zkpMsg, proof)
+		}
+	})
+	fmt.Printf("    n=%2d  rounds=%d  prove+verify     : %s  (%d ops in %.2fs)\n",
+		n, rounds, fmtRate(ops, elapsed), ops, elapsed.Seconds())
 	fmt.Println()
 }
 
@@ -927,7 +1037,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.8.8 — Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.9.11 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:
@@ -967,6 +1077,10 @@ func main() {
 	testHpksSternFCorrectness()
 	testHpkeSternFCorrectness()
 
+	fmt.Println("--- Security Tests: ZKP (Ring-LWR Sigma + NL-FSCX ZKBoo) ---\n")
+	testZkpRnlCorrectness()
+	testZkpNlCorrectness()
+
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()
 	benchHkexGFPow()
@@ -978,4 +1092,6 @@ func main() {
 	benchHskeNlA2RoundTrip()
 	benchHkexRnlHandshake()
 	benchHpksSternF()
+	benchZkpRnl()
+	benchZkpNl()
 }

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,7 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python) v1.8.8
+    Herradura KEx — Security & Performance Tests (Python) v1.9.11
+    v1.9.11: ZKP-RNL + ZKP-NL security tests [20][21] and benchmarks [32][33] (TODO #77 Batch 7);
+            benchmarks renumbered [22]-[33].
     v1.8.7: 32-bit benchmark columns; bench_hpks_stern_f loops over all sizes (TODO #61 extension).
     v1.8.0: KDF domain constant (TODO #38) — _RNL_KDF_DC_256 applied to all HSKE-NL-A1 and HKEX-RNL seed sites.
     v1.7.3: NumPy NTT acceleration — ~10× speedup on _rnl_poly_mul (TODO #40).
@@ -18,7 +20,7 @@
     v1.5.2: proposed multi-size key-length tests for Herradura_tests.c (matching Python).
     v1.5.1: added --rounds/-r and --time/-t CLI options (also HTEST_ROUNDS / HTEST_TIME env).
     v1.5.0: added PQC extension tests [10-16] and benchmarks [22-25].
-            benchmarks renumbered [17-21] (were [10-14] in v1.4.0).
+            benchmarks renumbered [17-21] (were [10-14] in v1.4.0) (now [22]-[33]).
     v1.4.0: replaced broken fscx_revolve_n HKEX tests with HKEX-GF tests.
     v1.3.6: added HPKS sign+verify correctness test [7]; benchmarks renumbered [8-12].
     v1.3.3: added HPKE encrypt+decrypt round-trip benchmark [11].
@@ -605,6 +607,260 @@ def _rnl_agree(s, C_other, q, p, pp, n, key_bits, hint=None):
 
 
 # ---------------------------------------------------------------------------
+# ZKP-RNL Sigma-protocol helpers (self-contained, mirrors suite)
+# ---------------------------------------------------------------------------
+
+_SIGMA_GAMMA       = {32: 4096, 64: 8192, 128: 8192, 256: 8192}
+_SIGMA_T           = {32: 4,    64: 8,    128: 12,   256: 16}
+_SIGMA_MAX_ATTEMPTS = 1000
+
+
+def _sigma_params(n):
+    gamma = _SIGMA_GAMMA.get(n, 8192 if n >= 64 else 4096)
+    t     = _SIGMA_T.get(n, max(4, n // 16))
+    return gamma, t
+
+
+def _sigma_poly_bytes(poly):
+    return b''.join((c % (1 << 32)).to_bytes(4, 'big') for c in poly)
+
+
+def _sigma_challenge(m_poly, C_poly, w_poly, n, q, t, msg_bytes):
+    seed = hfscx_256(
+        n.to_bytes(4, 'big')
+        + _sigma_poly_bytes(m_poly)
+        + _sigma_poly_bytes(C_poly)
+        + _sigma_poly_bytes(w_poly)
+        + msg_bytes
+    )
+    positions = []
+    idx = 0
+    while len(positions) < t:
+        h = hfscx_256(seed + b'pos' + idx.to_bytes(4, 'big'))
+        v = int.from_bytes(h[:4], 'big') % n
+        if v not in positions:
+            positions.append(v)
+        idx += 1
+    c = [0] * n
+    for k, pos in enumerate(positions):
+        h = hfscx_256(seed + b'sgn' + k.to_bytes(4, 'big'))
+        c[pos] = 1 if (h[0] & 1) == 0 else q - 1
+    return c
+
+
+def _rnl_sigma_sign(s_poly, m_poly, C_poly, n, msg_bytes):
+    q     = RNLQ
+    gamma, t = _sigma_params(n)
+    bound = gamma - t
+    h     = q // 2
+    for _ in range(_SIGMA_MAX_ATTEMPTS):
+        y    = [int.from_bytes(os.urandom(4), 'big') % (2 * gamma + 1) - gamma
+                for _ in range(n)]
+        y_q  = [yi % q for yi in y]
+        my   = _rnl_poly_mul(m_poly, y_q, q, n)
+        w    = [c - q if c > h else c for c in my]
+        c    = _sigma_challenge(m_poly, C_poly, w, n, q, t, msg_bytes)
+        cs   = _rnl_poly_mul(c, s_poly, q, n)
+        cs_c = [x - q if x > h else x for x in cs]
+        z    = [y[i] + cs_c[i] for i in range(n)]
+        if max(abs(zi) for zi in z) <= bound:
+            return w, c, z
+    raise RuntimeError("_rnl_sigma_sign: rejection limit reached")
+
+
+def _rnl_sigma_verify(m_poly, C_poly, n, msg_bytes, w_poly, c_poly, z_poly):
+    q = RNLQ
+    p = RNLP
+    gamma, t = _sigma_params(n)
+    bound = gamma - t
+    slack = t * (q // (2 * p) + 1)
+    if max(abs(zi) for zi in z_poly) > bound:
+        return False
+    if c_poly != _sigma_challenge(m_poly, C_poly, w_poly, n, q, t, msg_bytes):
+        return False
+    h    = q // 2
+    z_q  = [zi % q for zi in z_poly]
+    mz   = _rnl_poly_mul(m_poly, z_q, q, n)
+    lift = _rnl_lift(C_poly, p, q)
+    ct   = _rnl_poly_mul(c_poly, lift, q, n)
+    w_q  = [wi % q for wi in w_poly]
+    diff = [(mz[i] - ct[i] - w_q[i]) % q for i in range(n)]
+    diff_c = [d - q if d > h else d for d in diff]
+    return max(abs(d) for d in diff_c) <= slack
+
+
+# ---------------------------------------------------------------------------
+# ZKP-NL ZKBoo helpers (self-contained, mirrors suite)
+# ---------------------------------------------------------------------------
+
+def _zkp_nl_h(*args):
+    buf = b''
+    for a in args:
+        if isinstance(a, bytes):
+            buf += a
+        elif isinstance(a, int):
+            buf += a.to_bytes(max(1, (a.bit_length() + 7) // 8), 'big')
+        else:
+            buf += repr(a).encode()
+    return hfscx_256(buf)
+
+
+def _zkp_nl_prg_bit(tape_key, gate_id):
+    h = _zkp_nl_h(tape_key, gate_id.to_bytes(4, 'big'))
+    return h[0] & 1
+
+
+def _zkp_nl_rol(x, r, n):
+    m = (1 << n) - 1
+    r = r % n
+    return ((x << r) | (x >> (n - r))) & m
+
+
+def _zkp_nl_evaluate_circuit(shares, tapes, B, n):
+    mask = (1 << n) - 1
+    carry = [[0, 0, 0]] * n
+    gate_views = [[], [], []]
+    gate_id = 0
+    for i in range(n - 1):
+        ai = [(shares[p] >> i) & 1 for p in range(3)]
+        ci = [carry[i][p] for p in range(3)]
+        Bi = (B >> i) & 1
+        ri = [_zkp_nl_prg_bit(tapes[p], gate_id) for p in range(3)]
+        gate_id += 1
+        and_out = [0, 0, 0]
+        for p in range(3):
+            p1 = (p + 1) % 3
+            and_out[p] = ((ai[p] & ci[p]) ^ (ai[p] & ci[p1])
+                          ^ (ai[p1] & ci[p]) ^ ri[p] ^ ri[p1])
+            gate_views[p].append((ai[p], ci[p], and_out[p]))
+        c_next = [(Bi * ai[p]) ^ and_out[p] ^ (Bi * ci[p]) for p in range(3)]
+        carry[i + 1] = c_next
+    sum_shares = [0, 0, 0]
+    for i in range(n):
+        for p in range(3):
+            bit_i = ((shares[p] >> i) & 1) ^ ((B >> i) & 1) ^ carry[i][p]
+            sum_shares[p] ^= bit_i << i
+    rot_shares = [_zkp_nl_rol(sum_shares[p], n // 4, n) for p in range(3)]
+    B_const = (B ^ _zkp_nl_rol(B, 1, n) ^ _zkp_nl_rol(B, n - 1, n)) & mask
+    lin_shares = [0, 0, 0]
+    for p in range(3):
+        A_terms = (shares[p] ^ _zkp_nl_rol(shares[p], 1, n)
+                   ^ _zkp_nl_rol(shares[p], n - 1, n)) & mask
+        lin_shares[p] = A_terms
+    lin_shares[0] ^= B_const
+    out_shares = [(lin_shares[p] ^ rot_shares[p]) & mask for p in range(3)]
+    return out_shares, gate_views
+
+
+def _zkp_nl_keygen(n):
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+    A = int.from_bytes(os.urandom(nb), 'big') & mask
+    B = int.from_bytes(os.urandom(nb), 'big') & mask
+    y = nl_fscx_v1(BitArray(n, A), BitArray(n, B)).uint
+    return A, B, y
+
+
+def _zkp_nl_prove(A, B, y, n, rounds, msg_bytes):
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+    all_coms  = []
+    all_views = []
+    com_block = b''
+    for j in range(rounds):
+        s0 = int.from_bytes(os.urandom(nb), 'big') & mask
+        s1 = int.from_bytes(os.urandom(nb), 'big') & mask
+        s2 = (A ^ s0 ^ s1) & mask
+        shares = [s0, s1, s2]
+        tapes  = [os.urandom(32) for _ in range(3)]
+        out_shares, gate_views = _zkp_nl_evaluate_circuit(shares, tapes, B, n)
+        coms = [
+            _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p]),
+                      tapes[p], out_shares[p].to_bytes(nb, 'big'))
+            for p in range(3)
+        ]
+        all_coms.append(coms)
+        all_views.append((shares, tapes, out_shares, gate_views))
+        com_block += b''.join(coms)
+    ch_seed = _zkp_nl_h(
+        com_block, B.to_bytes(nb, 'big'), y.to_bytes(nb, 'big'), msg_bytes
+    )
+    def _pack_view(p_idx, shares_l, tapes_l, out_shares_l, gate_views_l):
+        view  = shares_l[p_idx].to_bytes(nb, 'big')
+        view += tapes_l[p_idx]
+        view += out_shares_l[p_idx].to_bytes(nb, 'big')
+        for in0, in1, out in gate_views_l[p_idx]:
+            view += bytes([in0 | (in1 << 1) | (out << 2)])
+        return view
+    rounds_out = []
+    for j in range(rounds):
+        h = _zkp_nl_h(ch_seed, j.to_bytes(4, 'big'))
+        e = h[0] % 3
+        p1, p2 = (e + 1) % 3, (e + 2) % 3
+        shares, tapes, out_shares, gate_views = all_views[j]
+        rounds_out.append({
+            'com_0':   all_coms[j][0],
+            'com_1':   all_coms[j][1],
+            'com_2':   all_coms[j][2],
+            'e':       e,
+            'view_p1': _pack_view(p1, shares, tapes, out_shares, gate_views),
+            'view_p2': _pack_view(p2, shares, tapes, out_shares, gate_views),
+        })
+    return rounds_out
+
+
+def _zkp_nl_verify(B, y, n, rounds, msg_bytes, proof_rounds):
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+    coms_list  = [[r['com_0'], r['com_1'], r['com_2']] for r in proof_rounds]
+    challenges = [r['e'] for r in proof_rounds]
+    com_block = b''.join(b''.join(coms) for coms in coms_list)
+    ch_seed   = _zkp_nl_h(
+        com_block, B.to_bytes(nb, 'big'), y.to_bytes(nb, 'big'), msg_bytes
+    )
+    for j in range(rounds):
+        h = _zkp_nl_h(ch_seed, j.to_bytes(4, 'big'))
+        if h[0] % 3 != challenges[j]:
+            return False
+    def _unpack_view(view_bytes):
+        share = int.from_bytes(view_bytes[:nb], 'big')
+        tape  = view_bytes[nb:nb + 32]
+        out_s = int.from_bytes(view_bytes[nb + 32:nb + 32 + nb], 'big')
+        gv = []
+        for k in range(n - 1):
+            b3 = view_bytes[nb + 32 + nb + k]
+            gv.append((b3 & 1, (b3 >> 1) & 1, (b3 >> 2) & 1))
+        return share, tape, out_s, gv
+    for j, e in enumerate(challenges):
+        resp = proof_rounds[j]
+        p1, p2 = (e + 1) % 3, (e + 2) % 3
+        share_p1, tape_p1, out_p1, gv_p1 = _unpack_view(resp['view_p1'])
+        share_p2, tape_p2, out_p2, gv_p2 = _unpack_view(resp['view_p2'])
+        c_p1 = _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p1]),
+                          tape_p1, out_p1.to_bytes(nb, 'big'))
+        c_p2 = _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p2]),
+                          tape_p2, out_p2.to_bytes(nb, 'big'))
+        if c_p1 != coms_list[j][p1] or c_p2 != coms_list[j][p2]:
+            return False
+        carry_p1, carry_p2 = 0, 0
+        for i in range(n - 1):
+            ai_p1 = (share_p1 >> i) & 1
+            ai_p2 = (share_p2 >> i) & 1
+            ci_p1 = carry_p1
+            ci_p2 = carry_p2
+            Bi    = (B >> i) & 1
+            ri_p1 = _zkp_nl_prg_bit(tape_p1, i)
+            ri_p2 = _zkp_nl_prg_bit(tape_p2, i)
+            exp_and_p1 = ((ai_p1 & ci_p1) ^ (ai_p1 & ci_p2)
+                          ^ (ai_p2 & ci_p1) ^ ri_p1 ^ ri_p2)
+            if gv_p1[i][2] != exp_and_p1:
+                return False
+            carry_p1 = (Bi * ai_p1) ^ exp_and_p1 ^ (Bi * ci_p1)
+            carry_p2 = (Bi * ai_p2) ^ gv_p2[i][2] ^ (Bi * ci_p2)
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -1174,6 +1430,65 @@ def test_hfscx_256():
 
 
 # ---------------------------------------------------------------------------
+# Security tests [20]-[21]: ZKP-RNL and ZKP-NL
+# ---------------------------------------------------------------------------
+
+ZKP_MSG  = b"Herradura ZKP test"
+ZKP_MSG2 = b"Herradura ZKP tamper"
+
+
+def test_zkp_rnl_correctness():
+    print("[20] ZKP-RNL Sigma-protocol completeness + tamper-rejection  [PQC-EXT]")
+    for n in [32, 256]:
+        N = _iters(5)
+        ok_verify = 0; ok_tamper = 0; n_run = 0
+        m_base = _rnl_m_poly(n)
+        for _ in _trange(N):
+            n_run += 1
+            a_rand  = _rnl_rand_poly(n, RNLQ)
+            m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
+            s, C    = _rnl_keygen(m_blind, n, RNLQ, RNLP)
+            try:
+                w, c, z = _rnl_sigma_sign(s, m_blind, C, n, ZKP_MSG)
+            except RuntimeError:
+                n_run -= 1; continue
+            if _rnl_sigma_verify(m_blind, C, n, ZKP_MSG, w, c, z):
+                ok_verify += 1
+            if not _rnl_sigma_verify(m_blind, C, n, ZKP_MSG2, w, c, z):
+                ok_tamper += 1
+        status = "PASS" if (ok_verify == n_run and ok_tamper == n_run) else "FAIL"
+        print(f"    n={n:3d}  verify={ok_verify}/{n_run}  tamper_reject={ok_tamper}/{n_run}"
+              f"  [{status}]")
+    print()
+
+
+def test_zkp_nl_correctness():
+    print("[21] ZKP-NL (ZKBoo) completeness + tamper-rejection  [PQC-EXT]")
+    zkp_nl_rounds = 16
+    for n in [32, 64]:
+        N = _iters(5)
+        ok_verify = 0; ok_tamper = 0; n_run = 0
+        for _ in _trange(N):
+            n_run += 1
+            A, B, y = _zkp_nl_keygen(n)
+            proof = _zkp_nl_prove(A, B, y, n, zkp_nl_rounds, ZKP_MSG)
+            if _zkp_nl_verify(B, y, n, zkp_nl_rounds, ZKP_MSG, proof):
+                ok_verify += 1
+            # tamper: flip one bit in com_1[0]
+            tampered = [dict(r) for r in proof]
+            c1 = bytearray(tampered[0]['com_1'])
+            c1[0] ^= 1
+            tampered[0] = dict(tampered[0])
+            tampered[0]['com_1'] = bytes(c1)
+            if not _zkp_nl_verify(B, y, n, zkp_nl_rounds, ZKP_MSG, tampered):
+                ok_tamper += 1
+        status = "PASS" if (ok_verify == n_run and ok_tamper == n_run) else "FAIL"
+        print(f"    n={n:2d}  rounds={zkp_nl_rounds}  verify={ok_verify}/{n_run}"
+              f"  tamper_reject={ok_tamper}/{n_run}  [{status}]")
+    print()
+
+
+# ---------------------------------------------------------------------------
 # Performance benchmarks
 # ---------------------------------------------------------------------------
 
@@ -1194,7 +1509,7 @@ def _bench(label: str, fn):
 
 
 def bench_fscx():
-    print("[20] FSCX throughput  [CLASSICAL]")
+    print("[22] FSCX throughput  [CLASSICAL]")
     for size in SIZES:
         a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -1204,7 +1519,7 @@ def bench_fscx():
 
 
 def bench_hkex_gf_pow():
-    print("[21] HKEX-GF gf_pow throughput  [CLASSICAL]")
+    print("[23] HKEX-GF gf_pow throughput  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); a = BitArray.random(size)
         def fn(a=a, poly=poly, size=size):
@@ -1214,7 +1529,7 @@ def bench_hkex_gf_pow():
 
 
 def bench_hkex_handshake():
-    print("[22] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
+    print("[24] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425)
         def fn():
@@ -1227,7 +1542,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[23] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+    print("[25] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
     for size in SIZES:
         iv = i_val(size); rv = r_val(size); sink = BitArray(size, 0)
         def fn():
@@ -1239,7 +1554,7 @@ def bench_hske_roundtrip():
 
 
 def bench_hpke_roundtrip():
-    print("[24] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
+    print("[26] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size)
         sink = BitArray(size, 0)
@@ -1256,13 +1571,13 @@ def bench_hpke_roundtrip():
 
 
 def bench_nl_fscx_revolve():
-    print("[25] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+    print("[27] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn():
             nonlocal a; a = nl_fscx_revolve_v1(a, b, iv)
         _bench(f"bits={size:3d}  v1 n/4 steps", fn)
-    print("[25b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
+    print("[27b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn(size=size, rv=rv, b=b):
@@ -1272,7 +1587,7 @@ def bench_nl_fscx_revolve():
 
 
 def bench_hske_nl_a1_roundtrip():
-    print("[26] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+    print("[28] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); sink = BitArray(size, 0)
         def fn(size=size, iv=iv):
@@ -1288,7 +1603,7 @@ def bench_hske_nl_a1_roundtrip():
 
 
 def bench_hske_nl_a2_roundtrip():
-    print("[27] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+    print("[29] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); sink = BitArray(size, 0)
         def fn(size=size, rv=rv):
@@ -1302,7 +1617,7 @@ def bench_hske_nl_a2_roundtrip():
 
 def bench_hkex_rnl_handshake():
     # Uses RNL_SIZES for speed; production uses n=256.
-    print("[28] HKEX-RNL handshake throughput  [PQC-EXT]")
+    print("[30] HKEX-RNL handshake throughput  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; n^2 poly-mul — O(n^2) per exchange)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
@@ -1318,7 +1633,7 @@ def bench_hkex_rnl_handshake():
 
 
 def bench_hpks_stern_f():
-    print("[29] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
+    print("[31] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
     rounds = 4; sink = [True]
     for size in SIZES:
         sf_seed, sf_e, sf_syn = stern_f_keygen(size)
@@ -1330,6 +1645,34 @@ def bench_hpks_stern_f():
     print()
 
 
+def bench_zkp_rnl():
+    n = 256
+    print(f"[32] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
+    m_base  = _rnl_m_poly(n)
+    a_rand  = _rnl_rand_poly(n, RNLQ)
+    m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
+    s, C    = _rnl_keygen(m_blind, n, RNLQ, RNLP)
+    def fn():
+        try:
+            w, c, z = _rnl_sigma_sign(s, m_blind, C, n, ZKP_MSG)
+            _rnl_sigma_verify(m_blind, C, n, ZKP_MSG, w, c, z)
+        except RuntimeError:
+            pass
+    _bench(f"n={n:3d}  sign+verify", fn)
+    print()
+
+
+def bench_zkp_nl():
+    n = 32; rounds = 16
+    print(f"[33] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
+    A, B, y = _zkp_nl_keygen(n)
+    def fn():
+        proof = _zkp_nl_prove(A, B, y, n, rounds, ZKP_MSG)
+        _zkp_nl_verify(B, y, n, rounds, ZKP_MSG, proof)
+    _bench(f"n={n:2d}  rounds={rounds}  prove+verify", fn)
+    print()
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -1337,7 +1680,7 @@ def bench_hpks_stern_f():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.5.22 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.9.11 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -1365,7 +1708,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.8.8 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.9.11 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")
@@ -1400,6 +1743,10 @@ if __name__ == '__main__':
     print("--- Security Tests: HFSCX-256 Hash ---\n")
     test_hfscx_256()
 
+    print("--- Security Tests: ZKP (Ring-LWR Sigma + NL-FSCX ZKBoo) ---\n")
+    test_zkp_rnl_correctness()
+    test_zkp_nl_correctness()
+
     print("--- Performance Benchmarks ---\n")
     bench_fscx()
     bench_hkex_gf_pow()
@@ -1408,7 +1755,8 @@ if __name__ == '__main__':
     bench_hpke_roundtrip()
     bench_nl_fscx_revolve()
     bench_hske_nl_a1_roundtrip()
-
     bench_hske_nl_a2_roundtrip()
     bench_hkex_rnl_handshake()
     bench_hpks_stern_f()
+    bench_zkp_rnl()
+    bench_zkp_nl()

--- a/Herradura cryptographic suite.asm
+++ b/Herradura cryptographic suite.asm
@@ -1,7 +1,8 @@
-;  Herradura Cryptographic Suite v1.8.0
+;  Herradura Cryptographic Suite v1.9.9
 ;  NASM i386 Assembly -- HKEX-GF, HSKE, HPKS, HPKE,
 ;                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
-;                        HPKS-Stern-F, HPKE-Stern-F
+;                        HPKS-Stern-F, HPKE-Stern-F,
+;                        ZKP-RNL (Ring-LWR Sigma-protocol)
 ;  KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
 ;  HKEX-GF: DH over GF(2^32)*, poly x^32+x^22+x^2+x+1, generator g=3
 ;  HPKS:    Schnorr signature; s=(k-a*e) mod ORD; verify g^s*C^e==R
@@ -37,6 +38,11 @@
 %define SDF_T      2
 %define SDF_NROWS  16
 %define SDF_ROUNDS 4
+%define SIGMA_GAMMA  4096
+%define SIGMA_T      4
+%define SIGMA_BOUND  4092
+%define SIGMA_SLACK  32
+%define SIGMA_RANGE  8193
 %define RNL_KDF_DC 0x6A09E667       ; SHA-256 H0 — domain constant for KDF seed
 
 section .data
@@ -108,7 +114,7 @@ section .data
         db 0,16,8,24,4,20,12,28,2,18,10,26,6,22,14,30
         db 1,17,9,25,5,21,13,29,3,19,11,27,7,23,15,31
 
-    hdr         db "=== Herradura Cryptographic Suite v1.8.0 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
+    hdr         db "=== Herradura Cryptographic Suite v1.9.9 (NASM i386, KEYBITS=32, HKEX-GF) ===", 10
     hdr_l       equ $-hdr
 
     lbl_apriv   db "a_priv    : "
@@ -223,6 +229,13 @@ section .data
     eve_hpke_sdf_ok_l equ $-eve_hpke_sdf_ok
     eve_hpke_sdf_fail db "+ Eve guessed HPKE-Stern-F session key!", 10
     eve_hpke_sdf_fail_l equ $-eve_hpke_sdf_fail
+    zkp_rnl_hdr    db 10, "--- ZKP-RNL [Ring-LWR Sigma-protocol; N=32, gamma=4096, t=4]", 10
+    zkp_rnl_hdr_l  equ $-zkp_rnl_hdr
+    zkp_rnl_ok     db "+ ZKP-RNL proof verified", 10
+    zkp_rnl_ok_l   equ $-zkp_rnl_ok
+    zkp_rnl_fail   db "- ZKP-RNL verify FAILED", 10
+    zkp_rnl_fail_l equ $-zkp_rnl_fail
+    sigma_demo_msg dd 0xDEADB00B
     lbl_K_enc    db "K (encap) : "
     lbl_K_enc_l  equ $-lbl_K_enc
     lbl_K_dec    db "K (decap) : "
@@ -266,6 +279,15 @@ section .bss
     sdf_sr_tmp  resd SDF_ROUNDS
     sdf_sy_tmp  resd SDF_ROUNDS
     sdf_chals_tmp resd SDF_ROUNDS
+    sig_y           resd RNL_N
+    sig_w           resd RNL_N
+    sig_c           resd RNL_N
+    sig_z           resd RNL_N
+    sig_pos         resd SIGMA_T
+    sigma_yq_tmp    resd RNL_N
+    sigma_liftc_tmp resd RNL_N
+    sigma_mz_tmp    resd RNL_N
+    sigma_cw_tmp    resd RNL_N
 
 section .text
 global _start
@@ -1081,6 +1103,31 @@ _start:
     mov  ecx, eve_hpke_sdf_fail_l
     call print_str
 .eve_hpke_sdf_done:
+
+    ; ================================================================== ZKP-RNL
+    mov  eax, zkp_rnl_hdr
+    mov  ecx, zkp_rnl_hdr_l
+    call print_str
+
+    mov  eax, [sigma_demo_msg]
+    call rnl_sigma_sign_32
+    test eax, eax
+    jnz  .zkp_rnl_fail
+
+    mov  eax, [sigma_demo_msg]
+    call rnl_sigma_verify_32
+    cmp  eax, 1
+    jne  .zkp_rnl_fail
+
+    mov  eax, zkp_rnl_ok
+    mov  ecx, zkp_rnl_ok_l
+    call print_str
+    jmp  .zkp_rnl_done
+.zkp_rnl_fail:
+    mov  eax, zkp_rnl_fail
+    mov  ecx, zkp_rnl_fail_l
+    call print_str
+.zkp_rnl_done:
 
     ; ------------------------------------------------------------------ exit
     mov  eax, SYS_EXIT
@@ -2868,4 +2915,404 @@ hpke_stern_f_decap_known_32:
     call stern_hash2_32
     pop  ebx
     pop  ecx
+    ret
+
+; ============================================================
+; sigma_fold_poly_32: EAX=seed, EBX=poly_ptr -> EAX=new_seed
+; Folds all RNL_N poly coefficients into seed via hfscx_32.
+; hfscx_32 preserves ECX (saves it) and ESI (saved by
+; nl_fscx_revolve_v1 called inside), so both survive the call.
+; ============================================================
+sigma_fold_poly_32:
+    push ecx
+    push esi
+    mov  esi, ebx          ; esi = poly_ptr
+    xor  ecx, ecx          ; i = 0
+.sfp_loop:
+    cmp  ecx, RNL_N
+    jge  .sfp_done
+    xor  eax, [esi + ecx*4]
+    call hfscx_32
+    inc  ecx
+    jmp  .sfp_loop
+.sfp_done:
+    pop  esi
+    pop  ecx
+    ret
+
+; ============================================================
+; sigma_challenge_32: EAX=m_ptr, EBX=C_ptr, ECX=w_ptr, EDX=msg
+; Fills sig_c with SIGMA_T-sparse ternary challenge.
+; Uses local stack frame: [ebp-4]=seed, [ebp-8]=m_ptr,
+;   [ebp-12]=C_ptr, [ebp-16]=w_ptr, [ebp-20]=msg, [ebp-24]=idx.
+; ============================================================
+sigma_challenge_32:
+    push ebp
+    mov  ebp, esp
+    sub  esp, 24
+    push ebx
+    push ecx
+    push edx
+    push esi
+    push edi
+
+    mov  [ebp-8],  eax
+    mov  [ebp-12], ebx
+    mov  [ebp-16], ecx
+    mov  [ebp-20], edx
+
+    ; seed = hfscx_32(RNL_N), then fold m, C, w, msg
+    mov  eax, RNL_N
+    call hfscx_32
+    mov  ebx, [ebp-8]
+    call sigma_fold_poly_32
+    mov  ebx, [ebp-12]
+    call sigma_fold_poly_32
+    mov  ebx, [ebp-16]
+    call sigma_fold_poly_32
+    xor  eax, [ebp-20]
+    call hfscx_32
+    mov  [ebp-4], eax          ; save seed
+
+    ; clear sig_c
+    mov  edi, sig_c
+    xor  eax, eax
+    mov  ecx, RNL_N
+    rep  stosd
+
+    ; position expansion with duplicate rejection
+    mov  dword [ebp-24], 0     ; idx = 0
+    xor  esi, esi              ; k = 0 (positions found)
+
+.sc_pos_loop:
+    cmp  esi, SIGMA_T
+    jge  .sc_signs
+    mov  eax, [ebp-24]
+    shl  eax, 16
+    xor  eax, [ebp-4]
+    call hfscx_32
+    inc  dword [ebp-24]
+    and  eax, 31               ; pos = hash & 31
+    mov  edx, eax
+
+    xor  ecx, ecx              ; j = 0
+.sc_dup:
+    cmp  ecx, esi
+    jge  .sc_no_dup
+    cmp  edx, [sig_pos + ecx*4]
+    je   .sc_pos_loop
+    inc  ecx
+    jmp  .sc_dup
+.sc_no_dup:
+    mov  [sig_pos + esi*4], edx
+    inc  esi
+    jmp  .sc_pos_loop
+
+.sc_signs:
+    xor  ecx, ecx              ; j = 0
+.sc_sign_loop:
+    cmp  ecx, SIGMA_T
+    jge  .sc_done
+    mov  eax, ecx
+    shl  eax, 24
+    xor  eax, [ebp-4]
+    call hfscx_32
+    and  eax, 1                ; sign bit
+    mov  edi, [sig_pos + ecx*4]
+    test eax, eax
+    jne  .sc_sign_neg
+    mov  dword [sig_c + edi*4], 1
+    jmp  .sc_sign_next
+.sc_sign_neg:
+    mov  dword [sig_c + edi*4], 65536  ; -1 mod q = q-1
+.sc_sign_next:
+    inc  ecx
+    jmp  .sc_sign_loop
+
+.sc_done:
+    pop  edi
+    pop  esi
+    pop  edx
+    pop  ecx
+    pop  ebx
+    mov  esp, ebp
+    pop  ebp
+    ret
+
+; ============================================================
+; rnl_sigma_sign_32: EAX=msg -> EAX=0 (ok) or -1 (exhausted)
+; Fills sig_y, sig_w, sig_c, sig_z via rejection sampling.
+; Reuses rnl_s_A, rnl_m_blind, rnl_C_A from HKEX-RNL section.
+; ============================================================
+rnl_sigma_sign_32:
+    push ebp
+    mov  ebp, esp
+    sub  esp, 8                ; [ebp-4]=msg, [ebp-8]=attempt
+    push ebx
+    push ecx
+    push edx
+    push esi
+    push edi
+
+    mov  [ebp-4], eax
+    mov  dword [ebp-8], 0
+
+.sign_attempt:
+    cmp  dword [ebp-8], 200
+    jge  .sign_exhausted
+    inc  dword [ebp-8]
+
+    ; sample y[i] and yq[i] = y[i] mod q (positive)
+    xor  esi, esi
+.sign_y_loop:
+    cmp  esi, RNL_N
+    jge  .sign_y_done
+    call prng_next
+    xor  edx, edx
+    mov  ecx, SIGMA_RANGE      ; 8193
+    div  ecx                   ; edx = eax % 8193
+    mov  eax, edx
+    sub  eax, SIGMA_GAMMA      ; y = v - 4096 (signed)
+    mov  [sig_y + esi*4], eax
+    test eax, eax
+    jns  .sign_yq_pos
+    add  eax, RNL_Q
+.sign_yq_pos:
+    mov  [sigma_yq_tmp + esi*4], eax
+    inc  esi
+    jmp  .sign_y_loop
+.sign_y_done:
+
+    ; w = rnl_m_blind * yq  (negacyclic NTT poly_mul)
+    mov  dword [rnl_f_ptr], rnl_m_blind
+    mov  dword [rnl_g_ptr], sigma_yq_tmp
+    mov  dword [rnl_h_ptr], rnl_tmp
+    call rnl_poly_mul
+
+    ; center rnl_tmp -> sig_w (signed, range [-q/2, q/2])
+    xor  esi, esi
+.sign_cw_loop:
+    cmp  esi, RNL_N
+    jge  .sign_challenge
+    mov  eax, [rnl_tmp + esi*4]
+    cmp  eax, 32768
+    jle  .sign_cw_pos
+    sub  eax, RNL_Q
+.sign_cw_pos:
+    mov  [sig_w + esi*4], eax
+    inc  esi
+    jmp  .sign_cw_loop
+
+.sign_challenge:
+    mov  eax, rnl_m_blind
+    mov  ebx, rnl_C_A
+    mov  ecx, sig_w
+    mov  edx, [ebp-4]
+    call sigma_challenge_32    ; fills sig_c
+
+    ; cs = sig_c * s_A
+    mov  dword [rnl_f_ptr], sig_c
+    mov  dword [rnl_g_ptr], rnl_s_A
+    mov  dword [rnl_h_ptr], rnl_tmp2
+    call rnl_poly_mul
+
+    ; z[i] = y[i] + center(cs[i]); reject if |z[i]| > SIGMA_BOUND
+    xor  esi, esi
+.sign_z_loop:
+    cmp  esi, RNL_N
+    jge  .sign_z_done
+    mov  eax, [rnl_tmp2 + esi*4]
+    cmp  eax, 32768
+    jle  .sign_cs_pos
+    sub  eax, RNL_Q
+.sign_cs_pos:
+    add  eax, [sig_y + esi*4]
+    mov  edx, eax
+    test edx, edx
+    jns  .sign_z_abs
+    neg  edx
+.sign_z_abs:
+    cmp  edx, SIGMA_BOUND
+    jg   .sign_attempt
+    mov  [sig_z + esi*4], eax
+    inc  esi
+    jmp  .sign_z_loop
+.sign_z_done:
+    xor  eax, eax
+    jmp  .sign_exit
+
+.sign_exhausted:
+    mov  eax, -1
+
+.sign_exit:
+    pop  edi
+    pop  esi
+    pop  edx
+    pop  ecx
+    pop  ebx
+    mov  esp, ebp
+    pop  ebp
+    ret
+
+; ============================================================
+; rnl_sigma_verify_32: EAX=msg -> EAX=1 (ok) or 0 (fail)
+; Verifies sig_y/sig_w/sig_c/sig_z produced by rnl_sigma_sign_32.
+; Three checks: bound, recomputed challenge, slack on mz-cL-w.
+; ============================================================
+rnl_sigma_verify_32:
+    push ebp
+    mov  ebp, esp
+    sub  esp, 4                ; [ebp-4] = msg
+    push ebx
+    push ecx
+    push edx
+    push esi
+    push edi
+
+    mov  [ebp-4], eax
+
+    ; (1) ||z||_inf <= SIGMA_BOUND
+    xor  esi, esi
+.sv_bound:
+    cmp  esi, RNL_N
+    jge  .sv_bound_ok
+    mov  eax, [sig_z + esi*4]
+    mov  edx, eax
+    test edx, edx
+    jns  .sv_z_abs
+    neg  edx
+.sv_z_abs:
+    cmp  edx, SIGMA_BOUND
+    jg   .sv_fail
+    inc  esi
+    jmp  .sv_bound
+.sv_bound_ok:
+
+    ; (2a) save sig_c -> sigma_cw_tmp
+    xor  esi, esi
+.sv_save_c:
+    cmp  esi, RNL_N
+    jge  .sv_rechallenge
+    mov  eax, [sig_c + esi*4]
+    mov  [sigma_cw_tmp + esi*4], eax
+    inc  esi
+    jmp  .sv_save_c
+
+.sv_rechallenge:
+    ; (2b) recompute challenge -> sig_c
+    mov  eax, rnl_m_blind
+    mov  ebx, rnl_C_A
+    mov  ecx, sig_w
+    mov  edx, [ebp-4]
+    call sigma_challenge_32
+
+    ; (2c) compare recomputed sig_c vs saved sigma_cw_tmp
+    xor  esi, esi
+.sv_cmp_c:
+    cmp  esi, RNL_N
+    jge  .sv_cmp_ok
+    mov  eax, [sig_c + esi*4]
+    cmp  eax, [sigma_cw_tmp + esi*4]
+    jne  .sv_fail
+    inc  esi
+    jmp  .sv_cmp_c
+.sv_cmp_ok:
+
+    ; (2d) restore sig_c <- sigma_cw_tmp
+    xor  esi, esi
+.sv_restore_c:
+    cmp  esi, RNL_N
+    jge  .sv_lift
+    mov  eax, [sigma_cw_tmp + esi*4]
+    mov  [sig_c + esi*4], eax
+    inc  esi
+    jmp  .sv_restore_c
+
+.sv_lift:
+    ; (3a) lift(C_A) from p=4096 to q=65537 -> sigma_liftc_tmp
+    ; rnl_lift args: EBP=out, ESI=in, ECX=from_p, EDX=to_q
+    ; Save/restore EBP since rnl_lift clobbers it
+    push ebp
+    mov  ebp, sigma_liftc_tmp
+    mov  esi, rnl_C_A
+    mov  ecx, RNL_P
+    mov  edx, RNL_Q
+    call rnl_lift
+    pop  ebp
+
+    ; (3b) z_q: make sig_z positive mod q -> sigma_yq_tmp
+    xor  esi, esi
+.sv_zq:
+    cmp  esi, RNL_N
+    jge  .sv_mz
+    mov  eax, [sig_z + esi*4]
+    test eax, eax
+    jns  .sv_zq_pos
+    add  eax, RNL_Q
+.sv_zq_pos:
+    mov  [sigma_yq_tmp + esi*4], eax
+    inc  esi
+    jmp  .sv_zq
+
+.sv_mz:
+    ; (3c) m*z_q -> sigma_mz_tmp
+    mov  dword [rnl_f_ptr], rnl_m_blind
+    mov  dword [rnl_g_ptr], sigma_yq_tmp
+    mov  dword [rnl_h_ptr], sigma_mz_tmp
+    call rnl_poly_mul
+
+    ; (3d) sig_c * sigma_liftc_tmp -> sigma_cw_tmp
+    mov  dword [rnl_f_ptr], sig_c
+    mov  dword [rnl_g_ptr], sigma_liftc_tmp
+    mov  dword [rnl_h_ptr], sigma_cw_tmp
+    call rnl_poly_mul
+
+    ; (3e) ||mz - cL - w||_inf <= SIGMA_SLACK
+    xor  esi, esi
+.sv_slack:
+    cmp  esi, RNL_N
+    jge  .sv_ok
+    mov  eax, [sigma_mz_tmp + esi*4]   ; mz in [0, q-1]
+    mov  ecx, [sigma_cw_tmp + esi*4]   ; cL in [0, q-1]
+    mov  edx, [sig_w + esi*4]          ; w signed
+    test edx, edx
+    jns  .sv_wq_pos
+    add  edx, RNL_Q
+.sv_wq_pos:
+    sub  eax, ecx                       ; eax = mz - cL
+    sub  eax, edx                       ; eax = mz - cL - wq
+    add  eax, 131074                    ; + 2q to ensure positive
+    xor  edx, edx
+    mov  ecx, RNL_Q
+    div  ecx                            ; edx = eax % q
+    mov  eax, edx
+    cmp  eax, 32768
+    jle  .sv_centered
+    sub  eax, RNL_Q                     ; center to [-q/2, q/2]
+.sv_centered:
+    mov  edx, eax
+    test edx, edx
+    jns  .sv_abs2
+    neg  edx
+.sv_abs2:
+    cmp  edx, SIGMA_SLACK
+    jg   .sv_fail
+    inc  esi
+    jmp  .sv_slack
+
+.sv_ok:
+    mov  eax, 1
+    jmp  .sv_exit
+
+.sv_fail:
+    xor  eax, eax
+
+.sv_exit:
+    pop  edi
+    pop  esi
+    pop  edx
+    pop  ecx
+    pop  ebx
+    mov  esp, ebp
+    pop  ebp
     ret

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -534,6 +534,46 @@ int main(void)
         explicit_bzero(mac_iv, sizeof(mac_iv));
     }
 
+    /* --- ZKP-RNL [Ring-LWR Σ-protocol, Fiat-Shamir compiled; n=256] */
+    printf("\n--- ZKP-RNL [Ring-LWR \xcf\xa3-protocol, Fiat-Shamir, n=256]\n");
+    {
+        rnl_poly_t zkr_m, zkr_m_base, zkr_a_rand, zkr_s, zkr_Cp, zkr_ms;
+        rnl_poly_t zkr_w, zkr_c, zkr_z;
+        rnl_m_poly(zkr_m_base);
+        rnl_rand_poly(zkr_a_rand, urnd);
+        rnl_poly_add(zkr_m, zkr_m_base, zkr_a_rand);
+        rnl_keygen(zkr_s, zkr_ms, zkr_m, urnd);
+        rnl_poly_mul(zkr_ms, zkr_m, zkr_s);
+        rnl_round(zkr_Cp, zkr_ms, RNL_Q, RNL_P);
+        static const uint8_t zkr_msg[] = "ZKP-RNL demo";
+        int zkr_r = rnl_sigma_sign(zkr_s, zkr_m, zkr_Cp, RNL_N,
+                                    zkr_msg, sizeof(zkr_msg)-1, urnd,
+                                    zkr_w, zkr_c, zkr_z);
+        if (zkr_r == 0) {
+            int ok = rnl_sigma_verify(zkr_m, zkr_Cp, RNL_N,
+                                       zkr_msg, sizeof(zkr_msg)-1,
+                                       zkr_w, zkr_c, zkr_z);
+            puts(ok ? "+ ZKP-RNL proof verified" : "- ZKP-RNL verification FAILED");
+        } else {
+            puts("- ZKP-RNL rejection limit reached (unexpected)");
+        }
+    }
+
+    /* --- ZKP-NL [NL-FSCX ZKBoo; n=8, R=4] */
+    printf("\n--- ZKP-NL [NL-FSCX ZKBoo; n=8, R=%d]\n", ZKP_NL_DEMO_ROUNDS);
+    {
+        uint32_t zkn_A, zkn_B, zkn_y;
+        zkp_nl_keygen(ZKP_NL_DEFAULT_N, urnd, &zkn_A, &zkn_B, &zkn_y);
+        static const uint8_t zkn_msg[] = "ZKP-NL demo";
+        ZkpNlRound *zkn_proof = zkp_nl_prove(zkn_A, zkn_B, zkn_y,
+                                              ZKP_NL_DEFAULT_N, ZKP_NL_DEMO_ROUNDS,
+                                              zkn_msg, sizeof(zkn_msg)-1, urnd);
+        int ok = zkp_nl_verify(zkn_B, zkn_y, ZKP_NL_DEFAULT_N, ZKP_NL_DEMO_ROUNDS,
+                               zkn_msg, sizeof(zkn_msg)-1, zkn_proof);
+        zkp_nl_proof_free(zkn_proof, ZKP_NL_DEMO_ROUNDS);
+        puts(ok ? "+ ZKP-NL proof verified" : "- ZKP-NL verification FAILED");
+    }
+
     /* *** EVE bypass TESTS *** */
     printf("\n\n*** EVE bypass TESTS\n");
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -278,6 +278,53 @@ func main() {
 		}
 	}
 
+	// ── ZKP-RNL: Ring-LWR Σ-protocol ────────────────────────────────────────
+	fmt.Println("\n--- ZKP-RNL [PROOF — Ring-LWR Σ-protocol, Fiat-Shamir; n=32]")
+	{
+		zkpN := 32
+		zkpQ := RnlQ
+		zkpP := RnlP
+		zkpM := RnlMPoly(zkpN)
+		zkpA := RnlRandPoly(zkpN, zkpQ)
+		zkpMBlind := RnlPolyAdd(zkpM, zkpA, zkpQ)
+		zkpS, zkpCp := RnlKeygen(zkpMBlind, zkpN, zkpQ, zkpP)
+		zkpMsg := []byte("ZKP-RNL test message")
+		zkpW, zkpC, zkpZ, zkpErr := RnlSigmaSign(zkpS, zkpMBlind, zkpCp, zkpN, zkpMsg)
+		if zkpErr != nil {
+			fmt.Println("- ZKP-RNL sign error:", zkpErr)
+		} else {
+			ok := RnlSigmaVerify(zkpMBlind, zkpCp, zkpN, zkpMsg, zkpW, zkpC, zkpZ)
+			if ok {
+				fmt.Println("+ ZKP-RNL proof verified")
+			} else {
+				fmt.Println("- ZKP-RNL verify FAILED")
+			}
+		}
+	}
+
+	// ── ZKP-NL: NL-FSCX ZKBoo ───────────────────────────────────────────────
+	fmt.Printf("\n--- ZKP-NL [PROOF — NL-FSCX ZKBoo, MPC-in-the-head; n=%d, R=%d]\n",
+		ZkpNlDefaultN, ZkpNlDemoRounds)
+	{
+		zkpA, zkpB, zkpY, zkpErr := ZkpNlKeygen(ZkpNlDefaultN)
+		if zkpErr != nil {
+			fmt.Println("- ZKP-NL keygen error:", zkpErr)
+		} else {
+			zkpMsg := []byte("ZKP-NL test message")
+			zkpProof, zkpErr2 := ZkpNlProve(zkpA, zkpB, zkpY, ZkpNlDefaultN, ZkpNlDemoRounds, zkpMsg)
+			if zkpErr2 != nil {
+				fmt.Println("- ZKP-NL prove error:", zkpErr2)
+			} else {
+				ok := ZkpNlVerify(zkpB, zkpY, ZkpNlDefaultN, ZkpNlDemoRounds, zkpMsg, zkpProof)
+				if ok {
+					fmt.Println("+ ZKP-NL proof verified")
+				} else {
+					fmt.Println("- ZKP-NL verify FAILED")
+				}
+			}
+		}
+	}
+
 	// ── Eve bypass tests ─────────────────────────────────────────────────────
 	fmt.Println("\n\n*** EVE bypass TESTS")
 

--- a/Herradura cryptographic suite.ino
+++ b/Herradura cryptographic suite.ino
@@ -1,6 +1,6 @@
-/*  Herradura Cryptographic Suite v1.8.0 — Arduino (32-bit)
+/*  Herradura Cryptographic Suite v1.9.10 — Arduino (32-bit)
     HKEX-GF, HSKE, HPKS, HPKE, HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
-    HPKS-Stern-F, HPKE-Stern-F
+    HPKS-Stern-F, HPKE-Stern-F, ZKP-RNL, ZKP-NL
     KEYBITS = 32
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
@@ -42,6 +42,17 @@
 #define RNL_P   4096L
 #define RNL_PP  4L
 #define RNL_ETA 1  /* CBD eta: secret coeffs drawn from CBD(1) in {-1,0,1} mod q */
+
+/* ZKP-RNL: Lyubashevsky Sigma-protocol (n=32) */
+#define SIGMA_GAMMA 4096
+#define SIGMA_T     4
+#define SIGMA_BOUND 4092      /* gamma - t */
+#define SIGMA_SLACK 32
+#define SIGMA_RANGE 8193      /* 2*gamma + 1 */
+
+/* ZKP-NL: minimal ZKBoo concept demo (n=8 bits, R=4 rounds) */
+#define ZKP_NL_N   8
+#define ZKP_NL_R   4
 
 typedef unsigned long uint32;
 
@@ -501,6 +512,248 @@ static uint32 hpke_stern_f_decap_32(uint32 seed, uint32 e_p) {
 }
 
 /* ------------------------------------------------------------------ */
+/* ZKP-RNL: Lyubashevsky Ring-LWR Sigma-protocol (n=32)               */
+/* Requires Arduino Mega or Due (8+ KB SRAM).                         */
+/* ------------------------------------------------------------------ */
+
+/* Scratch polys shared between sign and verify. */
+static long sig_y[RNL_N], sig_w[RNL_N], sig_c[RNL_N], sig_z[RNL_N];
+static long sig_pos[SIGMA_T];
+static long sig_tmp0[RNL_N], sig_tmp1[RNL_N], sig_tmp2[RNL_N];
+static long sig_tmp3[RNL_N], sig_tmp4[RNL_N];
+
+/* Derive SIGMA_T-sparse ternary challenge polynomial into sig_c. */
+static void sigma_challenge(const long *m, const long *C_pub,
+                             const long *w, uint32 msg) {
+    int i, k;
+    uint32 seed = hfscx_32((uint32)RNL_N);
+    for (i = 0; i < RNL_N; i++) seed = hfscx_32(seed ^ (uint32)m[i]);
+    for (i = 0; i < RNL_N; i++) seed = hfscx_32(seed ^ (uint32)C_pub[i]);
+    for (i = 0; i < RNL_N; i++) seed = hfscx_32(seed ^ (uint32)w[i]);
+    seed = hfscx_32(seed ^ msg);
+    for (i = 0; i < RNL_N; i++) sig_c[i] = 0;
+    k = 0;
+    uint32 idx = 0;
+    while (k < SIGMA_T) {
+        uint32 h2 = hfscx_32((idx << 16) ^ seed);
+        idx++;
+        int pos = (int)(h2 & 31u);
+        int dup = 0;
+        for (int jj = 0; jj < k; jj++) if (sig_pos[jj] == (long)pos) { dup = 1; break; }
+        if (!dup) sig_pos[k++] = (long)pos;
+    }
+    for (int jj = 0; jj < SIGMA_T; jj++) {
+        uint32 h2 = hfscx_32(((uint32)jj << 24) ^ seed);
+        sig_c[(int)sig_pos[jj]] = (h2 & 1u) ? (long)(RNL_Q - 1L) : 1L;
+    }
+}
+
+/* Rejection-sampling Sigma-prover. Returns 1=ok, 0=exhausted (>200 attempts). */
+static int rnl_sigma_sign(const long *m, const long *s,
+                           const long *C_pub, uint32 msg) {
+    int i, attempt;
+    for (attempt = 0; attempt < 200; attempt++) {
+        for (i = 0; i < RNL_N; i++) {
+            uint32 v    = lcg_next() % (uint32)SIGMA_RANGE;
+            sig_y[i]    = (long)v - (long)SIGMA_GAMMA;
+            sig_tmp0[i] = sig_y[i] < 0 ? sig_y[i] + RNL_Q : sig_y[i];
+        }
+        rnl_poly_mul(sig_tmp1, m, sig_tmp0);
+        for (i = 0; i < RNL_N; i++)
+            sig_w[i] = sig_tmp1[i] > RNL_Q / 2 ? sig_tmp1[i] - RNL_Q : sig_tmp1[i];
+        sigma_challenge(m, C_pub, sig_w, msg);
+        rnl_poly_mul(sig_tmp2, sig_c, s);
+        int ok = 1;
+        for (i = 0; i < RNL_N; i++) {
+            long c_i = sig_tmp2[i] > RNL_Q / 2 ? sig_tmp2[i] - RNL_Q : sig_tmp2[i];
+            long z   = sig_y[i] + c_i;
+            if ((z < 0 ? -z : z) > (long)SIGMA_BOUND) { ok = 0; break; }
+            sig_z[i] = z;
+        }
+        if (ok) return 1;
+    }
+    return 0;
+}
+
+/* Three-step verifier. Returns 1=accept, 0=reject. */
+static int rnl_sigma_verify(const long *m, const long *C_pub, uint32 msg) {
+    int i;
+    for (i = 0; i < RNL_N; i++) {
+        long az = sig_z[i] < 0 ? -sig_z[i] : sig_z[i];
+        if (az > (long)SIGMA_BOUND) return 0;
+    }
+    for (i = 0; i < RNL_N; i++) sig_tmp0[i] = sig_c[i];
+    sigma_challenge(m, C_pub, sig_w, msg);
+    for (i = 0; i < RNL_N; i++) if (sig_c[i] != sig_tmp0[i]) return 0;
+    for (i = 0; i < RNL_N; i++) sig_c[i] = sig_tmp0[i];
+    for (i = 0; i < RNL_N; i++)
+        sig_tmp2[i] = sig_z[i] < 0 ? sig_z[i] + RNL_Q : sig_z[i];
+    rnl_lift(sig_tmp1, C_pub, RNL_P, RNL_Q);
+    rnl_poly_mul(sig_tmp3, m, sig_tmp2);
+    rnl_poly_mul(sig_tmp4, sig_c, sig_tmp1);
+    for (i = 0; i < RNL_N; i++) {
+        long wq  = sig_w[i] < 0 ? sig_w[i] + RNL_Q : sig_w[i];
+        long raw = sig_tmp3[i] - sig_tmp4[i] - wq;
+        raw = ((raw % RNL_Q) + RNL_Q) % RNL_Q;
+        if (raw > RNL_Q / 2) raw -= RNL_Q;
+        if ((raw < 0 ? -raw : raw) > (long)SIGMA_SLACK) return 0;
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* ZKP-NL: minimal ZKBoo concept demo (n=8 bits, R=4 rounds)         */
+/* PRG/commitments use hfscx_32 — concept illustration only.          */
+/* ------------------------------------------------------------------ */
+
+static uint32  zkp_coms[ZKP_NL_R][3];
+static uint8_t zkp_e[ZKP_NL_R];
+static uint32  zkp_sh1[ZKP_NL_R], zkp_tp1[ZKP_NL_R], zkp_out1[ZKP_NL_R];
+static uint32  zkp_sh2[ZKP_NL_R], zkp_tp2[ZKP_NL_R], zkp_out2[ZKP_NL_R];
+static uint8_t zkp_gv1[ZKP_NL_R][ZKP_NL_N - 1];
+static uint8_t zkp_gv2[ZKP_NL_R][ZKP_NL_N - 1];
+
+static int zkp_prg_bit(uint32 tape, int gate) {
+    return (int)(hfscx_32(tape ^ (uint32)gate) & 1u);
+}
+
+static uint32 zkp_commit(uint32 tape, uint32 share, uint32 out_share,
+                          const uint8_t *gv) {
+    int i;
+    uint32 h = hfscx_32(tape ^ share ^ out_share);
+    for (i = 0; i < ZKP_NL_N - 1; i++) h = hfscx_32(h ^ (uint32)gv[i]);
+    return h;
+}
+
+/* F1(A,B) at 8 bits: FSCX_8(A,B) XOR ROL8((A+B) mod 256, 2). */
+static uint32 zkp_nl_f1_8(uint32 A, uint32 B) {
+    uint32 a = A & 0xFFu, b = B & 0xFFu;
+    uint32 lin = (a ^ b ^ ((a<<1)|(a>>7)) ^ ((b<<1)|(b>>7))
+                  ^ ((a>>1)|(a<<7)) ^ ((b>>1)|(b<<7))) & 0xFFu;
+    uint32 s   = (a + b) & 0xFFu;
+    return (lin ^ (((s<<2)|(s>>6)) & 0xFFu)) & 0xFFu;
+}
+
+/* 3-party ripple-carry evaluation of F1 at 8 bits.
+   sh0^sh1^sh2=A (XOR shares); *o0^*o1^*o2=F1(A,B). */
+static void zkp_eval(uint32 s0, uint32 s1, uint32 s2,
+                     uint32 t0, uint32 t1, uint32 t2, uint32 B,
+                     uint32 *o0, uint32 *o1, uint32 *o2,
+                     uint8_t *gva, uint8_t *gvb, uint8_t *gvc) {
+    uint32 sh[3] = { s0 & 0xFFu, s1 & 0xFFu, s2 & 0xFFu };
+    uint32 tp[3] = { t0, t1, t2 };
+    uint8_t *gv[3] = { gva, gvb, gvc };
+    uint8_t carry[ZKP_NL_N + 1][3];
+    int i, p;
+    for (p = 0; p < 3; p++) carry[0][p] = 0;
+    for (i = 0; i < ZKP_NL_N - 1; i++) {
+        int Bi = (int)((B >> i) & 1u);
+        int ai[3], ci[3], ri[3], ao[3];
+        for (p = 0; p < 3; p++) {
+            ai[p] = (int)((sh[p] >> i) & 1u);
+            ci[p] = (int)(carry[i][p]);
+            ri[p] = zkp_prg_bit(tp[p], i);
+        }
+        for (p = 0; p < 3; p++) {
+            int p1 = (p + 1) % 3;
+            ao[p] = (ai[p]&ci[p]) ^ (ai[p]&ci[p1]) ^ (ai[p1]&ci[p]) ^ ri[p] ^ ri[p1];
+            gv[p][i] = (uint8_t)(ai[p] | (ci[p] << 1) | (ao[p] << 2));
+        }
+        for (p = 0; p < 3; p++)
+            carry[i+1][p] = (uint8_t)((Bi & ai[p]) ^ ao[p] ^ (Bi & ci[p]));
+    }
+    uint32 sum_s[3] = { 0u, 0u, 0u };
+    for (i = 0; i < ZKP_NL_N; i++) {
+        int Bi = (int)((B >> i) & 1u);
+        for (p = 0; p < 3; p++) {
+            int sb = (int)((sh[p] >> i) & 1u) ^ Bi ^ (int)(carry[i][p]);
+            sum_s[p] ^= (uint32)sb << i;
+        }
+    }
+    uint32 Bc = (B ^ ((B<<1)|(B>>7)) ^ ((B>>1)|(B<<7))) & 0xFFu;
+    uint32 out[3];
+    for (p = 0; p < 3; p++) {
+        uint32 rot = ((sum_s[p] << 2) | (sum_s[p] >> 6)) & 0xFFu;
+        uint32 lin = (sh[p] ^ ((sh[p]<<1)|(sh[p]>>7)) ^ ((sh[p]>>1)|(sh[p]<<7))) & 0xFFu;
+        if (p == 0) lin ^= Bc;
+        out[p] = (lin ^ rot) & 0xFFu;
+    }
+    *o0 = out[0]; *o1 = out[1]; *o2 = out[2];
+}
+
+/* Prove knowledge of A such that F1(A,B)=y; proof stored in module statics. */
+static void zkp_nl_prove_8(uint32 A, uint32 B, uint32 y, uint32 msg) {
+    static uint32  all_sh[ZKP_NL_R][3], all_tp[ZKP_NL_R][3], all_out[ZKP_NL_R][3];
+    static uint8_t all_gv[ZKP_NL_R][3][ZKP_NL_N - 1];
+    int j, p, i;
+    for (j = 0; j < ZKP_NL_R; j++) {
+        uint32 s0 = lcg_next() & 0xFFu;
+        uint32 s1 = lcg_next() & 0xFFu;
+        uint32 s2 = (A ^ s0 ^ s1) & 0xFFu;
+        all_sh[j][0] = s0; all_sh[j][1] = s1; all_sh[j][2] = s2;
+        for (p = 0; p < 3; p++) all_tp[j][p] = lcg_next();
+        zkp_eval(s0, s1, s2,
+                 all_tp[j][0], all_tp[j][1], all_tp[j][2], B & 0xFFu,
+                 &all_out[j][0], &all_out[j][1], &all_out[j][2],
+                 all_gv[j][0], all_gv[j][1], all_gv[j][2]);
+        for (p = 0; p < 3; p++)
+            zkp_coms[j][p] = zkp_commit(all_tp[j][p], all_sh[j][p],
+                                         all_out[j][p], all_gv[j][p]);
+    }
+    uint32 h = hfscx_32(msg ^ B ^ y);
+    for (j = 0; j < ZKP_NL_R; j++)
+        for (p = 0; p < 3; p++) h = hfscx_32(h ^ zkp_coms[j][p]);
+    for (j = 0; j < ZKP_NL_R; j++) {
+        h = hfscx_32(h ^ (uint32)j);
+        zkp_e[j] = (uint8_t)(h % 3u);
+    }
+    for (j = 0; j < ZKP_NL_R; j++) {
+        int e = (int)(zkp_e[j]);
+        int p1 = (e + 1) % 3, p2 = (e + 2) % 3;
+        zkp_sh1[j]  = all_sh[j][p1];  zkp_tp1[j]  = all_tp[j][p1];
+        zkp_out1[j] = all_out[j][p1];
+        zkp_sh2[j]  = all_sh[j][p2];  zkp_tp2[j]  = all_tp[j][p2];
+        zkp_out2[j] = all_out[j][p2];
+        for (i = 0; i < ZKP_NL_N - 1; i++) {
+            zkp_gv1[j][i] = all_gv[j][p1][i];
+            zkp_gv2[j][i] = all_gv[j][p2][i];
+        }
+    }
+}
+
+/* Verify ZKBoo proof from module statics. Returns 1=accept, 0=reject. */
+static int zkp_nl_verify_8(uint32 B, uint32 y, uint32 msg) {
+    int j;
+    uint32 h = hfscx_32(msg ^ B ^ y);
+    for (j = 0; j < ZKP_NL_R; j++)
+        for (int p = 0; p < 3; p++) h = hfscx_32(h ^ zkp_coms[j][p]);
+    for (j = 0; j < ZKP_NL_R; j++) {
+        h = hfscx_32(h ^ (uint32)j);
+        if ((uint8_t)(h % 3u) != zkp_e[j]) return 0;
+    }
+    for (j = 0; j < ZKP_NL_R; j++) {
+        int e = (int)(zkp_e[j]);
+        int p1 = (e + 1) % 3, p2 = (e + 2) % 3;
+        if (zkp_commit(zkp_tp1[j], zkp_sh1[j], zkp_out1[j], zkp_gv1[j]) != zkp_coms[j][p1]) return 0;
+        if (zkp_commit(zkp_tp2[j], zkp_sh2[j], zkp_out2[j], zkp_gv2[j]) != zkp_coms[j][p2]) return 0;
+        uint8_t c1 = 0, c2 = 0;
+        for (int i = 0; i < ZKP_NL_N - 1; i++) {
+            int Bi   = (int)((B >> i) & 1u);
+            int a1   = (int)((zkp_sh1[j] >> i) & 1u);
+            int a2   = (int)((zkp_sh2[j] >> i) & 1u);
+            int r1   = zkp_prg_bit(zkp_tp1[j], i);
+            int r2   = zkp_prg_bit(zkp_tp2[j], i);
+            int exp_ao1 = (a1&c1) ^ (a1&c2) ^ (a2&c1) ^ r1 ^ r2;
+            if (((zkp_gv1[j][i] >> 2) & 1) != exp_ao1) return 0;
+            c1 = (uint8_t)((Bi & a1) ^ exp_ao1 ^ (Bi & c1));
+            int ao2 = (zkp_gv2[j][i] >> 2) & 1;
+            c2 = (uint8_t)((Bi & a2) ^ ao2    ^ (Bi & c2));
+        }
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
 /* Fixed test vectors                                                  */
 /* ------------------------------------------------------------------ */
 
@@ -519,7 +772,7 @@ void setup() {
 }
 
 void loop() {
-    Serial.println("=== Herradura Cryptographic Suite v1.8.0 (Arduino, 32-bit) ===");
+    Serial.println("=== Herradura Cryptographic Suite v1.9.10 (Arduino, 32-bit) ===");
     Serial.println();
 
     printHexLine("a_priv : ", A_PRIV);
@@ -628,9 +881,9 @@ void loop() {
     /* ---------------------------------------------------------------- */
     Serial.println("--- HKEX-RNL [PQC -- Ring-LWR key exchange; N=32, q=65537]");
     uint32 sk_rnl_saved = 0;
+    static long m_base[RNL_N], a_rand[RNL_N], m_blind[RNL_N];
+    static long s_A[RNL_N], s_B[RNL_N], C_A[RNL_N], C_B[RNL_N];
     {
-        static long m_base[RNL_N], a_rand[RNL_N], m_blind[RNL_N];
-        static long s_A[RNL_N], s_B[RNL_N], C_A[RNL_N], C_B[RNL_N];
         rnl_m_poly(m_base);
         rnl_rand_poly(a_rand);
         rnl_poly_add(m_blind, m_base, a_rand);
@@ -771,6 +1024,34 @@ void loop() {
         Serial.println(eve_K == sf_K_enc_saved
             ? "+ Eve guessed KEM key (astronomically unlikely)!"
             : "- Eve random K does not match KEM key (SD protection)");
+    }
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* ZKP-RNL [Lyubashevsky Ring-LWR Sigma-protocol; n=32, t=4]       */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- ZKP-RNL [Ring-LWR Sigma-protocol; N=32, gamma=4096, t=4]");
+    {
+        int ok = rnl_sigma_sign(m_blind, s_A, C_A, PLAIN);
+        if (ok) ok = rnl_sigma_verify(m_blind, C_A, PLAIN);
+        Serial.println(ok ? "+ ZKP-RNL proof verified!" : "- ZKP-RNL FAILED");
+    }
+    Serial.println();
+
+    /* ---------------------------------------------------------------- */
+    /* ZKP-NL [ZKBoo MPC-in-the-head; n=8 bits, R=4 rounds]            */
+    /* ---------------------------------------------------------------- */
+    Serial.println("--- ZKP-NL [ZKBoo concept demo; n=8, R=4 rounds]");
+    {
+        uint32 A_nl = lcg_next() & 0xFFu;
+        uint32 B_nl = lcg_next() & 0xFFu;
+        uint32 y_nl = zkp_nl_f1_8(A_nl, B_nl);
+        zkp_nl_prove_8(A_nl, B_nl, y_nl, PLAIN);
+        int ok = zkp_nl_verify_8(B_nl, y_nl, PLAIN);
+        printHexLine("A (wit)   : ", A_nl);
+        printHexLine("B (pub)   : ", B_nl);
+        printHexLine("y=F1(A,B) : ", y_nl);
+        Serial.println(ok ? "+ ZKP-NL proof verified!" : "- ZKP-NL FAILED");
     }
     Serial.println();
 

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -149,6 +149,8 @@
         stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify
         hpke_stern_f_encap, hpke_stern_f_decap
         hkex_rnl_keygen, hkex_rnl_agree  (public aliases added in v1.7.4)
+        rnl_sigma_sign, rnl_sigma_verify  (ZKP-RNL: Ring-LWR Σ-protocol)
+        zkp_nl_keygen, zkp_nl_prove, zkp_nl_verify  (ZKP-NL: NL-FSCX ZKBoo)
 
     Key module constants: KEYBITS, I_VALUE, R_VALUE, GF_POLY, GF_GEN, ORD,
         RNLQ, RNLP, RNLPP, RNLB, SDFNR, SDFT, SDFR.
@@ -259,6 +261,16 @@ SDFR  = 32                     # ⚠ DEMO ONLY: Fiat-Shamir rounds (~19-bit soun
                                # 128-bit soundness (⌈λ / log2(3/2)⌉ at λ=128).
                                # Signing emits a RuntimeWarning when called below
                                # the production threshold.
+
+# ZKP-RNL (Ring-LWR Σ-protocol) parameters (SecurityProofs-3.md §11.10.2)
+_SIGMA_GAMMA        = {32: 4096, 64: 8192, 128: 8192, 256: 8192}  # mask bound γ per n
+_SIGMA_T            = {32: 4,    64: 8,    128: 12,   256: 16}     # challenge weight t per n
+_SIGMA_MAX_ATTEMPTS = 1000   # rejection-sampling attempts before RuntimeError
+
+# ZKBoo (NL-FSCX MPC-in-the-head) parameters (SecurityProofs-3.md §11.10.3)
+_ZKP_NL_DEFAULT_N   = 8    # default bit-width for CLI (proof ≈35 KB at R=219)
+_ZKP_NL_DEMO_ROUNDS = 4    # illustration only: soundness ≈ (2/3)^4 ≈ 20%
+_ZKP_NL_PROD_ROUNDS = 219  # ⌈128 / log₂(3/2)⌉ — required for 128-bit soundness
 
 
 # ---------------------------------------------------------------------------
@@ -1050,6 +1062,394 @@ def hpke_stern_f_encap_with_e(seed: 'BitArray', n: int = None):
 
 
 # ---------------------------------------------------------------------------
+# ZKP-RNL: Ring-LWR Σ-protocol (Lyubashevsky-style, Fiat-Shamir compiled)
+# SecurityProofs-3.md §11.10.2
+# ---------------------------------------------------------------------------
+#
+# Statement : (m, C) — blinding poly m ∈ Z_q^n, public key C ∈ Z_p^n
+# Witness   : s ∈ {-1,0,1}^n satisfying C = round_p(m·s mod q) in Z_q[x]/(x^n+1)
+# Message   : msg_bytes bound into challenge (Fiat-Shamir → signature)
+#
+# Sign  : y ← Unif[-γ,γ]^n;  w = m·y mod q (centered);
+#         c = challenge(m,C,w,msg); z = y + c·s (centered integers);
+#         reject and restart if ||z||∞ > γ − t.
+# Verify: (1) ||z||∞ ≤ γ−t; (2) c = challenge(m,C,w,msg);
+#         (3) ||m·z − w − c·lift(C)||∞ ≤ t·⌈q/(2p)⌉.
+# ---------------------------------------------------------------------------
+
+def _sigma_params(n):
+    """Return (gamma, t) for the Ring-LWR Σ-protocol at bit-width n."""
+    gamma = _SIGMA_GAMMA.get(n, 8192 if n >= 64 else 4096)
+    t     = _SIGMA_T.get(n, max(4, n // 16))
+    return gamma, t
+
+
+def _sigma_poly_bytes(poly):
+    """Serialize a polynomial (possibly signed/Z_q) to bytes for hashing (4 B/coeff)."""
+    return b''.join((c % (1 << 32)).to_bytes(4, 'big') for c in poly)
+
+
+def _sigma_challenge(m_poly, C_poly, w_poly, n, q, t, msg_bytes):
+    """Fiat-Shamir: derive sparse ternary challenge polynomial from (m, C, w, msg).
+
+    Returns a list of n integers in {0, 1, q-1} with exactly t nonzero entries.
+    Nonzero entries are either 1 (= +1) or q-1 (= -1 mod q).
+    """
+    seed = hfscx_256(
+        n.to_bytes(4, 'big')
+        + _sigma_poly_bytes(m_poly)
+        + _sigma_poly_bytes(C_poly)
+        + _sigma_poly_bytes(w_poly)
+        + msg_bytes
+    )
+    # Expand seed to t distinct positions via counter extension
+    positions = []
+    idx = 0
+    while len(positions) < t:
+        h = hfscx_256(seed + b'pos' + idx.to_bytes(4, 'big'))
+        v = int.from_bytes(h[:4], 'big') % n
+        if v not in positions:
+            positions.append(v)
+        idx += 1
+    # Assign ±1 signs (stored as Z_q: +1 or q-1)
+    c = [0] * n
+    for k, pos in enumerate(positions):
+        h = hfscx_256(seed + b'sgn' + k.to_bytes(4, 'big'))
+        c[pos] = 1 if (h[0] & 1) == 0 else q - 1
+    return c
+
+
+def rnl_sigma_sign(s_poly, m_poly, C_poly, n, msg_bytes):
+    """ZKP-RNL: Ring-LWR Σ-protocol proof of knowledge of s s.t. C = round_p(m·s).
+
+    s_poly: CBD(1) coefficients in Z_q (values in {0, 1, q-1}).
+    m_poly, C_poly: from an HKEX-RNL keypair (_rnl_keygen).
+    msg_bytes: message to bind (Fiat-Shamir → signature).
+
+    Returns (w_poly, c_poly, z_poly) — the proof triple.
+    w_poly: centered Z_q coefficients in (-q/2, q/2].
+    c_poly: sparse ternary in Z_q — t entries of {1, q-1}, rest 0.
+    z_poly: centered integer list with ||z||∞ ≤ γ − t.
+
+    Raises RuntimeError if rejection limit is reached (extremely rare).
+    """
+    q     = RNLQ
+    p     = RNLP
+    gamma, t = _sigma_params(n)
+    bound = gamma - t
+    h     = q // 2  # centering threshold
+
+    for _ in range(_SIGMA_MAX_ATTEMPTS):
+        # Sample mask y ← Unif[-γ, γ]^n
+        y = []
+        for _ in range(n):
+            v = int.from_bytes(os.urandom(4), 'big') % (2 * gamma + 1)
+            y.append(v - gamma)
+
+        y_q  = [yi % q for yi in y]
+        my   = _rnl_poly_mul(m_poly, y_q, q, n)
+        # Center w coefficients into (-q/2, q/2]
+        w    = [c - q if c > h else c for c in my]
+
+        c    = _sigma_challenge(m_poly, C_poly, w, n, q, t, msg_bytes)
+        cs   = _rnl_poly_mul(c, s_poly, q, n)
+        cs_c = [x - q if x > h else x for x in cs]
+        z    = [y[i] + cs_c[i] for i in range(n)]
+
+        if max(abs(zi) for zi in z) <= bound:
+            return w, c, z
+
+    raise RuntimeError(
+        f"rnl_sigma_sign: rejection sampling limit ({_SIGMA_MAX_ATTEMPTS}) reached"
+    )
+
+
+def rnl_sigma_verify(m_poly, C_poly, n, msg_bytes, w_poly, c_poly, z_poly):
+    """Verify a ZKP-RNL Ring-LWR Σ-protocol proof.
+
+    Returns True iff (w, c, z) is an accepting transcript for (m, C, msg).
+    """
+    q = RNLQ
+    p = RNLP
+    gamma, t = _sigma_params(n)
+    bound = gamma - t
+    slack = t * (q // (2 * p) + 1)   # t × ⌈q/(2p)⌉ = e.g. 16 × 9 = 144 at n=256
+
+    # (1) Infinity-norm bound on response
+    if max(abs(zi) for zi in z_poly) > bound:
+        return False
+
+    # (2) Fiat-Shamir consistency
+    if c_poly != _sigma_challenge(m_poly, C_poly, w_poly, n, q, t, msg_bytes):
+        return False
+
+    # (3) Rounding slack: ||m·z − w − c·lift(C)||∞ ≤ slack
+    h    = q // 2
+    z_q  = [zi % q for zi in z_poly]
+    mz   = _rnl_poly_mul(m_poly, z_q, q, n)
+    lift = _rnl_lift(C_poly, p, q)
+    ct   = _rnl_poly_mul(c_poly, lift, q, n)
+    w_q  = [wi % q for wi in w_poly]
+    diff = [(mz[i] - ct[i] - w_q[i]) % q for i in range(n)]
+    diff_c = [d - q if d > h else d for d in diff]
+    return max(abs(d) for d in diff_c) <= slack
+
+
+# ---------------------------------------------------------------------------
+# ZKP-NL: NL-FSCX ZKBoo (MPC-in-the-head, 3-party Boolean circuit)
+# SecurityProofs-3.md §11.10.3
+# ---------------------------------------------------------------------------
+#
+# Statement : (B, y) — public; B, y ∈ {0,…,2^n-1}
+# Witness   : A ∈ {0,…,2^n-1} with nl_fscx_v1(A, B) = y
+# Circuit   : F1(A,B) = fscx(A,B) ⊕ ROL((A+B) mod 2^n, n/4)
+#   Linear  : fscx(A,B) — free XOR-rotation (linear in A, B constant public)
+#   Nonlinear: (A+B) mod 2^n — n−1 AND gates for carry chain (A_i AND c_i)
+#
+# ZKBoo 3-party AND gate: x,y secret-XOR-shared across parties 0,1,2.
+#   z_i = x_i·y_i ⊕ x_i·y_{i+1} ⊕ x_{i+1}·y_i ⊕ r_i ⊕ r_{i+1}  (indices mod 3)
+#   z_0 ⊕ z_1 ⊕ z_2 = x · y
+#
+# Soundness: (2/3)^R per proof; R=219 for 128-bit soundness.
+# ---------------------------------------------------------------------------
+
+def _zkp_nl_rol(x, r, n):
+    """Cyclic left-rotate n-bit integer x by r positions."""
+    m = (1 << n) - 1
+    r = r % n
+    return ((x << r) | (x >> (n - r))) & m
+
+
+def _zkp_nl_h(*args):
+    """Domain hash for ZKBoo commitments and challenges (HFSCX-256)."""
+    buf = b''
+    for a in args:
+        if isinstance(a, bytes):
+            buf += a
+        elif isinstance(a, int):
+            buf += a.to_bytes(max(1, (a.bit_length() + 7) // 8), 'big')
+        else:
+            buf += repr(a).encode()
+    return hfscx_256(buf)
+
+
+def _zkp_nl_prg_bit(tape_key, gate_id):
+    """One pseudorandom bit from party tape + gate index."""
+    h = _zkp_nl_h(tape_key, gate_id.to_bytes(4, 'big'))
+    return h[0] & 1
+
+
+def _zkp_nl_evaluate_circuit(shares, tapes, B, n):
+    """Evaluate nl_fscx_v1(A, B) in 3-party ZKBoo decomposition.
+
+    shares: list of 3 n-bit integers (XOR shares of A; A = s0^s1^s2)
+    tapes : list of 3 × 32-byte random tapes (one per party)
+    B     : public n-bit integer
+
+    Returns (out_shares, gate_views) where:
+      out_shares[p] = party p's output share (XOR of all three = nl_fscx_v1(A,B))
+      gate_views[p] = list of (a_bit, c_bit, and_out) for each of the n-1 AND gates
+    """
+    mask = (1 << n) - 1
+    carry = [[0, 0, 0]] * n   # carry[0] always 0 (no input carry)
+    gate_views = [[], [], []]
+    gate_id = 0
+
+    for i in range(n - 1):
+        ai = [(shares[p] >> i) & 1 for p in range(3)]
+        ci = [carry[i][p] for p in range(3)]
+        Bi = (B >> i) & 1
+
+        # c_{i+1} = Bi*Ai XOR (Ai AND ci) XOR Bi*ci
+        # Only (Ai AND ci) is a secret-secret AND gate.
+        ri = [_zkp_nl_prg_bit(tapes[p], gate_id) for p in range(3)]
+        gate_id += 1
+
+        and_out = [0, 0, 0]
+        for p in range(3):
+            p1 = (p + 1) % 3
+            and_out[p] = ((ai[p] & ci[p]) ^ (ai[p] & ci[p1])
+                          ^ (ai[p1] & ci[p]) ^ ri[p] ^ ri[p1])
+            gate_views[p].append((ai[p], ci[p], and_out[p]))
+
+        c_next = [(Bi * ai[p]) ^ and_out[p] ^ (Bi * ci[p]) for p in range(3)]
+        carry[i + 1] = c_next
+
+    # Sum shares: bit i of (A+B) mod 2^n = A_i XOR B_i XOR carry_i (linear)
+    sum_shares = [0, 0, 0]
+    for i in range(n):
+        for p in range(3):
+            bit_i = ((shares[p] >> i) & 1) ^ ((B >> i) & 1) ^ carry[i][p]
+            sum_shares[p] ^= bit_i << i
+
+    # ROL_{n/4} is a bit-permutation (linear) — apply identically to each share
+    rot_shares = [_zkp_nl_rol(sum_shares[p], n // 4, n) for p in range(3)]
+
+    # Linear part L(A,B): fscx(A,B) with B constant
+    B_const = (B ^ _zkp_nl_rol(B, 1, n) ^ _zkp_nl_rol(B, n - 1, n)) & mask
+    lin_shares = [0, 0, 0]
+    for p in range(3):
+        A_terms = (shares[p] ^ _zkp_nl_rol(shares[p], 1, n)
+                   ^ _zkp_nl_rol(shares[p], n - 1, n)) & mask
+        lin_shares[p] = A_terms
+    lin_shares[0] ^= B_const   # absorb public constant into party 0 only
+
+    # F1(A,B) = linear XOR rotated-sum
+    out_shares = [(lin_shares[p] ^ rot_shares[p]) & mask for p in range(3)]
+    return out_shares, gate_views
+
+
+def zkp_nl_keygen(n=_ZKP_NL_DEFAULT_N):
+    """Generate ZKP-NL keypair: (A private, B public, y = nl_fscx_v1(A,B) public).
+
+    n: bit-width; must be a positive multiple of 2. Default: 8 (demo).
+    """
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+    A = int.from_bytes(os.urandom(nb), 'big') & mask
+    B = int.from_bytes(os.urandom(nb), 'big') & mask
+    y = nl_fscx_v1(BitArray(n, A), BitArray(n, B)).uint
+    return A, B, y
+
+
+def zkp_nl_prove(A, B, y, n, rounds, msg_bytes):
+    """ZKBoo prover: prove knowledge of A s.t. nl_fscx_v1(A, B) = y.
+
+    Returns a list of `rounds` dicts, each with keys:
+      com_0, com_1, com_2  — 32-byte HFSCX-256 commitments
+      e                    — hidden party index ∈ {0, 1, 2}
+      view_p1, view_p2     — bytes encoding revealed parties' shares, tape, and gate views
+    """
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+
+    all_coms  = []
+    all_views = []
+    com_block = b''
+
+    for j in range(rounds):
+        s0 = int.from_bytes(os.urandom(nb), 'big') & mask
+        s1 = int.from_bytes(os.urandom(nb), 'big') & mask
+        s2 = (A ^ s0 ^ s1) & mask
+        shares = [s0, s1, s2]
+        tapes  = [os.urandom(32) for _ in range(3)]
+
+        out_shares, gate_views = _zkp_nl_evaluate_circuit(shares, tapes, B, n)
+
+        coms = [
+            _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p]),
+                      tapes[p], out_shares[p].to_bytes(nb, 'big'))
+            for p in range(3)
+        ]
+        all_coms.append(coms)
+        all_views.append((shares, tapes, out_shares, gate_views))
+        com_block += b''.join(coms)
+
+    # Fiat-Shamir: bind B, y, msg_bytes, and all commitments
+    ch_seed = _zkp_nl_h(
+        com_block, B.to_bytes(nb, 'big'), y.to_bytes(nb, 'big'), msg_bytes
+    )
+
+    def _pack_view(p_idx, shares_l, tapes_l, out_shares_l, gate_views_l):
+        view  = shares_l[p_idx].to_bytes(nb, 'big')
+        view += tapes_l[p_idx]
+        view += out_shares_l[p_idx].to_bytes(nb, 'big')
+        for in0, in1, out in gate_views_l[p_idx]:
+            view += bytes([in0 | (in1 << 1) | (out << 2)])
+        return view
+
+    rounds_out = []
+    for j in range(rounds):
+        h = _zkp_nl_h(ch_seed, j.to_bytes(4, 'big'))
+        e = h[0] % 3
+        p1, p2 = (e + 1) % 3, (e + 2) % 3
+        shares, tapes, out_shares, gate_views = all_views[j]
+        rounds_out.append({
+            'com_0':   all_coms[j][0],
+            'com_1':   all_coms[j][1],
+            'com_2':   all_coms[j][2],
+            'e':       e,
+            'view_p1': _pack_view(p1, shares, tapes, out_shares, gate_views),
+            'view_p2': _pack_view(p2, shares, tapes, out_shares, gate_views),
+        })
+    return rounds_out
+
+
+def zkp_nl_verify(B, y, n, rounds, msg_bytes, proof_rounds):
+    """ZKBoo verifier: verify proof that prover knows A s.t. nl_fscx_v1(A, B) = y.
+
+    Returns True iff all rounds verify.
+    """
+    mask = (1 << n) - 1
+    nb   = (n + 7) // 8
+    view_size = nb + 32 + nb + (n - 1)   # share + tape + out + gate bits
+
+    coms_list  = [[r['com_0'], r['com_1'], r['com_2']] for r in proof_rounds]
+    challenges = [r['e'] for r in proof_rounds]
+
+    # Re-derive Fiat-Shamir challenges and validate
+    com_block = b''.join(b''.join(coms) for coms in coms_list)
+    ch_seed   = _zkp_nl_h(
+        com_block, B.to_bytes(nb, 'big'), y.to_bytes(nb, 'big'), msg_bytes
+    )
+    for j in range(rounds):
+        h = _zkp_nl_h(ch_seed, j.to_bytes(4, 'big'))
+        if h[0] % 3 != challenges[j]:
+            return False
+
+    def _unpack_view(view_bytes):
+        share = int.from_bytes(view_bytes[:nb], 'big')
+        tape  = view_bytes[nb:nb + 32]
+        out_s = int.from_bytes(view_bytes[nb + 32:nb + 32 + nb], 'big')
+        gv = []
+        for k in range(n - 1):
+            b3 = view_bytes[nb + 32 + nb + k]
+            gv.append((b3 & 1, (b3 >> 1) & 1, (b3 >> 2) & 1))
+        return share, tape, out_s, gv
+
+    for j, e in enumerate(challenges):
+        resp = proof_rounds[j]
+        p1, p2 = (e + 1) % 3, (e + 2) % 3
+
+        share_p1, tape_p1, out_p1, gv_p1 = _unpack_view(resp['view_p1'])
+        share_p2, tape_p2, out_p2, gv_p2 = _unpack_view(resp['view_p2'])
+
+        # Hidden party's output share
+        out_pe = (y ^ out_p1 ^ out_p2) & mask
+
+        # Verify commitments for revealed parties
+        c_p1 = _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p1]),
+                          tape_p1, out_p1.to_bytes(nb, 'big'))
+        c_p2 = _zkp_nl_h(j.to_bytes(4, 'big'), bytes([p2]),
+                          tape_p2, out_p2.to_bytes(nb, 'big'))
+        if c_p1 != coms_list[j][p1] or c_p2 != coms_list[j][p2]:
+            return False
+
+        # Re-evaluate p1's AND gates using p1 and p2 shares (both revealed)
+        carry_p1, carry_p2 = 0, 0
+        for i in range(n - 1):
+            ai_p1 = (share_p1 >> i) & 1
+            ai_p2 = (share_p2 >> i) & 1
+            ci_p1 = carry_p1
+            ci_p2 = carry_p2
+            Bi    = (B >> i) & 1
+
+            ri_p1 = _zkp_nl_prg_bit(tape_p1, i)
+            ri_p2 = _zkp_nl_prg_bit(tape_p2, i)
+
+            exp_and_p1 = ((ai_p1 & ci_p1) ^ (ai_p1 & ci_p2)
+                          ^ (ai_p2 & ci_p1) ^ ri_p1 ^ ri_p2)
+
+            if gv_p1[i][2] != exp_and_p1:
+                return False
+
+            carry_p1 = (Bi * ai_p1) ^ exp_and_p1 ^ (Bi * ci_p1)
+            carry_p2 = (Bi * ai_p2) ^ gv_p2[i][2] ^ (Bi * ci_p2)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Protocol documentation
 # ---------------------------------------------------------------------------
 '''
@@ -1363,6 +1763,43 @@ def main():
     print(f"+ hash length correct ({len(_bare)} bytes)")
     print("+ keyed ≠ bare (key influences output)" if _bare != _keyed
           else "- keyed == bare (unexpected!)")
+
+    # ── ZKP-RNL: Ring-LWR Σ-protocol ────────────────────────────────────────
+    print("\n--- ZKP-RNL [PROOF — Ring-LWR Σ-protocol, Fiat-Shamir; n=32]")
+    _zkprnl_n = 32
+    _zkprnl_q = RNLQ
+    _zkprnl_p = RNLP
+    _zkprnl_m_base = _rnl_m_poly(_zkprnl_n)
+    _zkprnl_a_rand = _rnl_rand_poly(_zkprnl_n, _zkprnl_q)
+    _zkprnl_m      = _rnl_poly_add(_zkprnl_m_base, _zkprnl_a_rand, _zkprnl_q)
+    _zkprnl_s, _zkprnl_C = _rnl_keygen(_zkprnl_m, _zkprnl_n, _zkprnl_q, _zkprnl_p, RNLB)
+    _zkprnl_msg = b"ZKP-RNL test message"
+    _zkprnl_w, _zkprnl_c, _zkprnl_z = rnl_sigma_sign(
+        _zkprnl_s, _zkprnl_m, _zkprnl_C, _zkprnl_n, _zkprnl_msg)
+    _zkprnl_ok = rnl_sigma_verify(
+        _zkprnl_m, _zkprnl_C, _zkprnl_n, _zkprnl_msg,
+        _zkprnl_w, _zkprnl_c, _zkprnl_z)
+    print(f"proof (w[0]={_zkprnl_w[0]}, c-nonzero={sum(1 for x in _zkprnl_c if x)}, "
+          f"z[0]={_zkprnl_z[0]})")
+    print(f"+ ZKP-RNL proof verified" if _zkprnl_ok else "- ZKP-RNL verify FAILED")
+
+    # ── ZKP-NL: NL-FSCX ZKBoo ───────────────────────────────────────────────
+    print(f"\n--- ZKP-NL [PROOF — NL-FSCX ZKBoo, MPC-in-the-head; n={_ZKP_NL_DEFAULT_N}, R={_ZKP_NL_DEMO_ROUNDS}]")
+    _zkpnl_A, _zkpnl_B, _zkpnl_y = zkp_nl_keygen(_ZKP_NL_DEFAULT_N)
+    _zkpnl_msg = b"ZKP-NL test message"
+    _zkpnl_proof = zkp_nl_prove(
+        _zkpnl_A, _zkpnl_B, _zkpnl_y,
+        _ZKP_NL_DEFAULT_N, _ZKP_NL_DEMO_ROUNDS, _zkpnl_msg)
+    _zkpnl_ok = zkp_nl_verify(
+        _zkpnl_B, _zkpnl_y, _ZKP_NL_DEFAULT_N,
+        _ZKP_NL_DEMO_ROUNDS, _zkpnl_msg, _zkpnl_proof)
+    print(f"keypair: A=0x{_zkpnl_A:0{_ZKP_NL_DEFAULT_N//4}x}, "
+          f"B=0x{_zkpnl_B:0{_ZKP_NL_DEFAULT_N//4}x}, "
+          f"y=0x{_zkpnl_y:0{_ZKP_NL_DEFAULT_N//4}x}")
+    print(f"proof rounds: {len(_zkpnl_proof)}, "
+          f"view size: {len(_zkpnl_proof[0]['view_p1'])} bytes each")
+    print(f"+ ZKP-NL proof verified" if _zkpnl_ok else "- ZKP-NL verify FAILED")
+    print(f"  (demo uses R={_ZKP_NL_DEMO_ROUNDS}; production requires R={_ZKP_NL_PROD_ROUNDS} for 128-bit soundness)")
 
     # ── Eve bypass tests ─────────────────────────────────────────────────────
     print(f"\n\n*** EVE bypass TESTS")

--- a/Herradura cryptographic suite.s
+++ b/Herradura cryptographic suite.s
@@ -1,7 +1,7 @@
-/*  Herradura Cryptographic Suite v1.8.0
+/*  Herradura Cryptographic Suite v1.9.8
     ARM 32-bit Thumb Assembly (GAS) — HKEX-GF, HSKE, HPKS, HPKE,
                                        HSKE-NL-A1/A2, HKEX-RNL, HPKS-NL, HPKE-NL,
-                                       HPKS-Stern-F, HPKE-Stern-F
+                                       HPKS-Stern-F, HPKE-Stern-F, ZKP-RNL
     KEYBITS = 32, I_VALUE = 8, R_VALUE = 24
     HKEX-GF:   DH over GF(2^32)*, poly x^32+x^22+x^2+x+1, generator g=3
     HPKS:      Schnorr; s=(k-a*e) mod ORD; verify g^s*C^e==R
@@ -42,6 +42,12 @@
     .equ SDF_T,    2
     .equ SDF_NROWS,16
     .equ SDF_ROUNDS,4
+    /* ZKP-RNL parameters (n=32) */
+    .equ SIGMA_GAMMA, 4096
+    .equ SIGMA_T,     4
+    .equ SIGMA_BOUND, 4092
+    .equ SIGMA_SLACK, 32
+    .equ SIGMA_RANGE, 8193
 
 /* ------------------------------------------------------------------ */
 /* .data section                                                       */
@@ -50,7 +56,7 @@
     .balign 4
 
 /* format strings */
-fmt_header: .asciz "=== Herradura Cryptographic Suite v1.8.0 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
+fmt_header: .asciz "=== Herradura Cryptographic Suite v1.9.8 (ARM 32-bit Thumb, KEYBITS=32) ===\n"
 fmt_hex:    .asciz "%s: 0x%08x\n"
 fmt_nl:     .asciz "\n"
 
@@ -76,6 +82,12 @@ fmt_eve_sdf_ok:    .asciz "- Eve cannot forge: Fiat-Shamir mismatch  (SD + PRF p
 fmt_eve_sdf_fail:  .asciz "+ Eve forged HPKS-Stern-F (Eve wins!)\n"
 fmt_eve_hpke_sdf_ok:  .asciz "- Eve random guess does not match session key  (SD protection)\n"
 fmt_eve_hpke_sdf_fail: .asciz "+ Eve guessed HPKE-Stern-F session key!\n"
+fmt_zkp_rnl_hdr: .asciz "\n-- ZKP-RNL [Ring-LWR Sigma-protocol; N=32, gamma=4096, t=4] --\n"
+fmt_zkp_rnl_ok:  .asciz "+ ZKP-RNL proof verified\n"
+fmt_zkp_rnl_fail:.asciz "- ZKP-RNL verify FAILED\n"
+lbl_sigma_msg:   .asciz "msg (sigma) "
+    .balign 4
+sigma_demo_msg:  .word 0xDEADB00B
 
 /* result strings */
 fmt_ok:          .asciz "+ correct!\n"
@@ -233,6 +245,16 @@ sdf_pi_tmp:   .space 16   /* pi[0..3] perm seeds */
 sdf_sr_tmp:   .space 16   /* sigma(r)[0..3] */
 sdf_sy_tmp:   .space 16   /* sigma(y)[0..3] */
 sdf_chals_tmp:.space 16   /* verify: re-derived challenges */
+/* ZKP-RNL scratch (n=32, 4 bytes per coeff) */
+sig_y:           .space 128  /* y poly (signed int32, [-gamma,gamma]) */
+sig_w:           .space 128  /* w = centered(m*y) (signed int32) */
+sig_c:           .space 128  /* challenge poly {0,1,q-1} */
+sig_z:           .space 128  /* z = y + cs (signed int32) */
+sig_pos:         .space 16   /* positions[4] of nonzero challenge entries */
+sigma_yq_tmp:    .space 128  /* y_q / z_q scratch for poly_mul */
+sigma_liftc_tmp: .space 128  /* lift(C) from p to q */
+sigma_mz_tmp:    .space 128  /* m*z (verify scratch) */
+sigma_cw_tmp:    .space 128  /* c*lift(C) / saved c (verify scratch) */
 
 /* ------------------------------------------------------------------ */
 /* .text                                                               */
@@ -1133,6 +1155,44 @@ eve_hpke_sdf_fail:
     ldr     r0, =fmt_eve_hpke_sdf_fail
     bl      printf
 eve_hpke_sdf_done:
+
+    /* ================================================================
+       ZKP-RNL  (Ring-LWR Sigma-protocol, N=32, gamma=4096, t=4)
+       Reuses rnl_s_A / rnl_m_blind / rnl_C_A from the HKEX-RNL section.
+       ================================================================ */
+    ldr     r0, =fmt_zkp_rnl_hdr
+    bl      printf
+
+    ldr     r0, =fmt_hex
+    ldr     r1, =lbl_sigma_msg
+    ldr     r2, =sigma_demo_msg
+    ldr     r2, [r2]
+    bl      printf
+
+    ldr     r0, =sigma_demo_msg
+    ldr     r0, [r0]
+    bl      rnl_sigma_sign_32
+    cmp     r0, #0
+    bne     zkp_rnl_sign_fail
+
+    ldr     r0, =sigma_demo_msg
+    ldr     r0, [r0]
+    bl      rnl_sigma_verify_32
+    cmp     r0, #1
+    bne     zkp_rnl_verify_fail
+    ldr     r0, =fmt_zkp_rnl_ok
+    bl      printf
+    b       zkp_rnl_done
+zkp_rnl_sign_fail:
+    ldr     r0, =fmt_zkp_rnl_fail
+    bl      printf
+    b       zkp_rnl_done
+zkp_rnl_verify_fail:
+    ldr     r0, =fmt_zkp_rnl_fail
+    bl      printf
+zkp_rnl_done:
+    ldr     r0, =fmt_nl
+    bl      printf
 
     mov     r0, #0
     bl      exit
@@ -2735,6 +2795,466 @@ hpke_stern_f_decap_known_32:
     mov     r0, #4              @ ds = 4
     bl      stern_hash2_32
     pop     {r4, pc}
+
+    .ltorg
+
+/* ================================================================== */
+/* sigma_fold_poly_32: r0=seed, r1=poly_ptr -> r0=new_seed            */
+/* Chain-hashes all N=32 coefficients of poly into seed via hfscx_32. */
+/* ================================================================== */
+    .thumb_func
+sigma_fold_poly_32:
+    push    {r4-r6, lr}
+    mov     r4, r0              @ seed
+    mov     r5, r1              @ poly_ptr
+    mov     r6, #0              @ i = 0
+sfp_loop:
+    cmp     r6, #RNL_N
+    bge     sfp_done
+    ldr     r0, [r5, r6, lsl #2]
+    eor     r0, r0, r4
+    bl      hfscx_32
+    mov     r4, r0
+    add     r6, r6, #1
+    b       sfp_loop
+sfp_done:
+    mov     r0, r4
+    pop     {r4-r6, pc}
+
+    .ltorg
+
+/* ================================================================== */
+/* sigma_challenge_32: r0=m_ptr,r1=C_ptr,r2=w_ptr,r3=msg -> sig_c    */
+/* Derives sparse ternary challenge polynomial via chained hfscx_32.  */
+/* Seed = hfscx_32(N) folded over m,C,w,msg.  t=4 positions expand   */
+/* from seed; signs assigned by additional hash bits.                  */
+/* ================================================================== */
+    .thumb_func
+sigma_challenge_32:
+    push    {r4-r11, lr}
+    mov     r4, r0              @ m_ptr
+    mov     r5, r1              @ C_ptr
+    mov     r6, r2              @ w_ptr
+    mov     r7, r3              @ msg scalar
+
+    @ seed0 = hfscx_32(n=32)
+    mov     r0, #RNL_N
+    bl      hfscx_32
+    mov     r8, r0              @ r8 = running seed
+
+    @ fold m_ptr coefficients into seed
+    mov     r0, r8
+    mov     r1, r4
+    bl      sigma_fold_poly_32
+    mov     r8, r0
+
+    @ fold C_ptr coefficients into seed
+    mov     r0, r8
+    mov     r1, r5
+    bl      sigma_fold_poly_32
+    mov     r8, r0
+
+    @ fold w_ptr coefficients into seed
+    mov     r0, r8
+    mov     r1, r6
+    bl      sigma_fold_poly_32
+    mov     r8, r0
+
+    @ fold msg scalar into seed
+    eor     r0, r7, r8
+    bl      hfscx_32
+    mov     r8, r0              @ final seed
+
+    @ clear sig_c[0..31]
+    ldr     r10, =sig_c
+    mov     r0, #0
+    mov     r9, #0
+sc_clr:
+    cmp     r9, #RNL_N
+    bge     sc_pos_init
+    str     r0, [r10, r9, lsl #2]
+    add     r9, r9, #1
+    b       sc_clr
+
+sc_pos_init:
+    mov     r4, #0              @ idx = 0 (safe across hfscx_32: it saves r4)
+    mov     r9, #0              @ k = found count
+    ldr     r11, =sig_pos
+
+    @ expand t=4 distinct positions in [0,31]
+sc_pos_loop:
+    cmp     r9, #SIGMA_T
+    bge     sc_signs
+
+    @ h = hfscx_32(seed XOR (idx<<16)); pos = h & 31
+    lsl     r0, r4, #16
+    eor     r0, r0, r8
+    bl      hfscx_32
+    add     r4, r4, #1          @ idx++ (r4 preserved by hfscx_32)
+    and     r2, r0, #31         @ pos = h % 32
+
+    @ duplicate check against sig_pos[0..k-1]
+    mov     r0, #0              @ j = 0
+sc_dup:
+    cmp     r0, r9
+    bge     sc_no_dup
+    ldr     r3, [r11, r0, lsl #2]
+    cmp     r3, r2
+    beq     sc_pos_loop         @ duplicate: retry with next idx
+    add     r0, r0, #1
+    b       sc_dup
+sc_no_dup:
+    str     r2, [r11, r9, lsl #2]  @ sig_pos[k] = pos
+    add     r9, r9, #1
+    b       sc_pos_loop
+
+sc_signs:
+    @ q-1 = 65536 = 0x10000
+    mov     r5, #1
+    lsl     r5, r5, #16         @ r5 = 65536 = q-1
+    mov     r9, #0              @ k = 0
+
+sc_sign_loop:
+    cmp     r9, #SIGMA_T
+    bge     sc_done
+
+    @ sign_bit = hfscx_32(seed XOR (k<<24)) & 1
+    lsl     r0, r9, #24
+    eor     r0, r0, r8
+    bl      hfscx_32
+    and     r1, r0, #1          @ sign_bit (r4,r5,r8,r9,r10,r11 preserved)
+
+    ldr     r2, [r11, r9, lsl #2]  @ pos = sig_pos[k]
+    cmp     r1, #0
+    bne     sc_sign_neg
+    mov     r3, #1
+    b       sc_sign_store
+sc_sign_neg:
+    mov     r3, r5              @ q-1
+sc_sign_store:
+    str     r3, [r10, r2, lsl #2]  @ sig_c[pos] = val
+    add     r9, r9, #1
+    b       sc_sign_loop
+
+sc_done:
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ================================================================== */
+/* rnl_sigma_sign_32: r0=msg -> r0=0 success / r0=-1 exhausted        */
+/* Reads: rnl_s_A (s), rnl_m_blind (m), rnl_C_A (C, rounded)         */
+/* Writes: sig_y (y), sig_w (centered w), sig_c (challenge), sig_z (z)*/
+/* ================================================================== */
+    .thumb_func
+rnl_sigma_sign_32:
+    push    {r4-r11, lr}
+    mov     r4, r0              @ msg (preserved across retries)
+    mov     r5, #0              @ attempt counter
+    movw    r6, #200            @ max attempts
+
+sign_attempt:
+    cmp     r5, r6
+    bge     sign_exhausted
+    add     r5, r5, #1
+
+    @ --- sample y[i] for i=0..31 ---
+    ldr     r7, =sig_y
+    ldr     r8, =sigma_yq_tmp
+    mov     r9, #0              @ i
+    movw    r10, #8193          @ SIGMA_RANGE = 2*gamma+1
+    movw    r11, #4096          @ SIGMA_GAMMA
+
+sign_y_loop:
+    cmp     r9, #RNL_N
+    bge     sign_y_done
+    bl      prng_next           @ r0 = pseudo-random (clobbers r1,r2 only)
+    @ v = r0 % SIGMA_RANGE (= 0..8192)
+    udiv    r1, r0, r10         @ r1 = r0 / 8193
+    mls     r0, r10, r1, r0    @ r0 = r0 % 8193
+    @ y[i] = v - SIGMA_GAMMA (signed, in [-4096,4096])
+    sub     r1, r0, r11         @ r1 = y[i]
+    str     r1, [r7, r9, lsl #2]
+    @ y_q[i] = (y[i]<0) ? y[i]+q : y[i]
+    cmp     r1, #0
+    bge     sign_yq_pos
+    ldr     r2, =65537
+    add     r1, r1, r2
+sign_yq_pos:
+    str     r1, [r8, r9, lsl #2]
+    add     r9, r9, #1
+    b       sign_y_loop
+
+sign_y_done:
+    @ --- w = rnl_poly_mul(m, y_q) -> rnl_tmp ---
+    ldr     r0, =rnl_m_blind
+    ldr     r1, =rnl_f_ptr
+    str     r0, [r1]
+    ldr     r0, =sigma_yq_tmp
+    ldr     r1, =rnl_g_ptr
+    str     r0, [r1]
+    ldr     r0, =rnl_tmp
+    ldr     r1, =rnl_h_ptr
+    str     r0, [r1]
+    bl      rnl_poly_mul        @ rnl_tmp = m*y_q  (r4-r11 preserved)
+
+    @ --- center w, store to sig_w ---
+    ldr     r7, =rnl_tmp
+    ldr     r8, =sig_w
+    mov     r9, #0
+    movw    r10, #32768         @ q/2
+sign_center_w:
+    cmp     r9, #RNL_N
+    bge     sign_challenge
+    ldr     r0, [r7, r9, lsl #2]   @ w[i] in [0,q-1]
+    cmp     r0, r10
+    ble     sign_cw_pos
+    ldr     r1, =65537
+    sub     r0, r0, r1              @ w[i] -= q
+sign_cw_pos:
+    str     r0, [r8, r9, lsl #2]
+    add     r9, r9, #1
+    b       sign_center_w
+
+sign_challenge:
+    @ --- sigma_challenge_32(m, C, sig_w, msg) -> sig_c ---
+    ldr     r0, =rnl_m_blind
+    ldr     r1, =rnl_C_A
+    ldr     r2, =sig_w
+    mov     r3, r4              @ msg
+    bl      sigma_challenge_32  @ (r4-r11 preserved)
+
+    @ --- cs = rnl_poly_mul(sig_c, s) -> rnl_tmp2 ---
+    ldr     r0, =sig_c
+    ldr     r1, =rnl_f_ptr
+    str     r0, [r1]
+    ldr     r0, =rnl_s_A
+    ldr     r1, =rnl_g_ptr
+    str     r0, [r1]
+    ldr     r0, =rnl_tmp2
+    ldr     r1, =rnl_h_ptr
+    str     r0, [r1]
+    bl      rnl_poly_mul        @ rnl_tmp2 = c*s
+
+    @ --- compute z[i]=y[i]+centered(cs[i]); check |z[i]|<=SIGMA_BOUND ---
+    ldr     r7, =rnl_tmp2       @ cs (raw, [0,q-1])
+    ldr     r8, =sig_y          @ y (signed)
+    ldr     r9, =sig_z          @ z output
+    mov     r10, #0             @ i
+    movw    r11, #32768         @ q/2
+
+sign_z_loop:
+    cmp     r10, #RNL_N
+    bge     sign_z_done
+    @ cs_cent[i]: center cs[i] from [0,q-1] to signed
+    ldr     r0, [r7, r10, lsl #2]
+    cmp     r0, r11
+    ble     sign_cs_pos
+    ldr     r2, =65537
+    sub     r0, r0, r2              @ cs[i] -= q
+sign_cs_pos:
+    @ z[i] = y[i] + cs_cent[i]
+    ldr     r1, [r8, r10, lsl #2]
+    add     r0, r0, r1
+    @ bound check: |z[i]| <= SIGMA_BOUND = 4092
+    movw    r2, #4092
+    cmp     r0, r2
+    bgt     sign_attempt            @ z[i] > 4092: retry
+    neg     r2, r0
+    movw    r1, #4092
+    cmp     r2, r1
+    bgt     sign_attempt            @ z[i] < -4092: retry
+    @ store z[i]
+    str     r0, [r9, r10, lsl #2]
+    add     r10, r10, #1
+    b       sign_z_loop
+
+sign_z_done:
+    mov     r0, #0
+    pop     {r4-r11, pc}
+
+sign_exhausted:
+    mvn     r0, #0              @ r0 = 0xFFFFFFFF = -1
+    pop     {r4-r11, pc}
+
+    .ltorg
+
+/* ================================================================== */
+/* rnl_sigma_verify_32: r0=msg -> r0=1 ok / r0=0 fail                 */
+/* Reads: sig_w, sig_c, sig_z, rnl_m_blind, rnl_C_A                  */
+/* Steps: (1) ||z||∞<=bound  (2) c'==c  (3) ||mz-cL-w||∞<=slack     */
+/* ================================================================== */
+    .thumb_func
+rnl_sigma_verify_32:
+    push    {r4-r11, lr}
+    mov     r4, r0              @ msg
+
+    @ --- (1) check ||z||∞ <= SIGMA_BOUND = 4092 ---
+    ldr     r5, =sig_z
+    mov     r6, #0              @ i
+sv_bound_loop:
+    cmp     r6, #RNL_N
+    bge     sv_bound_ok
+    ldr     r0, [r5, r6, lsl #2]   @ z[i] (signed)
+    movw    r7, #4092               @ SIGMA_BOUND
+    cmp     r0, r7
+    bgt     sv_fail
+    neg     r1, r0
+    cmp     r1, r7
+    bgt     sv_fail
+    add     r6, r6, #1
+    b       sv_bound_loop
+sv_bound_ok:
+
+    @ --- (2a) save sig_c -> sigma_cw_tmp ---
+    ldr     r5, =sig_c
+    ldr     r6, =sigma_cw_tmp
+    mov     r7, #0
+sv_save_c:
+    cmp     r7, #RNL_N
+    bge     sv_rechallenge
+    ldr     r0, [r5, r7, lsl #2]
+    str     r0, [r6, r7, lsl #2]
+    add     r7, r7, #1
+    b       sv_save_c
+
+sv_rechallenge:
+    @ --- (2b) recompute challenge -> sig_c ---
+    ldr     r0, =rnl_m_blind
+    ldr     r1, =rnl_C_A
+    ldr     r2, =sig_w
+    mov     r3, r4
+    bl      sigma_challenge_32  @ sig_c = c'(m,C,w,msg)
+
+    @ --- (2c) compare sigma_cw_tmp (original c) with sig_c (c') ---
+    ldr     r5, =sig_c
+    ldr     r6, =sigma_cw_tmp
+    mov     r7, #0
+sv_cmp_c:
+    cmp     r7, #RNL_N
+    bge     sv_cmp_ok
+    ldr     r0, [r5, r7, lsl #2]
+    ldr     r1, [r6, r7, lsl #2]
+    cmp     r0, r1
+    bne     sv_fail
+    add     r7, r7, #1
+    b       sv_cmp_c
+sv_cmp_ok:
+
+    @ --- (2d) restore sig_c <- sigma_cw_tmp (needed for step 3) ---
+    ldr     r5, =sig_c
+    ldr     r6, =sigma_cw_tmp
+    mov     r7, #0
+sv_restore_c:
+    cmp     r7, #RNL_N
+    bge     sv_lift
+    ldr     r0, [r6, r7, lsl #2]
+    str     r0, [r5, r7, lsl #2]
+    add     r7, r7, #1
+    b       sv_restore_c
+
+sv_lift:
+    @ --- (3a) lift(C_A) -> sigma_liftc_tmp ---
+    ldr     r0, =sigma_liftc_tmp
+    ldr     r1, =rnl_C_A
+    mov     r2, #RNL_P          @ from_p = 4096
+    ldr     r3, =65537          @ to_q
+    bl      rnl_lift            @ (r4-r9 preserved by rnl_lift)
+
+    @ --- (3b) z_q[i] from sig_z -> sigma_yq_tmp ---
+    ldr     r5, =sig_z
+    ldr     r6, =sigma_yq_tmp
+    mov     r7, #0
+sv_zq:
+    cmp     r7, #RNL_N
+    bge     sv_mz
+    ldr     r0, [r5, r7, lsl #2]
+    cmp     r0, #0
+    bge     sv_zq_pos
+    ldr     r1, =65537
+    add     r0, r0, r1          @ z_q = z + q
+sv_zq_pos:
+    str     r0, [r6, r7, lsl #2]
+    add     r7, r7, #1
+    b       sv_zq
+
+sv_mz:
+    @ --- (3c) m * z_q -> sigma_mz_tmp ---
+    ldr     r0, =rnl_m_blind
+    ldr     r1, =rnl_f_ptr
+    str     r0, [r1]
+    ldr     r0, =sigma_yq_tmp
+    ldr     r1, =rnl_g_ptr
+    str     r0, [r1]
+    ldr     r0, =sigma_mz_tmp
+    ldr     r1, =rnl_h_ptr
+    str     r0, [r1]
+    bl      rnl_poly_mul
+
+    @ --- (3d) sig_c * sigma_liftc_tmp -> sigma_cw_tmp ---
+    ldr     r0, =sig_c
+    ldr     r1, =rnl_f_ptr
+    str     r0, [r1]
+    ldr     r0, =sigma_liftc_tmp
+    ldr     r1, =rnl_g_ptr
+    str     r0, [r1]
+    ldr     r0, =sigma_cw_tmp
+    ldr     r1, =rnl_h_ptr
+    str     r0, [r1]
+    bl      rnl_poly_mul
+
+    @ --- (3e) check ||mz - cL - w_q||∞ <= SIGMA_SLACK = 32 ---
+    ldr     r5, =sigma_mz_tmp
+    ldr     r6, =sigma_cw_tmp
+    ldr     r7, =sig_w
+    mov     r8, #0              @ i
+    movw    r9, #32768          @ q/2
+    movw    r10, #32            @ SIGMA_SLACK
+
+sv_slack_loop:
+    cmp     r8, #RNL_N
+    bge     sv_ok
+
+    ldr     r0, [r5, r8, lsl #2]   @ mz[i]   [0,q-1]
+    ldr     r1, [r6, r8, lsl #2]   @ cL[i]   [0,q-1]
+    ldr     r2, [r7, r8, lsl #2]   @ w[i]    signed
+    @ w_q = (w<0) ? w+q : w
+    cmp     r2, #0
+    bge     sv_wq_pos
+    ldr     r11, =65537
+    add     r2, r2, r11
+sv_wq_pos:
+    @ raw = mz - cL - w_q  (may be negative)
+    sub     r3, r0, r1
+    sub     r3, r3, r2
+    @ add 2*q = 131074 to make positive: raw in [-(2q-2), q-1] + 131074 >= 2
+    ldr     r11, =131074
+    add     r3, r3, r11         @ r3 in [2, 3q-1], positive
+    @ diff = r3 % q
+    ldr     r11, =65537
+    udiv    r0, r3, r11
+    mls     r3, r11, r0, r3     @ r3 = r3 % q  [0, q-1]
+    @ center: if r3 > q/2: r3 -= q
+    cmp     r3, r9
+    ble     sv_centered
+    ldr     r11, =65537
+    sub     r3, r3, r11
+sv_centered:
+    @ |r3| <= SIGMA_SLACK?
+    cmp     r3, r10
+    bgt     sv_fail
+    neg     r0, r3
+    cmp     r0, r10
+    bgt     sv_fail
+    add     r8, r8, #1
+    b       sv_slack_loop
+
+sv_ok:
+    mov     r0, #1
+    pop     {r4-r11, pc}
+sv_fail:
+    mov     r0, #0
+    pop     {r4-r11, pc}
 
     .ltorg
 

--- a/HerraduraCli/codec.py
+++ b/HerraduraCli/codec.py
@@ -118,6 +118,167 @@ def pem_unwrap(pem_text: str) -> tuple:
 
 
 # ---------------------------------------------------------------------------
+# ZKP-RNL proof encode/decode
+#   Wire format (raw binary, PEM label "HERRADURA ZKP-RNL PROOF"):
+#     4B n  |  n×4B w (signed s32-be)  |  n×4B c (unsigned u32-be)  |  n×4B z (signed s32-be)
+# ---------------------------------------------------------------------------
+
+def _s32be_pack(coeffs: list) -> bytes:
+    """Serialize list of signed integers as n×4-byte big-endian two's complement."""
+    return b''.join(c.to_bytes(4, 'big', signed=True) for c in coeffs)
+
+
+def _u32be_pack(coeffs: list) -> bytes:
+    """Serialize list of non-negative integers as n×4-byte big-endian unsigned."""
+    return b''.join(c.to_bytes(4, 'big') for c in coeffs)
+
+
+def _s32be_unpack(data: bytes, n: int, offset: int = 0) -> tuple:
+    """Deserialize n signed s32-be values from data[offset:]; return (list, end_offset)."""
+    out = []
+    for i in range(n):
+        val = int.from_bytes(data[offset:offset + 4], 'big', signed=True)
+        out.append(val)
+        offset += 4
+    return out, offset
+
+
+def _u32be_unpack(data: bytes, n: int, offset: int = 0) -> tuple:
+    """Deserialize n unsigned u32-be values from data[offset:]; return (list, end_offset)."""
+    out = []
+    for i in range(n):
+        val = int.from_bytes(data[offset:offset + 4], 'big')
+        out.append(val)
+        offset += 4
+    return out, offset
+
+
+def encode_zkp_rnl_proof(w_poly: list, c_poly: list, z_poly: list, n: int) -> str:
+    """Encode a ZKP-RNL Σ-protocol proof as a PEM block.
+
+    w_poly: centered Z_q coefficients; c_poly: sparse ternary Z_q; z_poly: signed ints.
+    """
+    body  = n.to_bytes(4, 'big')
+    body += _s32be_pack(w_poly)
+    body += _u32be_pack(c_poly)
+    body += _s32be_pack(z_poly)
+    return pem_wrap("HERRADURA ZKP-RNL PROOF", body)
+
+
+def decode_zkp_rnl_proof(pem_text: str) -> tuple:
+    """Decode a ZKP-RNL PEM proof block.
+
+    Returns (w_poly, c_poly, z_poly, n).
+    """
+    label, body = pem_unwrap(pem_text)
+    if label != "HERRADURA ZKP-RNL PROOF":
+        raise ValueError(f"Unexpected PEM label: {label!r}")
+    n = int.from_bytes(body[:4], 'big')
+    off = 4
+    w_poly, off = _s32be_unpack(body, n, off)
+    c_poly, off = _u32be_unpack(body, n, off)
+    z_poly, off = _s32be_unpack(body, n, off)
+    return w_poly, c_poly, z_poly, n
+
+
+# ---------------------------------------------------------------------------
+# ZKP-NL keypair and proof encode/decode
+#   Private key  (label "HERRADURA ZKP-NL PRIVATE KEY"):
+#     4B n  |  nb bytes A  (nb = ceil(n/8))
+#   Public key   (label "HERRADURA ZKP-NL PUBLIC KEY"):
+#     4B n  |  nb bytes B  |  nb bytes y
+#   Proof        (label "HERRADURA ZKP-NL PROOF"):
+#     4B n  |  4B rounds  |  for each round:
+#       32B com_0  |  32B com_1  |  32B com_2  |  1B e
+#       |  2B len_p1  |  view_p1  |  2B len_p2  |  view_p2
+# ---------------------------------------------------------------------------
+
+def encode_zkp_nl_privkey(A: int, B: int, y: int, n: int) -> str:
+    """Encode a ZKP-NL private key (A, B, y, n) as PEM.
+
+    All three values are stored so that `pkey --pubout` can extract (B, y, n)
+    without needing to re-run nl_fscx_v1.
+    """
+    nb   = (n + 7) // 8
+    body = (n.to_bytes(4, 'big')
+            + A.to_bytes(nb, 'big')
+            + B.to_bytes(nb, 'big')
+            + y.to_bytes(nb, 'big'))
+    return pem_wrap("HERRADURA ZKP-NL PRIVATE KEY", body)
+
+
+def decode_zkp_nl_privkey(pem_text: str) -> tuple:
+    """Decode a ZKP-NL private key PEM block. Returns (A, B, y, n)."""
+    label, body = pem_unwrap(pem_text)
+    if label != "HERRADURA ZKP-NL PRIVATE KEY":
+        raise ValueError(f"Unexpected PEM label: {label!r}")
+    n  = int.from_bytes(body[:4], 'big')
+    nb = (n + 7) // 8
+    A  = int.from_bytes(body[4:4 + nb], 'big')
+    B  = int.from_bytes(body[4 + nb:4 + 2 * nb], 'big')
+    y  = int.from_bytes(body[4 + 2 * nb:4 + 3 * nb], 'big')
+    return A, B, y, n
+
+
+def encode_zkp_nl_pubkey(B: int, y: int, n: int) -> str:
+    """Encode a ZKP-NL public key (B, y) as PEM."""
+    nb   = (n + 7) // 8
+    body = n.to_bytes(4, 'big') + B.to_bytes(nb, 'big') + y.to_bytes(nb, 'big')
+    return pem_wrap("HERRADURA ZKP-NL PUBLIC KEY", body)
+
+
+def decode_zkp_nl_pubkey(pem_text: str) -> tuple:
+    """Decode a ZKP-NL public key PEM block. Returns (B, y, n)."""
+    label, body = pem_unwrap(pem_text)
+    if label != "HERRADURA ZKP-NL PUBLIC KEY":
+        raise ValueError(f"Unexpected PEM label: {label!r}")
+    n  = int.from_bytes(body[:4], 'big')
+    nb = (n + 7) // 8
+    B  = int.from_bytes(body[4:4 + nb], 'big')
+    y  = int.from_bytes(body[4 + nb:4 + 2 * nb], 'big')
+    return B, y, n
+
+
+def encode_zkp_nl_proof(proof_rounds: list, n: int) -> str:
+    """Encode a ZKP-NL ZKBoo proof list as PEM.
+
+    proof_rounds: list of dicts with keys com_0, com_1, com_2, e, view_p1, view_p2.
+    """
+    R    = len(proof_rounds)
+    body = n.to_bytes(4, 'big') + R.to_bytes(4, 'big')
+    for rnd in proof_rounds:
+        body += rnd['com_0'] + rnd['com_1'] + rnd['com_2']
+        body += bytes([rnd['e']])
+        for vk in ('view_p1', 'view_p2'):
+            v = rnd[vk]
+            body += len(v).to_bytes(2, 'big') + v
+    return pem_wrap("HERRADURA ZKP-NL PROOF", body)
+
+
+def decode_zkp_nl_proof(pem_text: str) -> tuple:
+    """Decode a ZKP-NL PEM proof block. Returns (proof_rounds, n)."""
+    label, body = pem_unwrap(pem_text)
+    if label != "HERRADURA ZKP-NL PROOF":
+        raise ValueError(f"Unexpected PEM label: {label!r}")
+    off = 0
+    n   = int.from_bytes(body[off:off + 4], 'big'); off += 4
+    R   = int.from_bytes(body[off:off + 4], 'big'); off += 4
+    rounds = []
+    for _ in range(R):
+        com_0 = body[off:off + 32]; off += 32
+        com_1 = body[off:off + 32]; off += 32
+        com_2 = body[off:off + 32]; off += 32
+        e     = body[off];          off += 1
+        l1    = int.from_bytes(body[off:off + 2], 'big'); off += 2
+        vp1   = body[off:off + l1]; off += l1
+        l2    = int.from_bytes(body[off:off + 2], 'big'); off += 2
+        vp2   = body[off:off + l2]; off += l2
+        rounds.append({'com_0': com_0, 'com_1': com_1, 'com_2': com_2,
+                       'e': e, 'view_p1': vp1, 'view_p2': vp2})
+    return rounds, n
+
+
+# ---------------------------------------------------------------------------
 # Self-test (runs when imported as __main__ only)
 # ---------------------------------------------------------------------------
 if __name__ == '__main__':
@@ -140,4 +301,25 @@ if __name__ == '__main__':
     pem = pem_wrap(label, der_seq(der_int(42)))
     lbl, raw = pem_unwrap(pem)
     assert lbl == label
+    # Round-trip ZKP-RNL proof
+    n_test = 8
+    w_test = [100, -200, 300, -400, 500, -600, 700, -800]
+    c_test = [0, 1, 65536, 0, 0, 1, 0, 0]
+    z_test = [-1000, 2000, -3000, 4000, -5000, 6000, -7000, 8000]
+    rnl_pem = encode_zkp_rnl_proof(w_test, c_test, z_test, n_test)
+    w2, c2, z2, n2 = decode_zkp_rnl_proof(rnl_pem)
+    assert w2 == w_test and c2 == c_test and z2 == z_test and n2 == n_test
+    # Round-trip ZKP-NL keys and proof
+    A_t, B_t, y_t, n_t = 0xAB, 0xCD, 0xEF, 8
+    priv_pem = encode_zkp_nl_privkey(A_t, B_t, y_t, n_t)
+    A2, B2, y2, n2 = decode_zkp_nl_privkey(priv_pem)
+    assert (A2, B2, y2, n2) == (A_t, B_t, y_t, n_t)
+    pub_pem = encode_zkp_nl_pubkey(B_t, y_t, n_t)
+    B3, y3, n3 = decode_zkp_nl_pubkey(pub_pem)
+    assert (B3, y3, n3) == (B_t, y_t, n_t)
+    rnd_t = [{'com_0': b'\x01' * 32, 'com_1': b'\x02' * 32, 'com_2': b'\x03' * 32,
+              'e': 1, 'view_p1': b'\xaa\xbb', 'view_p2': b'\xcc\xdd\xee'}]
+    proof_pem = encode_zkp_nl_proof(rnd_t, 8)
+    rounds2, n4 = decode_zkp_nl_proof(proof_pem)
+    assert n4 == 8 and rounds2[0]['e'] == 1 and rounds2[0]['view_p1'] == b'\xaa\xbb'
     print("codec.py self-test OK")

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -37,7 +37,11 @@ import os
 sys.path.insert(0, os.path.dirname(__file__))
 
 from codec import (der_int, der_seq, der_parse_seq, pem_wrap, pem_unwrap,
-                   pack_poly, unpack_poly)
+                   pack_poly, unpack_poly,
+                   encode_zkp_rnl_proof, decode_zkp_rnl_proof,
+                   encode_zkp_nl_privkey, decode_zkp_nl_privkey,
+                   encode_zkp_nl_pubkey, decode_zkp_nl_pubkey,
+                   encode_zkp_nl_proof, decode_zkp_nl_proof)
 from primitives import (
     BitArray, fscx_revolve, nl_fscx_revolve_v1, nl_fscx_revolve_v2,
     nl_fscx_revolve_v2_inv, gf_mul, gf_pow,
@@ -46,9 +50,12 @@ from primitives import (
     _rnl_lift, _rnl_poly_mul,
     stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
     hpke_stern_f_encap_with_e, hpke_stern_f_decap,
+    rnl_sigma_sign, rnl_sigma_verify,
+    zkp_nl_keygen, zkp_nl_prove, zkp_nl_verify,
     KEYBITS, GF_POLY, GF_GEN, ORD,
     RNLQ, RNLP, RNLPP, RNLB,
     I_VALUE, R_VALUE, SDFT, SDFNR, SDFR,
+    _ZKP_NL_DEFAULT_N, _ZKP_NL_PROD_ROUNDS,
 )
 from primitives import _s as _suite_mod
 
@@ -65,6 +72,7 @@ _PRIV_ALGOS = {
     'hpke-nl':     'HERRADURA HPKE-NL PRIVATE KEY',
     'hpks-stern':  'HERRADURA HPKS-STERN PRIVATE KEY',
     'hpke-stern':  'HERRADURA HPKE-STERN PRIVATE KEY',
+    'hpks-zkp-nl': 'HERRADURA ZKP-NL PRIVATE KEY',
 }
 
 _PUB_ALGOS = {k: v.replace('PRIVATE', 'PUBLIC') for k, v in _PRIV_ALGOS.items()}
@@ -77,6 +85,11 @@ _LABEL_RNL_RESP    = 'HERRADURA HKEX-RNL RESPONSE'
 _LABEL_SIG         = 'HERRADURA SIGNATURE'
 _LABEL_CT          = 'HERRADURA CIPHERTEXT'
 _LABEL_DIGEST      = 'HERRADURA DIGEST'
+_LABEL_ZKP_RNL     = 'HERRADURA ZKP-RNL PROOF'
+_LABEL_ZKP_NL      = 'HERRADURA ZKP-NL PROOF'
+
+_ZKP_NL_ALGOS      = {'hpks-zkp-nl'}
+_ZKP_CLI_ROUNDS    = _ZKP_NL_PROD_ROUNDS   # CLI default: full 128-bit soundness
 
 # Binary container format for encfile / decfile (.hkx files)
 _HKX_MAGIC     = b'HKX1'   # 4-byte magic
@@ -189,21 +202,47 @@ def _encode_stern_pubkey(syn_int, seed, n, algo):
     return pem_wrap(_PUB_ALGOS[algo], der)
 
 
+def _load_zkp_nl_privkey(path):
+    """Load a ZKP-NL private key PEM; return (A, B, y, n)."""
+    pem_text = _read_file(path).decode('ascii')
+    return decode_zkp_nl_privkey(pem_text)
+
+
+def _load_zkp_nl_pubkey(path):
+    """Load a ZKP-NL public key PEM; return (B, y, n)."""
+    pem_text = _read_file(path).decode('ascii')
+    return decode_zkp_nl_pubkey(pem_text)
+
+
 def _decode_privkey(path):
-    """Load a private key PEM; return (algo, fields_list)."""
-    label, ints = _read_pem_ints(path)
-    algo = _LABEL_TO_ALGO.get(label)
+    """Load a private key PEM; return (algo, fields_list).
+
+    For ZKP-NL keys the fields_list contains raw bytes (not DER integers);
+    use _load_zkp_nl_privkey() directly when algo is known to be hpks-zkp-nl.
+    """
+    raw = _read_file(path).decode('ascii')
+    label, _ = pem_unwrap(raw)
+    if label == _PRIV_ALGOS.get('hpks-zkp-nl'):
+        A, B, y, n = decode_zkp_nl_privkey(raw)
+        return 'hpks-zkp-nl', (A, B, y, n)
+    label2, ints = _read_pem_ints(path)
+    algo = _LABEL_TO_ALGO.get(label2)
     if algo is None:
-        raise ValueError(f"Unrecognised PEM label: {label!r}")
+        raise ValueError(f"Unrecognised PEM label: {label2!r}")
     return algo, ints
 
 
 def _decode_pubkey(path):
     """Load a public key PEM; return (algo, fields_list)."""
-    label, ints = _read_pem_ints(path)
-    algo = _LABEL_TO_ALGO.get(label)
+    raw = _read_file(path).decode('ascii')
+    label, _ = pem_unwrap(raw)
+    if label == _PUB_ALGOS.get('hpks-zkp-nl'):
+        B, y, n = decode_zkp_nl_pubkey(raw)
+        return 'hpks-zkp-nl', (B, y, n)
+    label2, ints = _read_pem_ints(path)
+    algo = _LABEL_TO_ALGO.get(label2)
     if algo is None:
-        raise ValueError(f"Unrecognised PEM label: {label!r}")
+        raise ValueError(f"Unrecognised PEM label: {label2!r}")
     return algo, ints
 
 
@@ -474,6 +513,11 @@ def cmd_genpkey(args):
         seed, e_int, syn = stern_f_keygen(bits)
         pem_out = _encode_stern_privkey(e_int, seed, bits, algo)
 
+    elif algo in _ZKP_NL_ALGOS:
+        n = bits if bits != KEYBITS else _ZKP_NL_DEFAULT_N
+        A, B, y = zkp_nl_keygen(n)
+        pem_out = encode_zkp_nl_privkey(A, B, y, n)
+
     else:
         sys.exit(f"Unknown algorithm: {algo!r}")
 
@@ -501,6 +545,9 @@ def cmd_pkey(args):
             syn   = _suite_mod._stern_syndrome(seed_int, e_int, n, n // 2)
             seed  = BitArray(n, seed_int)
             pem_out = _encode_stern_pubkey(syn, seed, n, algo)
+        elif algo in _ZKP_NL_ALGOS:
+            A, B, y, n = ints
+            pem_out = encode_zkp_nl_pubkey(B, y, n)
         else:
             sys.exit(f"Unknown algorithm: {algo!r}")
         _write_file(args.out or '-', pem_out)
@@ -784,6 +831,26 @@ def cmd_sign(args):
         sig  = hpks_stern_f_sign(msg, e_int, seed, syn, n)
         _write_file(args.out, _pack_stern_sig(sig, n))
 
+    elif algo == 'rnl-sigma':
+        # Sign using an HKEX-RNL private key: proves knowledge of s s.t. C = round_p(m·s)
+        if our_algo != 'hkex-rnl':
+            sys.exit(f"rnl-sigma sign: expected hkex-rnl key, got {our_algo!r}")
+        s_poly, m_poly, n = _decode_rnl_privkey(our_ints)
+        C_poly = _rnl_derive_C(m_poly, s_poly, n)
+        w, c, z = rnl_sigma_sign(s_poly, m_poly, C_poly, n, in_bytes)
+        pem_out = encode_zkp_rnl_proof(w, c, z, n)
+        _write_file(args.out, pem_out)
+
+    elif algo == 'nl-zkboo':
+        # Sign using a ZKP-NL private key: proves knowledge of A s.t. nl_fscx_v1(A,B)=y
+        if our_algo != 'hpks-zkp-nl':
+            sys.exit(f"nl-zkboo sign: expected hpks-zkp-nl key, got {our_algo!r}")
+        A, B, y, n = our_ints
+        rounds = getattr(args, 'rounds', None) or _ZKP_CLI_ROUNDS
+        proof_rounds = zkp_nl_prove(A, B, y, n, rounds, in_bytes)
+        pem_out = encode_zkp_nl_proof(proof_rounds, n)
+        _write_file(args.out, pem_out)
+
     else:
         sys.exit(f"sign: unsupported algorithm {algo!r}")
 
@@ -827,6 +894,37 @@ def cmd_verify(args):
         commits, challenges, responses, _n = _unpack_stern_sig(sig_path)
         sig  = (commits, challenges, responses)
         ok   = hpks_stern_f_verify(msg, sig, seed, syn_int, n)
+        if ok:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    elif algo == 'rnl-sigma':
+        # Verify using an HKEX-RNL public key
+        if their_algo != 'hkex-rnl':
+            sys.exit(f"rnl-sigma verify: expected hkex-rnl pubkey, got {their_algo!r}")
+        C_poly, m_poly, n = _decode_rnl_pubkey(their_ints)
+        sig_pem = _read_file(sig_path).decode('ascii')
+        w, c, z, _n = decode_zkp_rnl_proof(sig_pem)
+        ok = rnl_sigma_verify(m_poly, C_poly, n, in_bytes, w, c, z)
+        if ok:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    elif algo == 'nl-zkboo':
+        # Verify using a ZKP-NL public key
+        if their_algo != 'hpks-zkp-nl':
+            sys.exit(f"nl-zkboo verify: expected hpks-zkp-nl pubkey, got {their_algo!r}")
+        B, y, n = their_ints
+        sig_pem = _read_file(sig_path).decode('ascii')
+        proof_rounds, _n = decode_zkp_nl_proof(sig_pem)
+        rounds = len(proof_rounds)
+        ok = zkp_nl_verify(B, y, n, rounds, in_bytes, proof_rounds)
         if ok:
             print("Signature OK")
             sys.exit(0)
@@ -1042,18 +1140,22 @@ def build_parser():
     de.add_argument('--out', required=True)
 
     # sign
-    sg = sub.add_parser('sign', help='Sign a message')
-    sg.add_argument('--algo', required=True, choices=['hpks', 'hpks-nl', 'hpks-stern'])
+    sg = sub.add_parser('sign', help='Sign a message or generate a ZKP')
+    sg.add_argument('--algo', required=True,
+                    choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo'])
     sg.add_argument('--key',  required=True)
     sg.add_argument('--in',  required=True, dest='in')
     sg.add_argument('--out', required=True)
     sg.add_argument('--digest', default='none', choices=['none', 'hfscx-256'],
                     help='Pre-hash: none=truncate input to block size (default), '
                          'hfscx-256=hash full input then sign the 32-byte digest')
+    sg.add_argument('--rounds', type=int, default=None,
+                    help='ZKBoo rounds (nl-zkboo only; default: 219 for 128-bit soundness)')
 
     # verify
-    vf = sub.add_parser('verify', help='Verify a signature')
-    vf.add_argument('--algo', required=True, choices=['hpks', 'hpks-nl', 'hpks-stern'])
+    vf = sub.add_parser('verify', help='Verify a signature or ZKP proof')
+    vf.add_argument('--algo', required=True,
+                    choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo'])
     vf.add_argument('--pubkey', required=True)
     vf.add_argument('--in',  required=True, dest='in')
     vf.add_argument('--sig', required=True)

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -178,6 +178,100 @@ static void pem_key_load(PemKey *k, const char *path)
 }
 static void pem_key_free(PemKey *k) { free(k->der); k->der = NULL; }
 
+/* Read raw-binary PEM (no DER parse). Returns heap buffer; *olen = byte count. */
+static uint8_t *zkp_raw_pem_read(const char *path, const char *expect_label, size_t *olen)
+{
+    size_t raw_len;
+    uint8_t *raw = read_binary_file(path, &raw_len);
+    char label[80] = {0};
+    size_t cap = raw_len;
+    uint8_t *buf = (uint8_t *)malloc(cap);
+    if (!buf) die("out of memory");
+    /* pem_read_file opens the file itself; raw is only for sizing */
+    free(raw);
+    if (pem_read_file(path, label, buf, &cap) != 0)
+        dief("cannot parse PEM from: %s", path);
+    if (expect_label && strcmp(label, expect_label) != 0) {
+        free(buf);
+        fprintf(stderr, "expected PEM label '%s', got '%s'\n", expect_label, label);
+        exit(1);
+    }
+    *olen = cap;
+    return buf;
+}
+
+/* Peek at a PEM label without DER-parsing the body. */
+static void zkp_pem_peek_label(const char *path, char label_out[80])
+{
+    size_t dummy_len = 4096;
+    uint8_t dummy[4096];
+    memset(label_out, 0, 80);
+    pem_read_file(path, label_out, dummy, &dummy_len);
+}
+
+/* Serialize ZkpNlRound[] to raw bytes (matches Python encode_zkp_nl_proof). */
+static uint8_t *zkp_nl_pack_proof(const ZkpNlRound *proof, int rounds, int n, size_t *olen)
+{
+    size_t vl = proof[0].view_len;
+    size_t per = 96 + 1 + 2 + vl + 2 + vl;
+    size_t total = 8 + (size_t)rounds * per;
+    uint8_t *buf = (uint8_t *)malloc(total);
+    if (!buf) die("out of memory");
+    buf[0]=(uint8_t)(n>>24);      buf[1]=(uint8_t)(n>>16);
+    buf[2]=(uint8_t)(n>>8);       buf[3]=(uint8_t)n;
+    buf[4]=(uint8_t)(rounds>>24); buf[5]=(uint8_t)(rounds>>16);
+    buf[6]=(uint8_t)(rounds>>8);  buf[7]=(uint8_t)rounds;
+    uint8_t *p = buf + 8;
+    int j;
+    for (j = 0; j < rounds; j++) {
+        memcpy(p, proof[j].com_0, 32); p += 32;
+        memcpy(p, proof[j].com_1, 32); p += 32;
+        memcpy(p, proof[j].com_2, 32); p += 32;
+        *p++ = proof[j].e;
+        *p++ = (uint8_t)(vl >> 8); *p++ = (uint8_t)vl;
+        memcpy(p, proof[j].view_p1, vl); p += vl;
+        *p++ = (uint8_t)(vl >> 8); *p++ = (uint8_t)vl;
+        memcpy(p, proof[j].view_p2, vl); p += vl;
+    }
+    *olen = total;
+    return buf;
+}
+
+/* Deserialize ZkpNlRound[] from raw bytes. */
+static ZkpNlRound *zkp_nl_unpack_proof(const uint8_t *buf, size_t blen,
+                                        int *n_out, int *rounds_out)
+{
+    if (blen < 8) die("ZKP-NL proof too short");
+    int n = (int)(((uint32_t)buf[0]<<24)|((uint32_t)buf[1]<<16)|
+                  ((uint32_t)buf[2]<<8)|buf[3]);
+    int rounds = (int)(((uint32_t)buf[4]<<24)|((uint32_t)buf[5]<<16)|
+                       ((uint32_t)buf[6]<<8)|buf[7]);
+    *n_out = n; *rounds_out = rounds;
+    ZkpNlRound *proof = (ZkpNlRound *)malloc((size_t)rounds * sizeof(ZkpNlRound));
+    if (!proof) die("out of memory");
+    const uint8_t *p = buf + 8;
+    int j;
+    for (j = 0; j < rounds; j++) {
+        if (p + 97 + 4 > buf + blen) die("truncated ZKP-NL proof");
+        memcpy(proof[j].com_0, p, 32); p += 32;
+        memcpy(proof[j].com_1, p, 32); p += 32;
+        memcpy(proof[j].com_2, p, 32); p += 32;
+        proof[j].e = *p++;
+        size_t l1 = ((size_t)p[0] << 8) | p[1]; p += 2;
+        if (p + l1 > buf + blen) die("truncated ZKP-NL proof view");
+        proof[j].view_p1  = (uint8_t *)malloc(l1);
+        if (!proof[j].view_p1) die("out of memory");
+        memcpy(proof[j].view_p1, p, l1); p += l1;
+        proof[j].view_len = l1;
+        size_t l2 = ((size_t)p[0] << 8) | p[1]; p += 2;
+        if (p + l2 > buf + blen) die("truncated ZKP-NL proof view");
+        proof[j].view_p2  = (uint8_t *)malloc(l2);
+        if (!proof[j].view_p2) die("out of memory");
+        memcpy(proof[j].view_p2, p, l2); p += l2;
+    }
+    return proof;
+}
+
 /* Get integer n=256 from a val. Returns 0 on success. */
 static int pem_key_get_n(const PemKey *k, int idx)
 {
@@ -263,6 +357,24 @@ static void cmd_genpkey(int argc, char **argv)
         fclose(urnd); return;
     }
 
+    /* ZKP-NL keypair: raw binary PEM (A, B, y, n) */
+    if (strcmp(algo, "hpks-zkp-nl") == 0) {
+        int nl_n = ZKP_NL_DEFAULT_N, nb = (nl_n+7)/8, k;
+        uint32_t A, B, y;
+        zkp_nl_keygen(nl_n, urnd, &A, &B, &y);
+        size_t blen = 4 + (size_t)3*nb;
+        uint8_t *body = (uint8_t *)malloc(blen);
+        if (!body) die("out of memory");
+        body[0]=(uint8_t)(nl_n>>24); body[1]=(uint8_t)(nl_n>>16);
+        body[2]=(uint8_t)(nl_n>>8);  body[3]=(uint8_t)nl_n;
+        for (k=0;k<nb;k++) body[4+k]       = (uint8_t)(A>>(8*(nb-1-k)));
+        for (k=0;k<nb;k++) body[4+nb+k]    = (uint8_t)(B>>(8*(nb-1-k)));
+        for (k=0;k<nb;k++) body[4+2*nb+k]  = (uint8_t)(y>>(8*(nb-1-k)));
+        if (pem_write_file(out ? out : "-", PEM_ZKP_NL_PRIV, body, blen) != 0)
+            die("cannot write ZKP-NL private key");
+        free(body); fclose(urnd); return;
+    }
+
     fclose(urnd);
     dief("genpkey: unsupported algorithm: %s", algo);
 }
@@ -286,6 +398,45 @@ static void cmd_pkey(int argc, char **argv)
     int text   = has_flag(argc, argv, "--text");
     if (!in_path) die("pkey: --in required");
     if (!pubout && !text) die("pkey: specify --pubout or --text");
+
+    /* ZKP-NL keys use raw binary PEM — handle before DER-based path. */
+    {
+        char peek[80];
+        zkp_pem_peek_label(in_path, peek);
+        if (strcmp(peek, PEM_ZKP_NL_PRIV) == 0) {
+            size_t blen;
+            uint8_t *body = zkp_raw_pem_read(in_path, PEM_ZKP_NL_PRIV, &blen);
+            if (blen < 4) die("pkey: malformed ZKP-NL private key");
+            int nl_n = (int)(((uint32_t)body[0]<<24)|((uint32_t)body[1]<<16)|
+                             ((uint32_t)body[2]<<8)|body[3]);
+            int nb = (nl_n+7)/8;
+            if ((int)blen < 4+3*nb) die("pkey: malformed ZKP-NL private key (short)");
+            uint32_t A=0, B=0, y=0; int k;
+            for (k=0;k<nb;k++) A=(A<<8)|body[4+k];
+            for (k=0;k<nb;k++) B=(B<<8)|body[4+nb+k];
+            for (k=0;k<nb;k++) y=(y<<8)|body[4+2*nb+k];
+            free(body);
+            if (text) {
+                printf("%-10s: %s\n", "algorithm", "hpks-zkp-nl");
+                printf("%-10s: %d\n", "n", nl_n);
+                printf("%-10s: %0*x\n", "A_private", 2*nb, A);
+                printf("%-10s: %0*x\n", "B_public",  2*nb, B);
+                printf("%-10s: %0*x\n", "y_public",  2*nb, y);
+            } else {
+                size_t pub_len = 4 + (size_t)2*nb;
+                uint8_t *pub = (uint8_t *)malloc(pub_len);
+                if (!pub) die("out of memory");
+                pub[0]=(uint8_t)(nl_n>>24); pub[1]=(uint8_t)(nl_n>>16);
+                pub[2]=(uint8_t)(nl_n>>8);  pub[3]=(uint8_t)nl_n;
+                for (k=0;k<nb;k++) pub[4+k]    = (uint8_t)(B>>(8*(nb-1-k)));
+                for (k=0;k<nb;k++) pub[4+nb+k] = (uint8_t)(y>>(8*(nb-1-k)));
+                if (pem_write_file(out_path ? out_path : "-", PEM_ZKP_NL_PUB, pub, pub_len) != 0)
+                    die("cannot write ZKP-NL public key");
+                free(pub);
+            }
+            return;
+        }
+    }
 
     PemKey k; pem_key_load(&k, in_path);
 
@@ -1030,6 +1181,34 @@ static void cmd_sign(int argc, char **argv)
     BitArray msg;
     memcpy(msg.b, msg_bytes, KEYBYTES);
 
+    /* nl-zkboo uses raw binary PEM — handle before pem_key_load. */
+    if (strcmp(algo, "nl-zkboo") == 0) {
+        FILE *urnd2 = fopen("/dev/urandom", "rb");
+        if (!urnd2) die("cannot open /dev/urandom");
+        size_t kblen;
+        uint8_t *kbody = zkp_raw_pem_read(key_path, PEM_ZKP_NL_PRIV, &kblen);
+        if (kblen < 4) die("sign: malformed ZKP-NL private key");
+        int nl_n = (int)(((uint32_t)kbody[0]<<24)|((uint32_t)kbody[1]<<16)|
+                         ((uint32_t)kbody[2]<<8)|kbody[3]);
+        int nb = (nl_n+7)/8;
+        if ((int)kblen < 4+3*nb) die("sign: malformed ZKP-NL private key (short)");
+        uint32_t zkA=0, zkB=0, zky=0; int ki;
+        for (ki=0;ki<nb;ki++) zkA=(zkA<<8)|kbody[4+ki];
+        for (ki=0;ki<nb;ki++) zkB=(zkB<<8)|kbody[4+nb+ki];
+        for (ki=0;ki<nb;ki++) zky=(zky<<8)|kbody[4+2*nb+ki];
+        free(kbody);
+        ZkpNlRound *zk_proof = zkp_nl_prove(zkA, zkB, zky, nl_n, ZKP_NL_PROD_ROUNDS,
+                                             msg_bytes, KEYBYTES, urnd2);
+        fclose(urnd2);
+        size_t pack_len;
+        uint8_t *pack = zkp_nl_pack_proof(zk_proof, ZKP_NL_PROD_ROUNDS, nl_n, &pack_len);
+        zkp_nl_proof_free(zk_proof, ZKP_NL_PROD_ROUNDS);
+        if (pem_write_file(out_path ? out_path : "-", PEM_ZKP_NL_PROOF, pack, pack_len) != 0)
+            die("cannot write ZKP-NL proof");
+        free(pack);
+        return;
+    }
+
     PemKey priv_k;
     pem_key_load(&priv_k, key_path);
 
@@ -1071,6 +1250,45 @@ static void cmd_sign(int argc, char **argv)
         hpks_stern_f_sign(&sig, &msg, &e_ba, &seed_ba, urnd);
         stern_sig_pack_and_write(&sig, out_path);
 
+    } else if (strcmp(algo, "rnl-sigma") == 0) {
+        /* ZKP-RNL: uses hkex-rnl private key, n must equal RNL_N */
+        if (priv_k.n_items < 3) die("sign: malformed hkex-rnl private key");
+        int sig_n = pem_key_get_n(&priv_k, 2);
+        if (sig_n != RNL_N) die("sign: rnl-sigma requires n=256 key");
+        rnl_poly_t sig_s, sig_m, sig_ms, sig_Cp;
+        poly_unpack(sig_s, priv_k.vals[0], priv_k.vlens[0], 4);
+        poly_unpack(sig_m, priv_k.vals[1], priv_k.vlens[1], 4);
+        pem_key_free(&priv_k);
+        rnl_poly_mul(sig_ms, sig_m, sig_s);
+        rnl_round(sig_Cp, sig_ms, RNL_Q, RNL_P);
+
+        rnl_poly_t sig_w, sig_c, sig_z;
+        int r = rnl_sigma_sign(sig_s, sig_m, sig_Cp, RNL_N,
+                               msg.b, KEYBYTES, urnd, sig_w, sig_c, sig_z);
+        if (r != 0) die("sign: rnl-sigma rejection limit reached");
+
+        /* Write raw binary proof: 4B n | n×4B w | n×4B c | n×4B z */
+        size_t proof_len = 4 + (size_t)RNL_N * 12;
+        uint8_t *pbuf = (uint8_t *)malloc(proof_len);
+        if (!pbuf) die("out of memory");
+        pbuf[0]=(uint8_t)(RNL_N>>24); pbuf[1]=(uint8_t)(RNL_N>>16);
+        pbuf[2]=(uint8_t)(RNL_N>>8);  pbuf[3]=(uint8_t)RNL_N;
+        int pi;
+        for (pi=0;pi<RNL_N;pi++) {
+            uint32_t v;
+            v=(uint32_t)sig_w[pi];
+            pbuf[4+pi*4+0]=v>>24; pbuf[4+pi*4+1]=v>>16; pbuf[4+pi*4+2]=v>>8; pbuf[4+pi*4+3]=v;
+            v=(uint32_t)sig_c[pi];
+            pbuf[4+RNL_N*4+pi*4+0]=v>>24; pbuf[4+RNL_N*4+pi*4+1]=v>>16;
+            pbuf[4+RNL_N*4+pi*4+2]=v>>8;  pbuf[4+RNL_N*4+pi*4+3]=v;
+            v=(uint32_t)sig_z[pi];
+            pbuf[4+RNL_N*8+pi*4+0]=v>>24; pbuf[4+RNL_N*8+pi*4+1]=v>>16;
+            pbuf[4+RNL_N*8+pi*4+2]=v>>8;  pbuf[4+RNL_N*8+pi*4+3]=v;
+        }
+        if (pem_write_file(out_path ? out_path : "-", PEM_ZKP_RNL_PROOF, pbuf, proof_len) != 0)
+            die("cannot write ZKP-RNL proof");
+        free(pbuf);
+
     } else {
         pem_key_free(&priv_k);
         fclose(urnd);
@@ -1111,6 +1329,31 @@ static void cmd_verify(int argc, char **argv)
 
     BitArray msg;
     memcpy(msg.b, msg_bytes, KEYBYTES);
+
+    /* nl-zkboo uses raw binary PEM — handle before pem_key_load. */
+    if (strcmp(algo, "nl-zkboo") == 0) {
+        size_t pkblen;
+        uint8_t *pkbody = zkp_raw_pem_read(pubkey_path, PEM_ZKP_NL_PUB, &pkblen);
+        if (pkblen < 4) die("verify: malformed ZKP-NL public key");
+        int nl_n = (int)(((uint32_t)pkbody[0]<<24)|((uint32_t)pkbody[1]<<16)|
+                         ((uint32_t)pkbody[2]<<8)|pkbody[3]);
+        int nb = (nl_n+7)/8;
+        if ((int)pkblen < 4+2*nb) die("verify: malformed ZKP-NL public key (short)");
+        uint32_t zkB=0, zky=0; int ki;
+        for (ki=0;ki<nb;ki++) zkB=(zkB<<8)|pkbody[4+ki];
+        for (ki=0;ki<nb;ki++) zky=(zky<<8)|pkbody[4+nb+ki];
+        free(pkbody);
+        size_t prflen;
+        uint8_t *prfbuf = zkp_raw_pem_read(sig_path, PEM_ZKP_NL_PROOF, &prflen);
+        int prf_n, prf_rounds;
+        ZkpNlRound *zk_proof = zkp_nl_unpack_proof(prfbuf, prflen, &prf_n, &prf_rounds);
+        free(prfbuf);
+        if (prf_n != nl_n) die("verify: proof n mismatch with pubkey n");
+        int ok = zkp_nl_verify(zkB, zky, nl_n, prf_rounds, msg.b, KEYBYTES, zk_proof);
+        zkp_nl_proof_free(zk_proof, prf_rounds);
+        if (ok) { puts("Signature OK");         exit(0); }
+        else    { puts("Verification FAILED");  exit(1); }
+    }
 
     PemKey pub_k;
     pem_key_load(&pub_k, pubkey_path);
@@ -1169,6 +1412,44 @@ static void cmd_verify(int argc, char **argv)
         int ok = hpks_stern_f_verify(&sig, &msg, &seed_ba, syndr);
         if (ok) { puts("Signature OK");        exit(0); }
         else    { puts("Verification FAILED"); exit(1); }
+
+    } else if (strcmp(algo, "rnl-sigma") == 0) {
+        /* ZKP-RNL verify: pubkey = hkex-rnl public key (C_p, m, n) */
+        if (pub_k.n_items < 3) die("verify: malformed hkex-rnl public key");
+        int vfy_n = pem_key_get_n(&pub_k, 2);
+        if (vfy_n != RNL_N) die("verify: rnl-sigma requires n=256 key");
+        rnl_poly_t vfy_Cp, vfy_m;
+        poly_unpack(vfy_Cp, pub_k.vals[0], pub_k.vlens[0], 2);
+        poly_unpack(vfy_m,  pub_k.vals[1], pub_k.vlens[1], 4);
+        pem_key_free(&pub_k);
+
+        /* Read proof */
+        size_t plen;
+        uint8_t *pbuf = zkp_raw_pem_read(sig_path, PEM_ZKP_RNL_PROOF, &plen);
+        if (plen < 4 + (size_t)RNL_N*12) die("verify: truncated ZKP-RNL proof");
+        int pn = (int)(((uint32_t)pbuf[0]<<24)|((uint32_t)pbuf[1]<<16)|
+                       ((uint32_t)pbuf[2]<<8)|pbuf[3]);
+        if (pn != RNL_N) die("verify: proof n mismatch");
+        rnl_poly_t vfy_w, vfy_c, vfy_z;
+        int pi;
+        for (pi=0;pi<RNL_N;pi++) {
+            vfy_w[pi]=(int32_t)(((uint32_t)pbuf[4+pi*4]<<24)|((uint32_t)pbuf[4+pi*4+1]<<16)|
+                                ((uint32_t)pbuf[4+pi*4+2]<<8)|pbuf[4+pi*4+3]);
+            vfy_c[pi]=(int32_t)(((uint32_t)pbuf[4+RNL_N*4+pi*4]<<24)|
+                                ((uint32_t)pbuf[4+RNL_N*4+pi*4+1]<<16)|
+                                ((uint32_t)pbuf[4+RNL_N*4+pi*4+2]<<8)|
+                                pbuf[4+RNL_N*4+pi*4+3]);
+            vfy_z[pi]=(int32_t)(((uint32_t)pbuf[4+RNL_N*8+pi*4]<<24)|
+                                ((uint32_t)pbuf[4+RNL_N*8+pi*4+1]<<16)|
+                                ((uint32_t)pbuf[4+RNL_N*8+pi*4+2]<<8)|
+                                pbuf[4+RNL_N*8+pi*4+3]);
+        }
+        free(pbuf);
+
+        int ok = rnl_sigma_verify(vfy_m, vfy_Cp, RNL_N, msg.b, KEYBYTES,
+                                   vfy_w, vfy_c, vfy_z);
+        if (ok) { puts("Signature OK");         exit(0); }
+        else    { puts("Verification FAILED");  exit(1); }
 
     } else {
         pem_key_free(&pub_k);
@@ -1363,7 +1644,7 @@ static void usage(void)
 "Commands:\n"
 "  genpkey --algo ALGO [--out FILE]\n"
 "    Generate a private key.  Algorithms: hkex-gf hkex-rnl hpks hpks-nl\n"
-"    hpke hpke-nl hpks-stern hpke-stern\n"
+"    hpke hpke-nl hpks-stern hpke-stern hpks-zkp-nl\n"
 "\n"
 "  pkey --in FILE (--pubout | --text) [--out FILE]\n"
 "    Extract public key (--pubout) or print fields in hex (--text).\n"
@@ -1389,11 +1670,15 @@ static void usage(void)
 "    Verify-then-decrypt a .hkx file.  Exits non-zero on auth failure.\n"
 "\n"
 "  sign --algo ALGO --key PRIV --in FILE --out SIG [--digest hfscx-256]\n"
-"    Sign.  Algorithms: hpks hpks-nl hpks-stern\n"
+"    Sign.  Algorithms: hpks hpks-nl hpks-stern rnl-sigma nl-zkboo\n"
+"    rnl-sigma: key = hkex-rnl private key (n=256); produces ZKP-RNL PROOF PEM.\n"
+"    nl-zkboo:  key = hpks-zkp-nl private key;      produces ZKP-NL PROOF PEM.\n"
 "    --digest hfscx-256: pre-hash input before signing.\n"
 "\n"
 "  verify --algo ALGO --pubkey PUB --in FILE --sig SIG [--digest hfscx-256]\n"
 "    Verify signature.  Exits 0 on OK, 1 on failure.\n"
+"    rnl-sigma: pubkey = hkex-rnl public key; sig = ZKP-RNL PROOF PEM.\n"
+"    nl-zkboo:  pubkey = hpks-zkp-nl public key; sig = ZKP-NL PROOF PEM.\n"
 "\n"
 "  dgst --in FILE [--algo hfscx-256] [--out FILE]\n"
 "    Compute HFSCX-256 digest.  Without --out: hex to stdout.\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -57,6 +57,11 @@ const (
 	lblCT      = "HERRADURA CIPHERTEXT"
 	lblSig     = "HERRADURA SIGNATURE"
 	lblDigest  = "HERRADURA DIGEST"
+
+	lblZkpRnlProof = "HERRADURA ZKP-RNL PROOF"
+	lblZkpNlPriv   = "HERRADURA ZKP-NL PRIVATE KEY"
+	lblZkpNlPub    = "HERRADURA ZKP-NL PUBLIC KEY"
+	lblZkpNlProof  = "HERRADURA ZKP-NL PROOF"
 )
 
 var privToAlgo = map[string]string{
@@ -416,6 +421,14 @@ func cmdGenpkey(args []string) {
 		seed, e, _ := SternFKeygen(n)
 		pem, err = encodeSternPriv(e, seed, n, *algo)
 
+	case *algo == "hpks-zkp-nl":
+		A, B, y, kerr := ZkpNlKeygen(ZkpNlDefaultN)
+		if kerr != nil {
+			fmt.Fprintln(os.Stderr, "genpkey:", kerr)
+			os.Exit(1)
+		}
+		pem = encodeZkpNlPriv(A, B, y, ZkpNlDefaultN)
+
 	default:
 		fmt.Fprintf(os.Stderr, "genpkey: unknown algorithm %q\n", *algo)
 		os.Exit(1)
@@ -446,6 +459,38 @@ func cmdPkey(args []string) {
 	if !*pubout && !*text {
 		fmt.Fprintln(os.Stderr, "pkey: specify --pubout or --text")
 		os.Exit(1)
+	}
+
+	// Handle ZKP-NL private key (raw binary PEM — not DER SEQUENCE)
+	{
+		lbl, lerr := peekPEMLabel(*in)
+		if lerr != nil {
+			die("pkey", lerr)
+		}
+		if lbl == lblZkpNlPriv {
+			body, rerr := readRawPEM(*in, lblZkpNlPriv)
+			if rerr != nil {
+				die("pkey", rerr)
+			}
+			A, B, y, zkpN, derr := decodeZkpNlPriv(body)
+			if derr != nil {
+				die("pkey", derr)
+			}
+			if *pubout {
+				pemOut := encodeZkpNlPub(B, y, zkpN)
+				if werr := writeString(*out, pemOut); werr != nil {
+					die("pkey", werr)
+				}
+			} else {
+				fmt.Printf("algorithm : hpks-zkp-nl\n")
+				fmt.Printf("n         : %d\n", zkpN)
+				nb := (zkpN + 7) / 8
+				fmt.Printf("A (priv)  : %0*x\n", nb*2, A)
+				fmt.Printf("B (pub)   : %0*x\n", nb*2, B)
+				fmt.Printf("y (pub)   : %0*x\n", nb*2, y)
+			}
+			return
+		}
 	}
 
 	label, ints, err := readPEMInts(*in)
@@ -948,6 +993,190 @@ func msgPad(inBytes []byte, nbytes int) []byte {
 	return out
 }
 
+// ── ZKP raw-binary PEM helpers ────────────────────────────────────────────────
+
+func peekPEMLabel(path string) (string, error) {
+	data, err := readFile(path)
+	if err != nil {
+		return "", err
+	}
+	label, _, err := PemUnwrap(string(data))
+	return label, err
+}
+
+func readRawPEM(path, expectLabel string) ([]byte, error) {
+	data, err := readFile(path)
+	if err != nil {
+		return nil, err
+	}
+	label, body, err := PemUnwrap(string(data))
+	if err != nil {
+		return nil, err
+	}
+	if label != expectLabel {
+		return nil, fmt.Errorf("expected PEM label %q, got %q", expectLabel, label)
+	}
+	return body, nil
+}
+
+// encodeZkpRnlProof serializes a ZKP-RNL proof to raw binary PEM.
+// Wire: 4B n | n×4B w (s32-be) | n×4B c (u32-be) | n×4B z (s32-be)
+func encodeZkpRnlProof(w, c, z []int, n int) string {
+	buf := make([]byte, 4+n*12)
+	binary.BigEndian.PutUint32(buf[0:], uint32(n))
+	for i := 0; i < n; i++ {
+		binary.BigEndian.PutUint32(buf[4+i*4:], uint32(int32(w[i])))
+	}
+	for i := 0; i < n; i++ {
+		binary.BigEndian.PutUint32(buf[4+n*4+i*4:], uint32(c[i]))
+	}
+	for i := 0; i < n; i++ {
+		binary.BigEndian.PutUint32(buf[4+n*8+i*4:], uint32(int32(z[i])))
+	}
+	return PemWrap(lblZkpRnlProof, buf)
+}
+
+func decodeZkpRnlProof(body []byte) (w, c, z []int, n int, err error) {
+	if len(body) < 4 {
+		return nil, nil, nil, 0, fmt.Errorf("ZKP-RNL proof too short")
+	}
+	n = int(binary.BigEndian.Uint32(body[0:4]))
+	if len(body) < 4+n*12 {
+		return nil, nil, nil, 0, fmt.Errorf("ZKP-RNL proof truncated (n=%d)", n)
+	}
+	w = make([]int, n)
+	c = make([]int, n)
+	z = make([]int, n)
+	for i := 0; i < n; i++ {
+		w[i] = int(int32(binary.BigEndian.Uint32(body[4+i*4:])))
+	}
+	for i := 0; i < n; i++ {
+		c[i] = int(binary.BigEndian.Uint32(body[4+n*4+i*4:]))
+	}
+	for i := 0; i < n; i++ {
+		z[i] = int(int32(binary.BigEndian.Uint32(body[4+n*8+i*4:])))
+	}
+	return
+}
+
+// encodeZkpNlPriv: Wire: 4B n | nb A | nb B | nb y
+func encodeZkpNlPriv(A, B, y uint32, n int) string {
+	nb := (n + 7) / 8
+	buf := make([]byte, 4+3*nb)
+	binary.BigEndian.PutUint32(buf[0:], uint32(n))
+	for i := nb - 1; i >= 0; i-- {
+		buf[4+i] = byte(A); A >>= 8
+	}
+	for i := nb - 1; i >= 0; i-- {
+		buf[4+nb+i] = byte(B); B >>= 8
+	}
+	for i := nb - 1; i >= 0; i-- {
+		buf[4+2*nb+i] = byte(y); y >>= 8
+	}
+	return PemWrap(lblZkpNlPriv, buf)
+}
+
+func decodeZkpNlPriv(body []byte) (A, B, y uint32, n int, err error) {
+	if len(body) < 4 {
+		return 0, 0, 0, 0, fmt.Errorf("ZKP-NL privkey too short")
+	}
+	n = int(binary.BigEndian.Uint32(body[0:4]))
+	nb := (n + 7) / 8
+	if len(body) < 4+3*nb {
+		return 0, 0, 0, 0, fmt.Errorf("ZKP-NL privkey truncated")
+	}
+	for i := 0; i < nb; i++ {
+		A = (A << 8) | uint32(body[4+i])
+	}
+	for i := 0; i < nb; i++ {
+		B = (B << 8) | uint32(body[4+nb+i])
+	}
+	for i := 0; i < nb; i++ {
+		y = (y << 8) | uint32(body[4+2*nb+i])
+	}
+	return
+}
+
+// encodeZkpNlPub: Wire: 4B n | nb B | nb y
+func encodeZkpNlPub(B, y uint32, n int) string {
+	nb := (n + 7) / 8
+	buf := make([]byte, 4+2*nb)
+	binary.BigEndian.PutUint32(buf[0:], uint32(n))
+	for i := nb - 1; i >= 0; i-- {
+		buf[4+i] = byte(B); B >>= 8
+	}
+	for i := nb - 1; i >= 0; i-- {
+		buf[4+nb+i] = byte(y); y >>= 8
+	}
+	return PemWrap(lblZkpNlPub, buf)
+}
+
+func decodeZkpNlPub(body []byte) (B, y uint32, n int, err error) {
+	if len(body) < 4 {
+		return 0, 0, 0, fmt.Errorf("ZKP-NL pubkey too short")
+	}
+	n = int(binary.BigEndian.Uint32(body[0:4]))
+	nb := (n + 7) / 8
+	if len(body) < 4+2*nb {
+		return 0, 0, 0, fmt.Errorf("ZKP-NL pubkey truncated")
+	}
+	for i := 0; i < nb; i++ {
+		B = (B << 8) | uint32(body[4+i])
+	}
+	for i := 0; i < nb; i++ {
+		y = (y << 8) | uint32(body[4+nb+i])
+	}
+	return
+}
+
+// encodeZkpNlProof: Wire: 4B n | 4B rounds | R×(96B coms | 1B e | 2B l1 | v1 | 2B l2 | v2)
+func encodeZkpNlProof(proof []ZkpNlRound, n int) string {
+	R := len(proof)
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint32(buf[0:], uint32(n))
+	binary.BigEndian.PutUint32(buf[4:], uint32(R))
+	for _, r := range proof {
+		buf = append(buf, r.Com0[:]...)
+		buf = append(buf, r.Com1[:]...)
+		buf = append(buf, r.Com2[:]...)
+		buf = append(buf, byte(r.E))
+		l1 := len(r.ViewP1)
+		buf = append(buf, byte(l1>>8), byte(l1))
+		buf = append(buf, r.ViewP1...)
+		l2 := len(r.ViewP2)
+		buf = append(buf, byte(l2>>8), byte(l2))
+		buf = append(buf, r.ViewP2...)
+	}
+	return PemWrap(lblZkpNlProof, buf)
+}
+
+func decodeZkpNlProof(body []byte) (proof []ZkpNlRound, n int, err error) {
+	if len(body) < 8 {
+		return nil, 0, fmt.Errorf("ZKP-NL proof too short")
+	}
+	n = int(binary.BigEndian.Uint32(body[0:4]))
+	R := int(binary.BigEndian.Uint32(body[4:8]))
+	off := 8
+	proof = make([]ZkpNlRound, R)
+	for j := 0; j < R; j++ {
+		if off+97 > len(body) {
+			return nil, 0, fmt.Errorf("ZKP-NL proof round %d truncated", j)
+		}
+		copy(proof[j].Com0[:], body[off:off+32]); off += 32
+		copy(proof[j].Com1[:], body[off:off+32]); off += 32
+		copy(proof[j].Com2[:], body[off:off+32]); off += 32
+		proof[j].E = int(body[off]); off++
+		l1 := int(body[off])<<8 | int(body[off+1]); off += 2
+		proof[j].ViewP1 = body[off : off+l1]; off += l1
+		if off+2 > len(body) {
+			return nil, 0, fmt.Errorf("ZKP-NL proof round %d view2 truncated", j)
+		}
+		l2 := int(body[off])<<8 | int(body[off+1]); off += 2
+		proof[j].ViewP2 = body[off : off+l2]; off += l2
+	}
+	return
+}
+
 // ── enc ───────────────────────────────────────────────────────────────────────
 
 func cmdEnc(args []string) {
@@ -1226,6 +1455,28 @@ func cmdSign(args []string) {
 		inBytes = Hfscx256(inBytes, nil)
 	}
 
+	// ZKP-NL: raw binary PEM — must not call readPEMInts
+	if *algo == "nl-zkboo" {
+		body, rerr := readRawPEM(*key, lblZkpNlPriv)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "sign nl-zkboo: %v\n", rerr)
+			os.Exit(1)
+		}
+		A, B, y, zkpN, derr := decodeZkpNlPriv(body)
+		if derr != nil {
+			die("sign", derr)
+		}
+		proof, perr := ZkpNlProve(A, B, y, zkpN, ZkpNlDemoRounds, msgPad(inBytes, 32))
+		if perr != nil {
+			die("sign", perr)
+		}
+		pem := encodeZkpNlProof(proof, zkpN)
+		if werr := writeString(*out, pem); werr != nil {
+			die("sign", werr)
+		}
+		return
+	}
+
 	_, ourInts, err := readPEMInts(*key)
 	if err != nil {
 		die("sign", err)
@@ -1234,6 +1485,23 @@ func cmdSign(args []string) {
 	gen := new(big.Int).SetInt64(GfGen)
 
 	switch *algo {
+	case "rnl-sigma":
+		// derive Cp from stored s and m_blind
+		zkpN := bytesToInt(ourInts[2])
+		zkpS := unpackPolyRaw(ourInts[0], zkpN, 4)
+		zkpM := unpackPolyRaw(ourInts[1], zkpN, 4)
+		ms   := RnlPolyMul(zkpM, zkpS, RnlQ, zkpN)
+		zkpCp := RnlRound(ms, RnlQ, RnlP)
+		w, c, z, serr := RnlSigmaSign(zkpS, zkpM, zkpCp, zkpN, msgPad(inBytes, 32))
+		if serr != nil {
+			die("sign", serr)
+		}
+		pem := encodeZkpRnlProof(w, c, z, zkpN)
+		if werr := writeString(*out, pem); werr != nil {
+			die("sign", werr)
+		}
+		return
+
 	case "hpks", "hpks-nl":
 		priv := new(big.Int).SetBytes(ourInts[0])
 		n    := bytesToInt(ourInts[2])
@@ -1309,6 +1577,35 @@ func cmdVerify(args []string) {
 		inBytes = Hfscx256(inBytes, nil)
 	}
 
+	// ZKP-NL: raw binary PEM — must not call readPEMInts
+	if *algo == "nl-zkboo" {
+		pubBody, rerr := readRawPEM(*pubkey, lblZkpNlPub)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr, "verify nl-zkboo: %v\n", rerr)
+			os.Exit(1)
+		}
+		B, y, zkpN, derr := decodeZkpNlPub(pubBody)
+		if derr != nil {
+			die("verify", derr)
+		}
+		proofBody, perr := readRawPEM(*sig, lblZkpNlProof)
+		if perr != nil {
+			fmt.Fprintf(os.Stderr, "verify nl-zkboo: %v\n", perr)
+			os.Exit(1)
+		}
+		proof, _, uerr := decodeZkpNlProof(proofBody)
+		if uerr != nil {
+			die("verify", uerr)
+		}
+		if ZkpNlVerify(B, y, zkpN, len(proof), msgPad(inBytes, 32), proof) {
+			fmt.Println("Signature OK")
+			os.Exit(0)
+		} else {
+			fmt.Println("Verification FAILED")
+			os.Exit(1)
+		}
+	}
+
 	_, theirInts, err := readPEMInts(*pubkey)
 	if err != nil {
 		die("verify", err)
@@ -1317,6 +1614,29 @@ func cmdVerify(args []string) {
 	gen := new(big.Int).SetInt64(GfGen)
 
 	switch *algo {
+	case "rnl-sigma":
+		// HKEX-RNL public key: theirInts[0]=C (2B/coeff), theirInts[1]=mBlind (4B/coeff), theirInts[2]=n
+		zkpN  := bytesToInt(theirInts[2])
+		zkpCp := unpackPolyRaw(theirInts[0], zkpN, 2)
+		zkpM  := unpackPolyRaw(theirInts[1], zkpN, 4)
+
+		proofBody, perr := readRawPEM(*sig, lblZkpRnlProof)
+		if perr != nil {
+			fmt.Fprintf(os.Stderr, "verify rnl-sigma: %v\n", perr)
+			os.Exit(1)
+		}
+		w, c, z, _, derr := decodeZkpRnlProof(proofBody)
+		if derr != nil {
+			die("verify", derr)
+		}
+		if RnlSigmaVerify(zkpM, zkpCp, zkpN, msgPad(inBytes, 32), w, c, z) {
+			fmt.Println("Signature OK")
+			os.Exit(0)
+		} else {
+			fmt.Println("Verification FAILED")
+			os.Exit(1)
+		}
+
 	case "hpks", "hpks-nl":
 		pub := new(big.Int).SetBytes(theirInts[0])
 		n   := bytesToInt(theirInts[1])
@@ -1610,11 +1930,11 @@ Commands:
   decfile  --key FILE --in FILE --out FILE
   dgst     [--algo hfscx-256] --in FILE [--out FILE]
 
-Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern hpke-stern
+Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern hpke-stern hpks-zkp-nl
 Algorithms (kex):           hkex-gf hkex-rnl
 Algorithms (enc/dec):       hske hske-nla1 hske-nla2 hpke hpke-nl hpke-stern
 Algorithms (encfile/decfile): hske-nla1
-Algorithms (sign/verify):   hpks hpks-nl hpks-stern
+Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo
 `)
 }
 

--- a/HerraduraCli/herradura_codec.h
+++ b/HerraduraCli/herradura_codec.h
@@ -46,6 +46,10 @@
 #define PEM_SIGNATURE       "HERRADURA SIGNATURE"
 #define PEM_CIPHERTEXT      "HERRADURA CIPHERTEXT"
 #define PEM_DIGEST          "HERRADURA DIGEST"
+#define PEM_ZKP_RNL_PROOF   "HERRADURA ZKP-RNL PROOF"
+#define PEM_ZKP_NL_PRIV     "HERRADURA ZKP-NL PRIVATE KEY"
+#define PEM_ZKP_NL_PUB      "HERRADURA ZKP-NL PUBLIC KEY"
+#define PEM_ZKP_NL_PROOF    "HERRADURA ZKP-NL PROOF"
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * Buffer-size macros

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -47,6 +47,15 @@ hpks_stern_f_verify       = _s.hpks_stern_f_verify
 hpke_stern_f_encap_with_e = _s.hpke_stern_f_encap_with_e
 hpke_stern_f_decap        = _s.hpke_stern_f_decap
 
+# ── ZKP-RNL: Ring-LWR Σ-protocol ─────────────────────────────────────────────
+rnl_sigma_sign   = _s.rnl_sigma_sign
+rnl_sigma_verify = _s.rnl_sigma_verify
+
+# ── ZKP-NL: NL-FSCX ZKBoo ────────────────────────────────────────────────────
+zkp_nl_keygen = _s.zkp_nl_keygen
+zkp_nl_prove  = _s.zkp_nl_prove
+zkp_nl_verify = _s.zkp_nl_verify
+
 # ── Module-level constants ───────────────────────────────────────────────────
 KEYBITS = _s.KEYBITS          # default key width (256)
 GF_POLY = _s.GF_POLY          # irreducible poly dict keyed by bit width
@@ -61,3 +70,5 @@ R_VALUE = _s.R_VALUE          # FSCX decrypt steps (3*KEYBITS/4 = 192)
 SDFT   = _s.SDFT              # Stern-F error weight t
 SDFNR  = _s.SDFNR             # Stern-F parity-check rows
 SDFR   = _s.SDFR              # Stern-F Fiat-Shamir rounds
+_ZKP_NL_DEFAULT_N   = _s._ZKP_NL_DEFAULT_N    # ZKBoo CLI default bit width (8)
+_ZKP_NL_PROD_ROUNDS = _s._ZKP_NL_PROD_ROUNDS  # ZKBoo production rounds (219)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.4)
+# Herradura Cryptographic Suite (v1.9.13)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -19,10 +19,10 @@ Full prototype code with completeness and soundness tests: `SecurityProofsCode/z
 | Hardness assumption | ZKP framework | Status |
 |---|---|---|
 | B2: Syndrome decoding SD(N,t) | Stern identification + Fiat-Shamir | **Implemented** v1.5.18, §11.8.4 |
-| B2: Syndrome decoding | MPC-in-the-head (ZKBoo) | Prototype §11.10.3 |
-| B1: Ring-LWR (HKEX-RNL) | Lyubashevsky $\Sigma$-protocol | Prototype §11.10.2 |
+| B2: Syndrome decoding | MPC-in-the-head (ZKBoo) | **Implemented** v1.9.x, §11.10.3 |
+| B1: Ring-LWR (HKEX-RNL) | Lyubashevsky $\Sigma$-protocol | **Implemented** v1.9.x, §11.10.2 |
 | B1: Ring-LWR | BDLOP commitments + linear proof | Option (linear relations) |
-| A: NL-FSCX OWF/PRF | MPC-in-the-head (ZKBoo) | Prototype §11.10.3 |
+| A: NL-FSCX OWF/PRF | MPC-in-the-head (ZKBoo) | **Implemented** v1.9.x, §11.10.3 |
 | A: NL-FSCX OWF/PRF | ZKB++ / Picnic variant | Option (smaller proofs) |
 
 Primary use case for §11.10.2: **anonymous credentials** — prove knowledge of an HKEX-RNL private key matching a given public key without revealing the key, enabling privacy-preserving authentication.  The Stern construction (§11.8.4) applies to syndrome decoding witnesses only and does not directly extend to Ring-LWR keys.
@@ -115,18 +115,51 @@ At production parameters ($n=256$, $R=219$), basic ZKBoo yields approximately 92
 
 **Honest limitation.** The NL-FSCX OWF assumption (§11.8.3) must hold.  The rotational-structure open concern (§11.8.3, TODO #75) affects two-sided rotation only (WOTS hash chain); one-sided rotation (all PRF uses, including the carry-chain circuit) gives coincidence probability $\approx 0$, so the ZKBoo construction is unaffected.
 
-### 11.10.4 Comparison and Recommendations
+### 11.10.4 Suite Implementation
+
+Both constructions are now fully implemented in the Herradura Cryptographic Suite — not prototype-only.  The function table below maps each operation to the corresponding symbol in each language target.
+
+| Operation | C (`herradura.h`) | Go (`herradura` pkg) | Python (suite module) |
+|---|---|---|---|
+| ZKP-RNL keygen | `rnl_keygen` (shared with HKEX-RNL) | `RnlKeygen` | `hkex_rnl_keygen` |
+| ZKP-RNL sign | `rnl_sigma_sign` | `RnlSigmaSign` | `_rnl_sigma_sign` |
+| ZKP-RNL verify | `rnl_sigma_verify` | `RnlSigmaVerify` | `_rnl_sigma_verify` |
+| ZKP-NL keygen | `zkp_nl_keygen` | `ZkpNlKeygen` | `_zkp_nl_keygen` |
+| ZKP-NL prove | `zkp_nl_prove` | `ZkpNlProve` | `_zkp_nl_prove` |
+| ZKP-NL verify | `zkp_nl_verify` | `ZkpNlVerify` | `_zkp_nl_verify` |
+
+ARM Thumb-2 and NASM i386 targets implement ZKP-RNL only (`rnl_sigma_sign_32`, `rnl_sigma_verify_32`) at n=32.  The Arduino target includes both ZKP-RNL (n=32) and ZKBoo (n=8, R=4 demo).
+
+**Implemented proof sizes:**
+
+| Construction | $n$ | $R$ | Proof size | Targets |
+|---|---|---|---|---|
+| ZKP-RNL | 32 | — | proportional to $n$ | all (ARM/NASM at n=32) |
+| ZKP-RNL | 256 | — | **1,056 B** | C, Go, Python |
+| ZKP-NL | 8 | 4 | demo (toy) | all |
+| ZKP-NL | 8 | 219 | 35.5 KB | C, Python |
+| ZKP-NL | 256 | 219 | 920 KB | C, Go, Python |
+
+**Comparison with HPKS-Stern-F and ML-DSA-44 (from §4):**
+
+ZKP-RNL at n=256 produces a 1,056-byte proof — smaller than both HPKS-Stern-F (78 KB) and the NIST reference scheme ML-DSA-44 (2,420 bytes).  It is therefore the most compact PQC signing option in the suite for Ring-LWR keys, at the cost of heuristic rather than tight security.
+
+ZKP-NL at n=256 and R=219 yields 920 KB, which exceeds practical limits for most use cases.  The CLI defaults to n=8 (35.5 KB) for this reason.  The ZKB++ optimisation (§11.10.6 open direction 3) would reduce the n=256 proof to approximately 180 KB.
+
+CLI integration is documented in `docs/TUTORIAL.md §ZKP Protocols`.  Cross-language interop is verified by `CliTest/test_zkp_interop.sh` (14-way test: 6 signing directions per protocol, plus 2 tamper-rejection checks).
+
+### 11.10.5 Comparison and Recommendations
 
 | Use case | Recommended construction | Proof size | Notes |
 |---|---|---|---|
 | PQC signature | HPKS-Stern-F (§11.8.4) | 78 KB | Production-ready, v1.5.18 |
-| Ring-LWR key proof / anonymous cred | Ring-LWR $\Sigma$-protocol (§11.10.2) | 1 KB | Prototype; heuristic security |
-| NL-FSCX witness proof | ZKBoo (§11.10.3) | 920 KB | Research quality |
+| Ring-LWR key proof / anonymous cred | Ring-LWR $\Sigma$-protocol (§11.10.2) | 1 KB | Implemented v1.9.x; heuristic security |
+| NL-FSCX witness proof | ZKBoo (§11.10.3) | 920 KB | Implemented v1.9.x; CLI defaults to n=8 |
 | NL-FSCX with circuit optimisation | ZKB++ / Picnic variant | ~180 KB (est.) | Future work |
 
 For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-protocol is the most practical option: its 1 KB proof size is competitive with ML-DSA-44 (2.4 KB).
 
-### 11.10.5 Open Research Directions
+### 11.10.6 Open Research Directions
 
 1. **Formal Ring-LWR reduction.** Establish a tight security reduction from the $\Sigma$-protocol soundness to Ring-LWR distinguishing hardness.  Quantify the effect of the rounding slack ($\leq t \cdot q/(2p) = 32$) on the security margin relative to the Lyubashevsky 2012 template.
 

--- a/TODO.md
+++ b/TODO.md
@@ -4603,13 +4603,13 @@ existing §11.10.3 empirical results:
 |---|---|---|
 | Batch 1 ✅ | Python suite (`rnl_sigma_*`, `zkp_nl_*`) + `codec.py` + `herradura.py` CLI | **DONE v1.9.5** — reference implementation; PEM/DER format validated |
 | Batch 2 ✅ | C (`herradura.h`) + C CLI (`herradura_cli.c`) | **DONE v1.9.6** — ZKP-RNL + ZKP-NL in header-only library; CLI `genpkey`/`pkey`/`sign`/`verify`; Python↔C PEM interop verified |
-| Batch 3 | Go suite + Go CLI (`herradura_cli.go`) | Matches C struct conventions; uses `[]int32` slices |
-| Batch 4 | ARM Thumb-2 (`rnl_sigma_sign_32` / `rnl_sigma_verify_32` only) | Reuses existing `rnl_poly_mul` subroutine |
-| Batch 5 | NASM i386 (same scope as Batch 4) | Reuses existing `rnl_poly_mul` proc |
-| Batch 6 | Arduino (ZKP-RNL n=32 + ZKBoo n=8/R=4 demo) | `uint32_t` throughout; no heap |
-| Batch 7 | `CryptosuiteTests/` — security tests and benchmarks for all targets | After all library batches |
-| Batch 8 | `CliTest/` scripts (see §6) | After CLI (Batches 1–3) |
-| Batch 9 | `docs/TUTORIAL.md` + `SecurityProofs-3.md §11.10` update (see §7) | After tests pass |
+| Batch 3 ✅ | Go suite + Go CLI (`herradura_cli.go`) | **DONE v1.9.7** — ZKP-RNL + ZKP-NL in `herradura/herradura.go`; CLI `genpkey`/`pkey`/`sign`/`verify`; demo blocks in suite |
+| Batch 4 ✅ | ARM Thumb-2 (`rnl_sigma_sign_32` / `rnl_sigma_verify_32` only) | **DONE v1.9.8** — sign/verify + demo block in main(); reuses rnl_poly_mul NTT + hfscx_32 |
+| Batch 5 ✅ | NASM i386 (`rnl_sigma_sign_32` / `rnl_sigma_verify_32` only) | **DONE v1.9.9** — sign/verify + demo block in `_start`; local stack frames for multi-call loops; saves/restores EBP around `rnl_lift`; reuses `rnl_poly_mul` NTT + `hfscx_32` + `rnl_lift` |
+| Batch 6 ✅ | Arduino (ZKP-RNL n=32 + ZKBoo n=8/R=4 demo) | **DONE v1.9.10** — `rnl_sigma_sign`/`rnl_sigma_verify` (n=32, γ=4096, t=4) + `zkp_nl_prove_8`/`zkp_nl_verify_8` ZKBoo (n=8, R=4); `static long` arrays only; no heap; targets Arduino Mega |
+| Batch 7 ✅ | `CryptosuiteTests/` — security tests and benchmarks for all targets | **DONE v1.9.11** — [21][22] C / [20][21] Go+Py ZKP-RNL+ZKP-NL; benches [33][34] C / [32][33] Go+Py |
+| Batch 8 ✅ | `CliTest/` scripts (see §6) | **DONE v1.9.12** — 5 new scripts: test_zkp_rnl.sh, test_zkp_nl.sh, test_c_zkp_rnl.sh, test_go_zkp_rnl.sh, test_zkp_interop.sh; Python CLI "Proof OK"→"Signature OK" fix |
+| Batch 9 ✅ | `docs/TUTORIAL.md` + `SecurityProofs-3.md §11.10` update (see §7) | **DONE v1.9.13** — `## ZKP Protocols` top-level section in TUTORIAL (C/Go/Py snippets, CLI usage, comparison table); §11.10.4 Suite Implementation + §11.10.5/§11.10.6 renumber in SecurityProofs-3 |
 
 ---
 
@@ -4661,7 +4661,7 @@ existing §11.10.3 empirical results:
   and proof-size analysis for both constructions).
 - `SecurityProofsCode/zkp_pqc_exploration.py` §2–§3 (reference prover/verifier code).
 
-Status: **Batch 1 DONE v1.9.5 · Batch 2 DONE v1.9.6** — Batch 1: Python suite + codec + CLI.  Batch 2: C header-only library (`herradura.h`) adds `sigma_params`, `sigma_poly_mul_n`, `sigma_challenge`, `rnl_sigma_sign`, `rnl_sigma_verify`, `ZkpNlRound` struct, `zkp_nl_keygen`, `zkp_nl_prove`, `zkp_nl_verify`, `zkp_nl_proof_free` + all helpers; `herradura_cli.c` extends `genpkey` (`hpks-zkp-nl`), `pkey` (ZKP-NL pubout), `sign` (`rnl-sigma`, `nl-zkboo`), `verify` (`rnl-sigma`, `nl-zkboo`); `herradura_codec.h` adds 4 PEM label constants; bidirectional Python↔C PEM interop verified; suite `main()` extended with ZKP-RNL and ZKP-NL demo blocks.  Batches 3–9 remain TODO.
+Status: **DONE v1.9.13** — **Batch 1 DONE v1.9.5 · Batch 2 DONE v1.9.6 · Batch 3 DONE v1.9.7 · Batch 4 DONE v1.9.8 · Batch 5 DONE v1.9.9 · Batch 6 DONE v1.9.10 · Batch 7 DONE v1.9.11 · Batch 8 DONE v1.9.12 · Batch 9 DONE v1.9.13** — Batch 1: Python suite + codec + CLI.  Batch 2: C header-only library (`herradura.h`) adds ZKP-RNL + ZKP-NL functions + C CLI extensions.  Batch 3: Go package (`herradura/herradura.go`) adds `ZkpRnlParams`, `RnlSigmaSign`, `RnlSigmaVerify`, `ZkpNlKeygen`, `ZkpNlProve`, `ZkpNlVerify`, `ZkpNlRound`; codec.go adds 4 PEM label constants; `herradura_cli.go` extends `genpkey` (`hpks-zkp-nl`), `pkey` (ZKP-NL pubout/text), `sign` (`rnl-sigma`, `nl-zkboo`), `verify` (`rnl-sigma`, `nl-zkboo`); suite `main()` extended with ZKP-RNL and ZKP-NL demo blocks.  Batch 4: ARM Thumb-2 `rnl_sigma_sign_32`/`rnl_sigma_verify_32` + demo in `main()`.  Batch 5: NASM i386 `rnl_sigma_sign_32`/`rnl_sigma_verify_32` + demo in `_start`; local stack frames; EBP save/restore around `rnl_lift`.  Batch 6: Arduino `rnl_sigma_sign`/`rnl_sigma_verify` (n=32) + `zkp_nl_prove_8`/`zkp_nl_verify_8` ZKBoo (n=8, R=4); all-static allocation for Arduino Mega.  Batch 7: `CryptosuiteTests/` — ZKP-RNL+ZKP-NL security tests + benchmarks in C/Go/Python using production library.  Batch 8: 5 CliTest scripts (ZKP-RNL + ZKP-NL Python/C/Go + full 6-direction interop); Python CLI "Proof OK"→"Signature OK" consistency fix.  Batch 9 DONE v1.9.13: `docs/TUTORIAL.md` `## ZKP Protocols` section (C/Go/Py snippets, CLI usage, comparison table); `SecurityProofs-3.md` §11.10.4 Suite Implementation + §11.10.5/§11.10.6 renumber; applicability matrix and comparison table updated to "Implemented".
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -4304,3 +4304,597 @@ Status: **DONE v1.9.4** — All six scope items complete.
   §4 Parameter comparison vs ML-DSA / SLH-DSA / Picnic / Stern-F.
   §5 Open construction paths: NTT-accelerated Σ-protocol, ZKB++, hybrid credential scheme.
   §11.10 in SecurityProofs-3.md (split to keep SecurityProofs-2.md under ~750 KaTeX expressions).
+
+---
+
+### 77. Implement ZKP protocols as production library functions, CLI subcommands, and tests (Feature, High)
+
+**Rationale:** TODO #76 (DONE v1.9.4) researched and prototyped two ZKP constructions in
+`SecurityProofsCode/zkp_pqc_exploration.py`:
+
+1. **Ring-LWR Σ-protocol** — proves knowledge of an HKEX-RNL private key without
+   revealing it.  Proof size: 132 B (n=32) / 1 056 B (n=256).  Smaller than ML-DSA-44
+   (2 420 B).  Enables anonymous credentials and HKEX-RNL-based privacy-preserving
+   authentication.
+
+2. **NL-FSCX ZKBoo** — 3-party MPC-in-the-head proof of knowledge of an NL-FSCX v1
+   preimage.  Proof size: ≈35 KB (n=8, R=219) / ≈920 KB (n=256, R=219).  Enables
+   privacy-preserving proofs for any statement whose truth depends on a secret
+   NL-FSCX preimage.
+
+Both constructions are prototype-only today.  This TODO promotes them to first-class
+library functions integrated into all applicable language targets, adds OpenSSL-style
+PEM/DER wire formats to the CLI, adds security tests and benchmarks, and updates
+the tutorial and SecurityProofs documents.
+
+---
+
+#### 1. New protocol identifiers
+
+**HPKS-ZKP-RNL** — Ring-LWR Σ-protocol proof-of-knowledge (Lyubashevsky-style,
+Fiat-Shamir compiled).
+
+- Statement: public pair (m, C) where m ∈ Z_q^n is the HKEX-RNL blinding polynomial
+  and C ∈ Z_p^n is the public key.
+- Witness: CBD(1) polynomial s ∈ {−1,0,1}^n with C = round_p(m·s mod q) in
+  Z_q[x]/(x^n+1).
+- Message binding: challenge c = SHAKE-256(m ‖ C ‖ w ‖ msg) — including msg makes
+  the proof a proper signature.
+- Parameters: n=256, q=65537, p=4096, γ=8192, t=16 (production);
+  n=32, γ=4096, t=4 (assembly / Arduino).
+- Reuses the existing HKEX-RNL keypair — no new keygen command required.
+
+**HPKS-ZKP-NL** — NL-FSCX ZKBoo proof-of-knowledge (3-party MPC-in-the-head,
+Giacomelli–Madsen–Orlandi 2016).
+
+- Statement: public pair (B, y) where y = NL-FSCX-v1-revolve(ROL(A, n/8), B, n/4)
+  evaluated in the suite's n-bit integer arithmetic.
+- Witness: secret preimage A.
+- New keypair type: A is the private key; (B, y) is the public key.
+- Parameters: n=8 (7 AND gates per step, 7×64=448 AND gates for n/4=2 steps;
+  proof ≈35 KB at R=219 for 128-bit soundness); n=256 proof (≈920 KB) is tracked
+  as a research target — CLI uses n=8 by default.  Full n=256 production requires a
+  ZKB++ optimization pass (proof ≈300 KB, see §5 open paths in SecurityProofs-3.md
+  §11.10) which is deferred.
+- Challenge binding: derived per round from SHAKE-256(all commitments ‖ B ‖ y ‖ msg).
+
+---
+
+#### 2. PEM / DER wire format
+
+New PEM labels following the `HERRADURA <ALGO> <TYPE>` convention already used in
+the CLI.  Distinct labels (not `HERRADURA SIGNATURE`) let mixed-algorithm pipelines
+identify proof type without parsing the DER body.
+
+| PEM label | DER body (ASN.1 SEQUENCE) | Used by |
+|---|---|---|
+| `HERRADURA ZKP-NL PRIVATE KEY` | `{ INTEGER n, INTEGER A }` | ZKBoo keygen |
+| `HERRADURA ZKP-NL PUBLIC KEY` | `{ INTEGER n, INTEGER B, INTEGER y }` | ZKBoo verify |
+| `HERRADURA ZKP-RNL PROOF` | `{ INTEGER n, SEQUENCE w_coeffs, SEQUENCE c_coeffs, SEQUENCE z_coeffs }` | Σ-protocol sign/verify |
+| `HERRADURA ZKP-NL PROOF` | `{ INTEGER n, INTEGER rounds, SEQUENCE round_list }` | ZKBoo sign/verify |
+
+where `round_list` contains `rounds` repetitions of
+`SEQUENCE { OCTET STRING com_0, OCTET STRING com_1, OCTET STRING com_2, INTEGER e, OCTET STRING view_e1, OCTET STRING view_e2 }`.
+Each commitment is a 32-byte SHAKE-256 digest.  Each view encodes the party's PRNG
+seed (32 bytes) followed by the per-AND-gate output shares for that party.
+
+Codec helpers to add to `HerraduraCli/codec.py`:
+- `encode_zkp_rnl_proof(n, w, c, z)` / `decode_zkp_rnl_proof(path)`
+- `encode_zkp_nl_privkey(n, A)` / `decode_zkp_nl_privkey(path)`
+- `encode_zkp_nl_pubkey(n, B, y)` / `decode_zkp_nl_pubkey(path)`
+- `encode_zkp_nl_proof(n, rounds, round_list)` / `decode_zkp_nl_proof(path)`
+
+`_decode_privkey` / `_decode_pubkey` in `herradura.py` dispatch on the new labels.
+
+---
+
+#### 3. CLI subcommands and arguments
+
+**genpkey** — one new `--algo` choice:
+
+```
+genpkey --algo hpks-zkp-nl [--bits N] --out nl_priv.pem [--pubout nl_pub.pem]
+```
+
+Generates random A and B of bit-width N (default 8 for ZKBoo demo; must be a
+multiple of 8).  Computes y = NL-FSCX-v1-revolve(ROL(A, N/8), B, N/4).  Writes
+`HERRADURA ZKP-NL PRIVATE KEY` to `--out`; writes `HERRADURA ZKP-NL PUBLIC KEY`
+if `--pubout` is given.  (HPKS-ZKP-RNL reuses `--algo hkex-rnl` — no change.)
+
+**sign** — two new `--algo` choices:
+
+```
+sign --algo rnl-sigma  --key alice.pem --in msg.bin --out proof.pem
+sign --algo nl-zkboo   --key nl_priv.pem --in msg.bin --out proof.pem
+```
+
+`rnl-sigma` loads an `HKEX-RNL PRIVATE KEY` PEM.  Calls `rnl_sigma_sign` with
+rejection sampling; writes `HERRADURA ZKP-RNL PROOF`.
+
+`nl-zkboo` loads a `ZKP-NL PRIVATE KEY` PEM.  Calls `zkp_nl_prove` for R=219 rounds
+(configurable via `--rounds`); writes `HERRADURA ZKP-NL PROOF`.
+
+**verify** — two new `--algo` choices (mirror of sign):
+
+```
+verify --algo rnl-sigma  --pubkey alice_pub.pem --in msg.bin --sig proof.pem
+verify --algo nl-zkboo   --pubkey nl_pub.pem --in msg.bin --sig proof.pem
+```
+
+Loads the matching public key PEM and proof PEM; calls `rnl_sigma_verify` or
+`zkp_nl_verify`; exits 0 on success, 1 on failure (same convention as `hpks`).
+
+Full CLI example sequence (same style as the usage comment block at the top of
+`herradura.py`):
+
+```
+# ── Ring-LWR ZKP (reuses HKEX-RNL keypair) ──────────────────────────────────
+python3 herradura.py genpkey --algo hkex-rnl --bits 256 --out alice.pem
+python3 herradura.py pkey    --in alice.pem --pubout alice_pub.pem
+python3 herradura.py sign    --algo rnl-sigma --key alice.pem \
+                             --in msg.bin --out proof.pem
+python3 herradura.py verify  --algo rnl-sigma --pubkey alice_pub.pem \
+                             --in msg.bin --sig proof.pem
+
+# ── NL-FSCX ZKBoo ────────────────────────────────────────────────────────────
+python3 herradura.py genpkey --algo hpks-zkp-nl --bits 8 \
+                             --out nl_priv.pem --pubout nl_pub.pem
+python3 herradura.py sign    --algo nl-zkboo --key nl_priv.pem \
+                             --in msg.bin --out zkp_nl_proof.pem
+python3 herradura.py verify  --algo nl-zkboo --pubkey nl_pub.pem \
+                             --in msg.bin --sig zkp_nl_proof.pem
+```
+
+The same subcommand names and flag names are used in the C (`herradura_cli`) and
+Go (`herradura_cli_go`) CLIs.
+
+---
+
+#### 4. Library API (all applicable language targets)
+
+Add the following functions following the naming conventions established by
+`hpks_stern_f_sign` / `hpks_stern_f_verify` in `herradura.h` (C), the Go suite,
+and the Python suite.  Prototypes given in Python notation for brevity.
+
+**Ring-LWR Σ-protocol (C, Go, Python; ARM n=32; i386 n=32; Arduino n=32):**
+
+```python
+def rnl_sigma_sign(s_poly, m_poly, C_poly, n, msg_bytes):
+    """
+    Lyubashevsky-style Fiat-Shamir signature.
+    Returns (w_poly, c_poly, z_poly) after rejection sampling.
+    Parameters: n, q=65537, p=4096, γ={4096 if n==32 else 8192}, t={4 if n==32 else 16}.
+    """
+
+def rnl_sigma_verify(m_poly, C_poly, n, msg_bytes, w_poly, c_poly, z_poly):
+    """
+    Returns True iff:
+      (1) ||z||_∞ ≤ γ − t
+      (2) c == SHAKE-256(m ‖ C ‖ w ‖ msg)
+      (3) ||m·z − w − c·lift(C)||_∞ ≤ t·⌈q/(2p)⌉
+    """
+```
+
+**NL-FSCX ZKBoo (C, Go, Python; Arduino n=8/R=4 demo only):**
+
+```python
+def zkp_nl_keygen(n):
+    """Returns (A, B, y) where y = nl_fscx_revolve_v1(rol(A, n//8), B, n//4)."""
+
+def zkp_nl_prove(A, B, y, n, rounds, msg_bytes):
+    """
+    ZKBoo prover.  Returns a list of `rounds` dicts, each with keys:
+      com_0, com_1, com_2   — 32-byte SHAKE-256 commitments
+      e                     — revealed party index ∈ {0, 1, 2}
+      view_e1, view_e2      — bytes encoding seed + AND-gate output shares
+    Challenge e per round derived by Fiat-Shamir over all commitments + msg.
+    """
+
+def zkp_nl_verify(B, y, n, rounds, msg_bytes, proof_rounds):
+    """
+    ZKBoo verifier.  Returns True iff all rounds verify.
+    For each round: re-derives AND-gate outputs from two revealed views;
+    reconstructs hidden output; checks commitments and final output == y.
+    """
+```
+
+**C API notes:**
+- Proof data returned as a caller-allocated struct array; size constants defined in
+  `herradura.h` for compile-time buffer sizing.
+- `rnl_sigma_sign` writes into output buffers `w[n]`, `c[n]`, `z[n]` (int32_t arrays).
+- `zkp_nl_prove` writes into a caller-allocated `ZkpNlRound rounds[R]` array;
+  `ZkpNlRound` is a struct with `com_0[32]`, `com_1[32]`, `com_2[32]`, `e` (uint8_t),
+  and `view_e1[VIEW_BYTES]`, `view_e2[VIEW_BYTES]` (where `VIEW_BYTES` = 32 + AND gate
+  share bytes for the given n).
+
+**Go API notes:**
+- Return `([]int32, []int32, []int32, error)` for `rnlSigmaSign`.
+- Return `([]ZkpNlRound, error)` for `zkpNlProve`; `ZkpNlRound` is a struct.
+
+**Assembly (ARM Thumb-2 and NASM i386):**
+Implement `rnl_sigma_sign_32` and `rnl_sigma_verify_32` for n=32.  These are
+self-contained subroutines reusing the existing `rnl_poly_mul` / `rnl_hint` /
+`rnl_reconcile_bits` register conventions.  ZKBoo is not implemented in assembly
+(circuit evaluation requires dynamic dispatch over AND gates with 32-byte hash
+calls; impractical in 32-bit bare-metal assembly without a SHA library).
+
+**Arduino:**
+Add `rnl_sigma_sign_32` / `rnl_sigma_verify_32` at n=32, mirroring the C suite
+(`uint32_t` throughout, no dynamic allocation).  Add a minimal ZKBoo demo at n=8
+R=4 for the demo loop (not full soundness — just illustrates the concept).
+
+---
+
+#### 5. Tests and benchmarks
+
+Append after the existing Stern-F tests in each test file.  Exact test numbers
+are assigned when the implementation lands; the descriptions below define the
+required test coverage.
+
+**Security tests:**
+
+| Test | Description | Protocol | Trials | Pass criterion |
+|---|---|---|---|---|
+| ZKP-RNL completeness | Honest prover at n=32 (and n=256 in Python/C/Go) | HPKS-ZKP-RNL | 100 | 0 failures |
+| ZKP-RNL soundness | Random z, no s, n=32 | HPKS-ZKP-RNL | 100 | 0 verifier accepts |
+| ZKP-RNL cross-lang | Proof produced by Python verifies under C and Go verifier | HPKS-ZKP-RNL | 10 | All accept |
+| ZKP-NL completeness | Honest prover at n=8, R=4 | HPKS-ZKP-NL | 100 | 0 failures |
+| ZKP-NL soundness | Random views, no A, n=8, R=4 | HPKS-ZKP-NL | 100 | 0 verifier accepts |
+
+**Benchmarks (Python/C/Go only — assembly at n=32 only for ZKP-RNL):**
+
+| Benchmark | Protocol | Sizes |
+|---|---|---|
+| ZKP-RNL proof generation throughput | HPKS-ZKP-RNL | n=32, n=256 |
+| ZKP-RNL verification throughput | HPKS-ZKP-RNL | n=32, n=256 |
+| ZKP-NL prove (toy) throughput | HPKS-ZKP-NL | n=8, R=4 |
+| ZKP-NL verify (toy) throughput | HPKS-ZKP-NL | n=8, R=4 |
+
+Benchmarks use the existing `-r` / `-t` timing infrastructure.
+
+---
+
+#### 6. CLI integration tests (CliTest/)
+
+| Script | What it tests |
+|---|---|
+| `CliTest/test_zkp_rnl.sh` | Python CLI: `genpkey` (hkex-rnl) → `sign` (rnl-sigma) → `verify` round-trip; tampered message must fail |
+| `CliTest/test_zkp_nl.sh` | Python CLI: `genpkey` (hpks-zkp-nl) → `sign` (nl-zkboo) → `verify` round-trip; wrong pubkey must fail |
+| `CliTest/test_c_zkp_rnl.sh` | C CLI (herradura_cli): same ZKP-RNL round-trip |
+| `CliTest/test_go_zkp_rnl.sh` | Go CLI (herradura_cli_go): same ZKP-RNL round-trip |
+| `CliTest/test_zkp_interop.sh` | Cross-language: Python `sign --algo rnl-sigma` → C `verify --algo rnl-sigma`; C sign → Go verify; Go sign → Python verify |
+
+Each test script prints `[PASS]` / `[FAIL]` per check, mirroring `test_c_interop.sh`.
+
+---
+
+#### 7. Documentation
+
+**`docs/TUTORIAL.md`** — new top-level section "ZKP Protocols":
+
+- When to use ZKP vs. conventional signatures: ZKPs prove knowledge without
+  message binding; with Fiat-Shamir they become signatures.  Use ZKP-RNL for
+  anonymous credentials where the verifier should not learn the signing key's
+  relationship to other keys; use ZKP-NL when the secret is an NL-FSCX preimage.
+- HPKS-ZKP-RNL API walk-through (keygen → sign → verify, Python and C snippets).
+- HPKS-ZKP-NL API walk-through (keygen → prove → verify, Python snippet).
+- CLI usage examples matching §3 above.
+- Proof-size and performance comparison table (ZKP-RNL vs. ZKP-NL vs.
+  HPKS-Stern-F vs. HPKS, populated from benchmark results).
+- Cross-reference: "See SecurityProofs-3.md §11.10 for completeness, soundness,
+  and zero-knowledge proofs."
+
+**`SecurityProofs-3.md §11.10`** — add implementation subsection after the
+existing §11.10.3 empirical results:
+
+- Note that `rnl_sigma_sign` / `rnl_sigma_verify` and `zkp_nl_prove` /
+  `zkp_nl_verify` are now in the suite (not prototype-only).
+- Table of function names per language target.
+- Comparison of ZKP-RNL proof size (1 056 B, n=256) vs. HPKS-Stern-F signature
+  and ML-DSA-44 from the §4 table already in the document.
+- Note that ZKP-NL at n=256 (920 KB) awaits ZKB++ optimization (open path §5);
+  CLI defaults to n=8 (35 KB) for now.
+
+---
+
+#### 8. Implementation batches
+
+| Batch | Scope | Notes |
+|---|---|---|
+| Batch 1 ✅ | Python suite (`rnl_sigma_*`, `zkp_nl_*`) + `codec.py` + `herradura.py` CLI | **DONE v1.9.5** — reference implementation; PEM/DER format validated |
+| Batch 2 ✅ | C (`herradura.h`) + C CLI (`herradura_cli.c`) | **DONE v1.9.6** — ZKP-RNL + ZKP-NL in header-only library; CLI `genpkey`/`pkey`/`sign`/`verify`; Python↔C PEM interop verified |
+| Batch 3 | Go suite + Go CLI (`herradura_cli.go`) | Matches C struct conventions; uses `[]int32` slices |
+| Batch 4 | ARM Thumb-2 (`rnl_sigma_sign_32` / `rnl_sigma_verify_32` only) | Reuses existing `rnl_poly_mul` subroutine |
+| Batch 5 | NASM i386 (same scope as Batch 4) | Reuses existing `rnl_poly_mul` proc |
+| Batch 6 | Arduino (ZKP-RNL n=32 + ZKBoo n=8/R=4 demo) | `uint32_t` throughout; no heap |
+| Batch 7 | `CryptosuiteTests/` — security tests and benchmarks for all targets | After all library batches |
+| Batch 8 | `CliTest/` scripts (see §6) | After CLI (Batches 1–3) |
+| Batch 9 | `docs/TUTORIAL.md` + `SecurityProofs-3.md §11.10` update (see §7) | After tests pass |
+
+---
+
+#### Files to create / modify
+
+| File | Change |
+|---|---|
+| `Herradura cryptographic suite.py` | Add `rnl_sigma_sign`, `rnl_sigma_verify`, `zkp_nl_keygen`, `zkp_nl_prove`, `zkp_nl_verify` |
+| `herradura.h` | Add same functions with C API; add `ZkpNlRound` struct and buffer size macros |
+| `Herradura cryptographic suite.go` | Add same functions with Go API |
+| `Herradura cryptographic suite.s` | Add `rnl_sigma_sign_32`, `rnl_sigma_verify_32` (ARM Thumb-2) |
+| `Herradura cryptographic suite.asm` | Add same (NASM i386) |
+| `Herradura cryptographic suite.ino` | Add ZKP-RNL n=32 + ZKBoo n=8/R=4 demo |
+| `CryptosuiteTests/Herradura_tests.c` | New ZKP test cases and benchmarks |
+| `CryptosuiteTests/Herradura_tests.go` | Same |
+| `CryptosuiteTests/Herradura_tests.py` | Same |
+| `CryptosuiteTests/Herradura_tests.s` | ZKP-RNL tests at n=32 |
+| `CryptosuiteTests/Herradura_tests.asm` | Same |
+| `CryptosuiteTests/Herradura_tests.ino` | Same |
+| `HerraduraCli/codec.py` | New DER encode/decode helpers for ZKP-RNL and ZKP-NL proof PEMs |
+| `HerraduraCli/herradura.py` | New PEM labels; extend `genpkey`, `sign`, `verify`; new `_encode_zkp_*` / `_decode_zkp_*` helpers |
+| `HerraduraCli/herradura_cli.c` | New subcommand handlers for `hpks-zkp-nl` keygen, `rnl-sigma` and `nl-zkboo` sign/verify |
+| `HerraduraCli/herradura_cli.go` | Same |
+| `CliTest/test_zkp_rnl.sh` | New |
+| `CliTest/test_zkp_nl.sh` | New |
+| `CliTest/test_c_zkp_rnl.sh` | New |
+| `CliTest/test_go_zkp_rnl.sh` | New |
+| `CliTest/test_zkp_interop.sh` | New |
+| `docs/TUTORIAL.md` | New "ZKP Protocols" section |
+| `SecurityProofs-3.md §11.10` | New implementation subsection (function names, proof-size table) |
+| `CHANGELOG.md` | Versioned entry per batch |
+
+**Prerequisites:**
+
+- TODO #76 DONE v1.9.4 — research prototype in `SecurityProofsCode/zkp_pqc_exploration.py`
+  is the reference implementation for all library functions.
+- TODO #74 (NL-FSCX OWF status) — ZKP-NL soundness is contingent on the NL-FSCX OWF
+  assumption.  If TODO #74 reveals a structural weakness, the ZKP-NL soundness claim
+  must be downgraded and documented accordingly; ZKP-RNL is independent and unaffected.
+
+**References:**
+
+- Lyubashevsky 2012, *Lattice Signatures Without Trapdoors*, Eurocrypt 2012.
+- Giacomelli, Madsen, Orlandi 2016, *ZKBoo: Faster Zero-Knowledge for Boolean Circuits*,
+  USENIX Security 2016.
+- Chase et al. 2017, *Post-Quantum Zero-Knowledge and Signatures from Symmetric-Key
+  Primitives*, CCS 2017 (ZKB++ — future optimization path for ZKP-NL at n=256).
+- SecurityProofs-3.md §11.10 (completeness, soundness, zero-knowledge proofs,
+  and proof-size analysis for both constructions).
+- `SecurityProofsCode/zkp_pqc_exploration.py` §2–§3 (reference prover/verifier code).
+
+Status: **Batch 1 DONE v1.9.5 · Batch 2 DONE v1.9.6** — Batch 1: Python suite + codec + CLI.  Batch 2: C header-only library (`herradura.h`) adds `sigma_params`, `sigma_poly_mul_n`, `sigma_challenge`, `rnl_sigma_sign`, `rnl_sigma_verify`, `ZkpNlRound` struct, `zkp_nl_keygen`, `zkp_nl_prove`, `zkp_nl_verify`, `zkp_nl_proof_free` + all helpers; `herradura_cli.c` extends `genpkey` (`hpks-zkp-nl`), `pkey` (ZKP-NL pubout), `sign` (`rnl-sigma`, `nl-zkboo`), `verify` (`rnl-sigma`, `nl-zkboo`); `herradura_codec.h` adds 4 PEM label constants; bidirectional Python↔C PEM interop verified; suite `main()` extended with ZKP-RNL and ZKP-NL demo blocks.  Batches 3–9 remain TODO.
+
+---
+
+### 78. New application directions from primitive characteristics — research catalogue (Research, Medium)
+
+**Rationale:** A systematic analysis of HerraduraKEx primitive properties identified ten
+candidate applications that are either unique to this suite's algebraic structure or
+particularly well-served by its existing building blocks.  This item records the findings
+so they can be tracked, refined, and promoted to implementation TODOs individually.
+
+Each candidate is labelled with its implementation distance (Low / Medium / High) and the
+specific primitive property it exploits.  Candidates are ordered from most to least
+immediately actionable.
+
+---
+
+#### 78.A — Format-Preserving Encryption (Low)
+
+**Primitive:** `nl_fscx_revolve_v2` bijectivity — bijective in plaintext A for every fixed
+tweak B, with closed-form inverse via `nl_fscx_revolve_v2_inv`.
+
+**Construction:**
+```python
+def fpe_encrypt(plaintext: BitArray, key: bytes, context: bytes) -> BitArray:
+    B = BitArray(KEYBITS, int.from_bytes(hfscx_256(key + context), 'big'))
+    return nl_fscx_revolve_v2(plaintext, B, I_VALUE)
+
+def fpe_decrypt(ciphertext: BitArray, key: bytes, context: bytes) -> BitArray:
+    B = BitArray(KEYBITS, int.from_bytes(hfscx_256(key + context), 'big'))
+    return nl_fscx_revolve_v2_inv(ciphertext, B, I_VALUE)
+```
+
+**Why native:** `delta(B) = ROL(B * floor((B+1)/2) mod 2^n, n/4)` is precomputed once per
+context, making the tweak overhead one multiply and one rotation per block.  Standard
+AES-FFX requires specialised modular arithmetic for arbitrary-alphabet FPE; `nl_fscx_v2`
+is natively a bijection on `{0,1}^n` with no adaptation.
+
+**Use cases:** Encrypting fixed-width database fields (SSNs, credit card numbers, tokens)
+without changing field width; searchable deterministic encryption of indexed columns.
+
+**Caveat:** Same (key, context, plaintext) always produces the same ciphertext — suitable
+for deterministic/searchable encryption, not for IND-CPA without a per-record nonce in the
+context.  This is the same determinism constraint already documented for HSKE-NL-A2 (TODO #12).
+
+---
+
+#### 78.B — Tweakable Wide-Block Cipher for Disk / File Encryption (Low)
+
+**Primitive:** `nl_fscx_revolve_v2` with `delta(B)` precomputed once per block sector.
+
+**Construction (analogous to AES-XTS):**
+```python
+def sector_encrypt(blocks: list[BitArray], key: bytes, sector: int) -> list[BitArray]:
+    return [
+        nl_fscx_revolve_v2(
+            block,
+            BitArray(KEYBITS, int.from_bytes(hfscx_256(key + sector.to_bytes(8,'big')
+                                                       + i.to_bytes(4,'big')), 'big')),
+            I_VALUE
+        )
+        for i, block in enumerate(blocks)
+    ]
+```
+
+**Why native:** The `delta(B)` term in `nl_fscx_v2` depends only on B and is precomputed
+once per (sector, block-index) pair.  Standard XTS requires a GF(2^128) multiply per
+sector; here the tweak cost is one HFSCX-256 call plus one integer multiply and one
+rotation — both already O(n) operations in the suite.
+
+**Key advantage over HSKE-NL-A2:** Each block gets a unique B derived from a public
+(sector, index) pair, so distinct blocks always have distinct tweaks even under a fixed
+key, defeating the deterministic-encryption limitation.
+
+---
+
+#### 78.C — Forward-Secret Unidirectional Ratchet (Medium)
+
+**Primitive:** `nl_fscx_revolve_v1` one-wayness (OWF conjecture — Theorem 16,
+SecurityProofs-2 §11.8.3).
+
+**Construction:**
+```python
+RATCHET_DOMAIN = BitArray(KEYBITS, int.from_bytes(b'NL-FSCX-RATCHET-V1\x00' * 2, 'big'))
+
+def ratchet_advance(state: BitArray) -> tuple[BitArray, bytes]:
+    """Returns (new_state, message_key). Erase state after calling."""
+    msg_key = hfscx_256(state.bytes + b'\x01')
+    new_state = nl_fscx_revolve_v1(state, RATCHET_DOMAIN, 1)
+    return new_state, msg_key
+```
+
+**Why native:** The same OWF assumption that underlies HPKS-WOTS-F (Theorem 16) and
+HSKE-NL-A1 (§11.3.1) makes `nl_fscx_revolve_v1` one-directional.  Erasing `state_i`
+makes `msg_key_i` irrecoverable from `state_{i+1}`, giving forward secrecy without a
+DH exchange per message.  All building blocks (`nl_fscx_revolve_v1`, `hfscx_256`) are
+already in the suite.
+
+**Open question:** The non-bijectivity of `nl_fscx_v1` means two distinct states could
+converge (collide) after enough steps, re-entering a previously-seen state.  Bounding
+the collision probability over the ratchet lifetime is a prerequisite before deployment.
+A `SecurityProofsCode/nl_fscx_v1_ratchet_collision.py` analysis script (analogous to
+`hkex_rnl_failure_rate.py`) would characterise the expected collision distance.
+
+---
+
+#### 78.D — PQC Password-Authenticated Key Exchange / PAKE (High)
+
+**Primitives:** HKEX-RNL (quantum-resistant key exchange) + ZKBoo (`zkp_nl_prove` /
+`zkp_nl_verify`) + HFSCX-256 (password hash).
+
+**Sketch:**
+```
+Registration:
+    client: H_pw = hfscx_256(password + salt)
+    client -> server: (salt, H_pw, client HKEX-RNL public key)
+
+Login:
+    1. client <-> server: HKEX-RNL handshake -> shared_key
+    2. client: proof = zkp_nl_prove(password_bits, salt, H_pw, msg=shared_key)
+    3. client -> server: proof
+    4. server: zkp_nl_verify(salt, H_pw, msg=shared_key, proof)
+    5. Both derive session key from shared_key (authenticated by step 4)
+```
+
+**Why native:** All existing PQC PAKEs (KHAPE, OPAQUE-Kyber) import external components.
+This construction uses only primitives already in HerraduraKEx.
+
+**Open gap:** The current ZKBoo proves preimage of a single `nl_fscx_v1` step; a password
+hash requires proving knowledge through HFSCX-256's full 64-round Merkle-Damgard chain.
+The practical near-term path is a simpler construction: client derives a blinded value
+from the password and uses it as the HKEX-RNL key material, with the ZKBoo proving only
+the final binding step.  This requires a formal security reduction that does not yet exist.
+
+---
+
+#### 78.E — Non-Abelian Key Exchange — Option C Continuation (High / Research)
+
+**Primitive:** `nl_fscx_revolve_v2` permutation family `{pi_K}` — non-abelian by
+Theorem 15 (SecurityProofs-2 §11.8.5).  Key recovery from a single evaluation pair is
+MQ-hard (Theorem 14); no polynomial quantum algorithm is known for generic non-abelian
+Conjugacy Search Problem (Ettinger-Hoyer-Knill 2004).
+
+**Three obstacles from §11.8.5 remain open:**
+1. No transfer theorem from black-box CSP hardness to the NL-FSCX v2 circuit model.
+2. No verified lower bound on orbit length of `pi_K` — small-subgroup attacks not excluded.
+3. No formal reduction to studied CSP (braid group results do not directly transfer).
+
+**Recommended first step:** A `SecurityProofsCode/nl_fscx_v2_orbit.py` script (analogous
+to `nl_fscx_rot_analysis.py`) characterising orbit-length distribution of
+`nl_fscx_revolve_v2(G, K, steps)` for random K would close obstacle 2.
+
+---
+
+#### 78.F — Verifiable Delay Function (VDF) — limited model (Low / Research)
+
+**Primitive:** FSCX orbit periodicity — `fscx_revolve(A, B, n) = A`.
+
+**Construction:**
+```python
+def vdf_eval(x: BitArray, t: int, domain: BitArray) -> BitArray:
+    return fscx_revolve(x, domain, t)
+
+def vdf_verify(x: BitArray, y: BitArray, t: int, domain: BitArray) -> bool:
+    return fscx_revolve(y, domain, KEYBITS - t) == x
+```
+
+**Critical limitation:** FSCX is GF(2)-linear: `M^t` can be precomputed in O(n^3), bypassing
+the sequential delay. Not a full VDF against adversaries with matrix exponentiation capability.
+
+---
+
+#### 78.G — Oblivious PRF (OPRF) — research direction (High)
+
+**Primitive:** `nl_fscx_v1` input symmetry — `nl_fscx_v1(A, B) = nl_fscx_v1(B, A)` (A3).
+
+**Open gap:** Requires formal blinding scheme and security reduction. Research direction only.
+
+---
+
+#### 78.H — Masking-Friendly / Side-Channel-Resistant Implementation (Medium)
+
+**Primitive:** FSCX GF(2)-linearity for Boolean masking; ZKBoo 3-party decomposition for NL-FSCX.
+
+**FSCX masking:**
+```python
+# FSCX(A XOR r, B) = FSCX(A, B) XOR FSCX(r, 0)  [by GF(2)-linearity of M]
+r      = BitArray.random(KEYBITS)
+masked = fscx_revolve(A ^ r, B, I_VALUE)
+result = masked ^ fscx_revolve(r, BitArray(KEYBITS, 0), I_VALUE)
+```
+
+ZKBoo circuit in `_zkp_nl_evaluate_circuit` is structurally a 3-share Boolean masking scheme.
+Target platforms: Arduino and ARM Thumb-2.
+
+---
+
+#### 78.I — Code-Based Ring / Group Signature (Medium)
+
+**Primitive:** HPKS-Stern-F. OR-composition of k Stern identification instances.
+**Constraint:** Proof size scales O(SDFR x k).
+
+---
+
+#### 78.J — Cryptographic Accumulator from HFSCX-256 (Very Low)
+
+**Primitive:** HFSCX-256 collision resistance.
+```python
+leaf = lambda x: hfscx_256(b'\x00' + x)
+node = lambda l, r: hfscx_256(b'\x01' + l + r)
+```
+
+---
+
+#### Summary table
+
+| Sub-item | Primitive exploited | Implementation distance | Key open question |
+|---|---|---|---|
+| 78.A FPE | NL-FSCX v2 bijectivity | Low | None — wrap existing functions |
+| 78.B Tweakable block cipher | NL-FSCX v2 delta(B) structure | Low | None — wrap existing functions |
+| 78.C NL-FSCX ratchet | NL-FSCX v1 one-wayness | Medium | Collision probability over ratchet lifetime |
+| 78.D PQC PAKE | HKEX-RNL + ZKBoo + HFSCX-256 | High | ZKBoo for full HFSCX-256 chain; formal reduction |
+| 78.E Non-Abelian KEx | F2 non-commutativity (Theorem 15) | High (research) | Orbit length bound; circuit-model CSP reduction |
+| 78.F VDF (limited) | FSCX orbit period | Low to implement; not a full VDF | Matrix shortcut breaks sequentiality |
+| 78.G OPRF | NL-FSCX v1 symmetry (A3) | High (research) | Formal blinding scheme; security reduction |
+| 78.H Masking / side-channel | FSCX linearity + ZKBoo decomposition | Medium | Formal higher-order masking proof |
+| 78.I Ring / group signature | Stern ZKP OR-composition | Medium | Proof-size scaling with ring size |
+| 78.J Accumulator | HFSCX-256 collision resistance | Very low | None — direct from existing hash |
+
+**Recommended first implementations:**
+1. **78.B** Tweakable block cipher — resolves HSKE-NL-A2 determinism (TODO #12).
+2. **78.A** FPE — same primitive, zero new code.
+3. **78.J** Accumulator — trivial wrapper around `hfscx_256`.
+4. **78.C** Ratchet — gated on collision-probability analysis.
+5. **78.E** Non-Abelian KEx — start with `nl_fscx_v2_orbit.py`.
+
+Status: **TODO**

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -27,9 +27,10 @@ with toy examples and verified references.
 1. [C integration](#c-integration)
 2. [Go integration](#go-integration)
 3. [Python integration](#python-integration)
-4. [Protocol reference](#protocol-reference)
-5. [Parameter reference](#parameter-reference)
-6. [Security notes](#security-notes)
+4. [ZKP Protocols](#zkp-protocols)
+5. [Protocol reference](#protocol-reference)
+6. [Parameter reference](#parameter-reference)
+7. [Security notes](#security-notes)
 
 ---
 
@@ -488,6 +489,183 @@ See [`docs/examples/python/hello_herradura.py`](examples/python/hello_herradura.
 
 ---
 
+## ZKP Protocols
+
+Zero-knowledge proof (ZKP) constructions allow a prover to demonstrate knowledge
+of a secret (a Ring-LWR signing key, an NL-FSCX preimage) without revealing it.
+Combined with the Fiat-Shamir heuristic they yield non-interactive signatures.
+
+**When to use ZKP vs. conventional signatures:**
+
+- Use **ZKP-RNL** when you need an anonymous credential: the verifier learns only
+  that the signer holds *a* valid key, not which key relative to other keys.
+  Post-quantum hardness follows Ring-LWR.  Proof size is 1,056 bytes at n=256 —
+  smaller than ML-DSA-44 (2,420 bytes).
+- Use **ZKP-NL** when the secret is an NL-FSCX preimage — e.g. to prove knowledge
+  of the input to the one-way function without revealing it.  CLI defaults to n=8
+  (35.5 KB proof at R=219); production at n=256 yields 920 KB pending ZKB++
+  optimisation.
+- Use **HPKS-Stern-F** for conventional signatures where a formal reduction to
+  syndrome decoding hardness is required (78 KB, production-ready).
+
+See `SecurityProofs-3.md §11.10` for completeness, soundness, and zero-knowledge
+proofs of both constructions.
+
+### ZKP-RNL (Ring-LWR Σ-protocol)
+
+The signer reuses an **HKEX-RNL key pair** (`m_blind`, secret `s`, public `C`).
+Proof components: commitment polynomial `w`, sparse ternary challenge `c`,
+response polynomial `z`.  Parameters at n=256: γ=8192, t=16 challenge positions.
+
+#### C
+
+```c
+#include "herradura.h"
+
+/* Keygen: use HKEX-RNL keygen — same key type */
+rnl_poly_t m_blind, s, C_pub;
+rnl_m_poly(m_blind);
+rnl_keygen(s, C_pub, m_blind, urnd);
+
+/* Sign */
+rnl_poly_t w, z;
+int        c[RNL_N];
+int ok = rnl_sigma_sign(s, m_blind, C_pub, RNL_N, msg, msglen, urnd, w, c, z);
+
+/* Verify — only needs public key */
+ok = rnl_sigma_verify(m_blind, C_pub, RNL_N, msg, msglen, w, c, z);
+```
+
+#### Go
+
+```go
+import h "herradurakex/herradura"
+
+// Keygen: same as HKEX-RNL
+n      := h.RnlN
+mBlind := h.RnlMPoly(n)
+sA, CA := h.RnlKeygen(mBlind, n, h.RnlQ, h.RnlP)
+
+// Sign
+w, c, z, err := h.RnlSigmaSign(sA, mBlind, CA, n, msg)
+
+// Verify
+ok := h.RnlSigmaVerify(mBlind, CA, n, msg, w, c, z)
+```
+
+#### Python
+
+```python
+# Keygen: same as HKEX-RNL
+m_blind = h._rnl_m_poly(n)
+s, C_pub = h.hkex_rnl_keygen(m_blind, n, h.RNLQ, h.RNLP, h.RNLB)
+
+# Sign
+w, c, z = h._rnl_sigma_sign(s, m_blind, C_pub, n, msg)
+
+# Verify
+ok = h._rnl_sigma_verify(m_blind, C_pub, n, msg, w, c, z)
+```
+
+### ZKP-NL (NL-FSCX ZKBoo)
+
+Proves knowledge of `A` satisfying `F1(A, B) = y` via MPC-in-the-head.
+The key pair is `(A secret, B and y public)`.  Default parameters: n=8 (toy demo),
+R=4 rounds (soundness error (1/3)^4 ≈ 1.2%).  Use R=219 for 128-bit soundness.
+
+#### C
+
+```c
+#include "herradura.h"
+
+/* Keygen */
+uint32_t A, B, y;
+zkp_nl_keygen(ZKP_NL_DEFAULT_N, urnd, &A, &B, &y);  /* A secret; B, y public */
+
+/* Prove */
+int rounds = ZKP_NL_DEMO_ROUNDS;    /* 4; use ZKP_NL_PROD_ROUNDS=219 for production */
+ZkpNlRound *proof = zkp_nl_prove(A, B, y, ZKP_NL_DEFAULT_N, rounds, msg, msglen);
+
+/* Verify */
+int ok = zkp_nl_verify(B, y, ZKP_NL_DEFAULT_N, rounds, msg, msglen, proof);
+zkp_nl_proof_free(proof, rounds);
+```
+
+#### Go
+
+```go
+import h "herradurakex/herradura"
+
+// Keygen
+A, B, y, _ := h.ZkpNlKeygen(h.ZkpNlDefaultN)
+
+// Prove (demo rounds=4; use h.ZkpNlProdRounds=219 for production)
+proof, _ := h.ZkpNlProve(A, B, y, h.ZkpNlDefaultN, h.ZkpNlDemoRounds, msg)
+
+// Verify
+ok := h.ZkpNlVerify(B, y, h.ZkpNlDefaultN, h.ZkpNlDemoRounds, msg, proof)
+```
+
+#### Python
+
+```python
+# Keygen
+A, B, y = h._zkp_nl_keygen(n)     # A secret; B, y public
+
+# Prove (rounds=4 demo; 219 for 128-bit soundness)
+proof = h._zkp_nl_prove(A, B, y, n, rounds=4, msg=msg)
+
+# Verify
+ok = h._zkp_nl_verify(B, y, n, rounds=4, msg=msg, proof=proof)
+```
+
+### CLI usage
+
+```bash
+# ZKP-RNL — key type: hkex-rnl, algo: rnl-sigma
+python3 HerraduraCli/herradura.py genpkey --algo hkex-rnl --out priv.pem
+python3 HerraduraCli/herradura.py pkey    --in priv.pem --pubout --out pub.pem
+python3 HerraduraCli/herradura.py sign    --algo rnl-sigma --key priv.pem \
+        --in msg.bin --out sig.pem
+python3 HerraduraCli/herradura.py verify  --algo rnl-sigma --pubkey pub.pem \
+        --in msg.bin --sig sig.pem
+
+# C and Go CLIs share identical subcommands
+./HerraduraCli/herradura_cli     sign   --algo rnl-sigma --key priv.pem --in msg.bin --out sig.pem
+./HerraduraCli/herradura_cli_go  sign   --algo rnl-sigma --key priv.pem --in msg.bin --out sig.pem
+
+# ZKP-NL — key type: hpks-zkp-nl, algo: nl-zkboo
+python3 HerraduraCli/herradura.py genpkey --algo hpks-zkp-nl --out zkpnl.pem
+python3 HerraduraCli/herradura.py pkey    --in zkpnl.pem --pubout --out zkpnl_pub.pem
+# Python CLI accepts --rounds; C CLI hardcodes 219 rounds; Go CLI hardcodes 4 rounds
+python3 HerraduraCli/herradura.py sign   --algo nl-zkboo --key zkpnl.pem \
+        --rounds 4 --in msg.bin --out proof.pem
+python3 HerraduraCli/herradura.py verify --algo nl-zkboo --pubkey zkpnl_pub.pem \
+        --in msg.bin --sig proof.pem
+./HerraduraCli/herradura_cli sign    --algo nl-zkboo --key zkpnl.pem --in msg.bin --out proof.pem
+./HerraduraCli/herradura_cli verify  --algo nl-zkboo --pubkey zkpnl_pub.pem --in msg.bin --sig proof.pem
+```
+
+Proof PEM files are cross-language compatible: a proof produced by the Python CLI
+verifies under the C and Go CLIs and vice versa.  See `CliTest/test_zkp_interop.sh`
+for a 14-way cross-language interop test.
+
+### Proof-size and performance comparison
+
+| Construction | Proof / signature size | Hardness | Notes |
+|---|---|---|---|
+| HPKS | 64 B | DLP in GF(2^256) — quantum-broken | Fastest |
+| ZKP-RNL (n=256) | **1,056 B** | Ring-LWR (heuristic) | Best lattice compactness |
+| ML-DSA-44 (reference) | 2,420 B | Module-LWE | NIST standard |
+| HPKS-Stern-F (rounds=219) | 78 KB | SD(N,t) + NL-FSCX v1 PRF | Production code-based PQC |
+| ZKP-NL (n=8, R=219) | 35.5 KB | NL-FSCX OWF | CLI default; toy parameters |
+| ZKP-NL (n=256, R=219) | 920 KB | NL-FSCX OWF | Awaits ZKB++ (~180 KB est.) |
+
+ZKP-RNL is the most compact lattice-based signing option in the suite.
+For NL-FSCX witness statements, ZKP-NL is the only applicable construction.
+
+---
+
 ## Protocol reference
 
 ### Classical protocols
@@ -515,6 +693,13 @@ See [`docs/examples/python/hello_herradura.py`](examples/python/hello_herradura.
 |----------|----------|--------|
 | HPKS-Stern-F | SD(N,t) + NL-FSCX v1 PRF | Demo params (rounds=32); production needs rounds≥219 |
 | HPKE-Stern-F | SD(N,t) | Demo only; decap requires QC-MDPC decoder for production |
+
+### ZKP protocols
+
+| Construction | Key type | Sign / prove | Verify | Proof size |
+|---|---|---|---|---|
+| ZKP-RNL (Ring-LWR Σ-protocol) | `hkex-rnl` | `rnl_sigma_sign` | `rnl_sigma_verify` | 1,056 B (n=256) |
+| ZKP-NL (NL-FSCX ZKBoo) | `hpks-zkp-nl` | `zkp_nl_prove` | `zkp_nl_verify` | 35.5 KB (n=8, R=219) |
 
 ### Hash primitive
 

--- a/herradura.h
+++ b/herradura.h
@@ -1366,4 +1366,527 @@ static inline void hpke_decrypt(const BitArray *ct, const BitArray *R,
     ba_fscx_revolve(pt_out, ct, &dec_key, R_VALUE);
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * ZKP-RNL  Ring-LWR Σ-protocol (Lyubashevsky / Fiat-Shamir)
+ * SecurityProofs-3.md §11.10.2
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * A proof-of-knowledge for the relation { (m,C_p ; s) : C_p = round_p(m·s) }
+ * in Z_q[x]/(x^n+1).  Proof = (w, c, z); accepted iff:
+ *   ‖z‖∞ ≤ γ−t  and  round_p(m·z) ≈ w + c·lift(C_p)  (within slack).
+ *
+ * Parameters are chosen per polynomial dimension n; for n = RNL_N = 256 the
+ * NTT-based rnl_poly_mul is used; for smaller n a naive O(n²) multiply is used.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+#define SIGMA_MAX_ATTEMPTS 1000
+
+static void sigma_params(int n, int *g_out, int *t_out)
+{
+    *t_out = (n <= 32) ? 4 : (n <= 64) ? 8 : (n <= 128) ? 12 : 16;
+    *g_out = (n <= 32) ? 4096 : 8192;
+}
+
+/* O(n²) negacyclic poly mul in Z_q[x]/(x^n+1).  Used when n ≠ RNL_N. */
+static void sigma_poly_mul_n(int32_t *h, const int32_t *f, const int32_t *g, int n, int q)
+{
+    int i, j;
+    int64_t *tmp = (int64_t *)calloc((size_t)n, sizeof(int64_t));
+    if (!tmp) { fputs("sigma_poly_mul_n OOM\n", stderr); exit(1); }
+    for (i = 0; i < n; i++) {
+        int64_t fi = (uint32_t)f[i];
+        for (j = 0; j < n; j++) {
+            int k = (i + j) % n;
+            int64_t v = fi * (uint32_t)g[j] % q;
+            tmp[k] = (i + j >= n) ? (tmp[k] - v + q) % q : (tmp[k] + v) % q;
+        }
+    }
+    for (i = 0; i < n; i++) h[i] = (int32_t)tmp[i];
+    free(tmp);
+}
+
+/* Serialize n poly coefficients as n×4 big-endian bytes (lower u32 each). */
+static void sigma_poly_bytes(uint8_t *out, const int32_t *p, int n)
+{
+    int i;
+    for (i = 0; i < n; i++) {
+        uint32_t v = (uint32_t)p[i];
+        out[i*4+0] = (uint8_t)(v >> 24); out[i*4+1] = (uint8_t)(v >> 16);
+        out[i*4+2] = (uint8_t)(v >>  8); out[i*4+3] = (uint8_t)v;
+    }
+}
+
+/* Fiat-Shamir: derive a sparse ternary challenge polynomial c from (m, C_p, w, msg).
+ * t nonzero coefficients in {1, q-1}.  Matches Python _sigma_challenge exactly. */
+static void sigma_challenge(const int32_t *m, const int32_t *Cp, const int32_t *w,
+                            int n, int q, int t, const uint8_t *msg, size_t mlen,
+                            int32_t *c_out)
+{
+    uint8_t seed[32];
+    /* Hash: 4B n | n×4B m | n×4B C | n×4B w | msg */
+    size_t bl = 4 + (size_t)n * 12 + mlen;
+    uint8_t *buf = (uint8_t *)malloc(bl);
+    if (!buf) { fputs("sigma_challenge OOM\n", stderr); exit(1); }
+    buf[0] = (uint8_t)((uint32_t)n >> 24); buf[1] = (uint8_t)((uint32_t)n >> 16);
+    buf[2] = (uint8_t)((uint32_t)n >>  8); buf[3] = (uint8_t)n;
+    sigma_poly_bytes(buf + 4,          m, n);
+    sigma_poly_bytes(buf + 4 + n * 4, Cp, n);
+    sigma_poly_bytes(buf + 4 + n * 8,  w, n);
+    if (mlen) memcpy(buf + 4 + n * 12, msg, mlen);
+    hfscx_256(buf, bl, NULL, seed);
+    free(buf);
+
+    /* Position expansion: seed||"pos"||4B_idx → sample t distinct positions in [0,n) */
+    int *pos = (int *)malloc((size_t)t * sizeof(int));
+    if (!pos) { fputs("sigma_challenge pos OOM\n", stderr); exit(1); }
+    uint8_t ext[39], h[32];
+    memcpy(ext, seed, 32); memcpy(ext + 32, "pos", 3);
+    int np = 0, idx = 0;
+    while (np < t) {
+        ext[35] = (uint8_t)(idx >> 24); ext[36] = (uint8_t)(idx >> 16);
+        ext[37] = (uint8_t)(idx >>  8); ext[38] = (uint8_t)idx;
+        hfscx_256(ext, 39, NULL, h);
+        uint32_t v = (uint32_t)(((uint32_t)h[0]<<24|(uint32_t)h[1]<<16|
+                                  (uint32_t)h[2]<<8|h[3]) % (uint32_t)n);
+        int dup = 0, k;
+        for (k = 0; k < np; k++) if (pos[k] == (int)v) { dup = 1; break; }
+        if (!dup) pos[np++] = (int)v;
+        idx++;
+    }
+    /* Sign expansion: seed||"sgn"||4B_k → ±1 per position */
+    memset(c_out, 0, (size_t)n * sizeof(int32_t));
+    memcpy(ext + 32, "sgn", 3);
+    for (int k = 0; k < t; k++) {
+        ext[35] = (uint8_t)(k >> 24); ext[36] = (uint8_t)(k >> 16);
+        ext[37] = (uint8_t)(k >>  8); ext[38] = (uint8_t)k;
+        hfscx_256(ext, 39, NULL, h);
+        c_out[pos[k]] = (h[0] & 1) ? (int32_t)(q - 1) : 1;
+    }
+    free(pos);
+}
+
+/* ZKP-RNL prover.
+ * s, m, Cp: n-element arrays in Z_q.  w_out, c_out, z_out: caller-allocated, n each.
+ * Returns 0 on success, -1 if SIGMA_MAX_ATTEMPTS exhausted. */
+static int rnl_sigma_sign(const int32_t *s, const int32_t *m, const int32_t *Cp,
+                          int n, const uint8_t *msg, size_t mlen, FILE *urnd,
+                          int32_t *w_out, int32_t *c_out, int32_t *z_out)
+{
+    int gamma, t;
+    sigma_params(n, &gamma, &t);
+    int bound = gamma - t, q = RNL_Q;
+    int64_t hq = q / 2;
+    uint32_t range = (uint32_t)(2 * gamma + 1);
+    uint32_t thresh = (1u << 24) - (1u << 24) % range;
+
+    int32_t *y   = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *y_q = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *my  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *ct  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *cs  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    if (!y || !y_q || !my || !ct || !cs) { fputs("OOM\n", stderr); exit(1); }
+
+    int ok = 0, attempt, i;
+    for (attempt = 0; attempt < SIGMA_MAX_ATTEMPTS; attempt++) {
+        for (i = 0; i < n; i++) {
+            uint32_t v;
+            do { uint8_t b[3];
+                 if (fread(b, 1, 3, urnd) != 3) { fputs("urandom\n", stderr); exit(1); }
+                 v = ((uint32_t)b[0] << 16) | ((uint32_t)b[1] << 8) | b[2];
+            } while (v >= thresh);
+            y[i] = (int32_t)(v % range) - gamma;
+        }
+        for (i = 0; i < n; i++) y_q[i] = (int32_t)(((int64_t)y[i] % q + q) % q);
+
+        if (n == RNL_N) rnl_poly_mul(my, m, y_q);
+        else            sigma_poly_mul_n(my, m, y_q, n, q);
+
+        for (i = 0; i < n; i++)
+            w_out[i] = (my[i] > (int32_t)hq) ? (int32_t)(my[i] - q) : my[i];
+
+        sigma_challenge(m, Cp, w_out, n, q, t, msg, mlen, ct);
+
+        if (n == RNL_N) rnl_poly_mul(cs, ct, s);
+        else            sigma_poly_mul_n(cs, ct, s, n, q);
+
+        int ok2 = 1;
+        for (i = 0; i < n; i++) {
+            int32_t csi = (cs[i] > (int32_t)hq) ? (int32_t)(cs[i] - q) : cs[i];
+            z_out[i] = y[i] + csi;
+            if (z_out[i] > bound || z_out[i] < -bound) ok2 = 0;
+        }
+        if (ok2) { memcpy(c_out, ct, (size_t)n * sizeof(int32_t)); ok = 1; break; }
+    }
+    free(y); free(y_q); free(my); free(ct); free(cs);
+    return ok ? 0 : -1;
+}
+
+/* ZKP-RNL verifier.  Returns 1 if proof is valid, 0 otherwise. */
+static int rnl_sigma_verify(const int32_t *m, const int32_t *Cp,
+                            int n, const uint8_t *msg, size_t mlen,
+                            const int32_t *w, const int32_t *c, const int32_t *z)
+{
+    int gamma, t;
+    sigma_params(n, &gamma, &t);
+    int bound = gamma - t, q = RNL_Q, p = RNL_P, i, valid = 1;
+    int64_t hq = q / 2, slack = (int64_t)t * (q / (2 * p) + 1);
+
+    for (i = 0; i < n; i++) if (z[i] > bound || z[i] < -bound) return 0;
+
+    int32_t *cc  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *z_q = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *lft = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *mz  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *cL  = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    int32_t *w_q = (int32_t *)malloc((size_t)n * sizeof(int32_t));
+    if (!cc || !z_q || !lft || !mz || !cL || !w_q) { fputs("OOM\n", stderr); exit(1); }
+
+    sigma_challenge(m, Cp, w, n, q, t, msg, mlen, cc);
+    for (i = 0; i < n; i++) if (cc[i] != c[i]) { valid = 0; goto vdone; }
+
+    for (i = 0; i < n; i++) z_q[i] = (int32_t)(((int64_t)z[i]  % q + q) % q);
+    for (i = 0; i < n; i++) lft[i] = (int32_t)((((int64_t)Cp[i] * q) + p/2) / p % q);
+    for (i = 0; i < n; i++) w_q[i] = (int32_t)(((int64_t)w[i]  % q + q) % q);
+
+    if (n == RNL_N) { rnl_poly_mul(mz, m, z_q); rnl_poly_mul(cL, c, lft); }
+    else            { sigma_poly_mul_n(mz, m, z_q, n, q); sigma_poly_mul_n(cL, c, lft, n, q); }
+
+    for (i = 0; i < n; i++) {
+        int64_t d = ((int64_t)mz[i] - cL[i] - w_q[i] + 2LL * q) % q;
+        if (d > hq) d -= q;
+        if (d > slack || d < -slack) { valid = 0; break; }
+    }
+vdone:
+    free(cc); free(z_q); free(lft); free(mz); free(cL); free(w_q);
+    return valid;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * ZKP-NL  NL-FSCX ZKBoo (MPC-in-the-head, 3-party Boolean circuit)
+ * SecurityProofs-3.md §11.10.3
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Proves knowledge of A s.t. nl_fscx_v1(A, B) = y (n ≤ ZKP_NL_MAX_N bits).
+ * Circuit: F1(A, B) = FSCX(A,B)  XOR  ROL_{n/4}((A+B) mod 2^n).
+ * The carry chain of (A+B) contributes n−1 AND gates (each 3-party shared).
+ * Soundness: (2/3)^R; R = ZKP_NL_PROD_ROUNDS gives 128-bit security.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+#define ZKP_NL_DEFAULT_N    8
+#define ZKP_NL_DEMO_ROUNDS  4
+#define ZKP_NL_PROD_ROUNDS  219
+#define ZKP_NL_MAX_N        32
+
+typedef struct {
+    uint8_t  com_0[32], com_1[32], com_2[32];
+    uint8_t  e;          /* hidden party index 0,1,2 */
+    uint8_t *view_p1;    /* heap: view of party (e+1)%3 */
+    uint8_t *view_p2;    /* heap: view of party (e+2)%3 */
+    size_t   view_len;
+} ZkpNlRound;
+
+static void zkp_nl_proof_free(ZkpNlRound *proof, int rounds)
+{
+    int j;
+    if (!proof) return;
+    for (j = 0; j < rounds; j++) { free(proof[j].view_p1); free(proof[j].view_p2); }
+    free(proof);
+}
+
+/* n-bit cyclic left-rotate. */
+static uint32_t zkp_nl_rol(uint32_t x, int r, int n)
+{
+    uint32_t mask = (n == 32) ? 0xFFFFFFFFU : (1u << n) - 1u;
+    r = ((r % n) + n) % n;
+    return r ? ((x << r) | (x >> (n - r))) & mask : x & mask;
+}
+
+/* Commitment: HFSCX-256( j(4B) || p(1B) || tape(32B) || out_share(nb B) ). */
+static void zkp_nl_commit(uint8_t out[32], int j, int p,
+                          const uint8_t tape[32], uint32_t out_share, int nb)
+{
+    uint8_t buf[4 + 1 + 32 + 4];
+    int k;
+    buf[0]=(uint8_t)(j>>24); buf[1]=(uint8_t)(j>>16); buf[2]=(uint8_t)(j>>8); buf[3]=(uint8_t)j;
+    buf[4] = (uint8_t)p;
+    memcpy(buf + 5, tape, 32);
+    for (k = 0; k < nb; k++) buf[5+32+k] = (uint8_t)(out_share >> (8*(nb-1-k)));
+    hfscx_256(buf, (size_t)(5 + 32 + nb), NULL, out);
+}
+
+/* One PRG bit from tape and gate index. */
+static int zkp_nl_prg_bit(const uint8_t tape[32], int gate_id)
+{
+    uint8_t buf[36], h[32];
+    memcpy(buf, tape, 32);
+    buf[32]=(uint8_t)(gate_id>>24); buf[33]=(uint8_t)(gate_id>>16);
+    buf[34]=(uint8_t)(gate_id>>8);  buf[35]=(uint8_t)gate_id;
+    hfscx_256(buf, 36, NULL, h);
+    return h[0] & 1;
+}
+
+/* 3-party ZKBoo evaluation of nl_fscx_v1(A, B).
+ * shares: XOR shares of A.  tapes: per-party 32-byte tape.  B: public constant.
+ * Fills out0/out1/out2 (XOR shares of F1(A,B)) and gv0/gv1/gv2 (gate views, n-1 bytes each). */
+static void zkp_nl_eval_3p(
+    uint32_t s0, uint32_t s1, uint32_t s2,
+    const uint8_t *t0, const uint8_t *t1, const uint8_t *t2,
+    uint32_t B, int n,
+    uint32_t *out0, uint32_t *out1, uint32_t *out2,
+    uint8_t *gv0, uint8_t *gv1, uint8_t *gv2)
+{
+    uint32_t mask = (n == 32) ? 0xFFFFFFFFU : (1u << n) - 1u;
+    uint32_t sh[3] = { s0, s1, s2 };
+    const uint8_t *tp[3] = { t0, t1, t2 };
+    uint8_t *gv[3] = { gv0, gv1, gv2 };
+    uint32_t carry[ZKP_NL_MAX_N + 1][3];
+    int i, p;
+    memset(carry, 0, sizeof(carry));
+
+    for (i = 0; i < n - 1; i++) {
+        int Bi = (B >> i) & 1;
+        int ai[3], ci[3], ri[3], ao[3];
+        for (p = 0; p < 3; p++) {
+            ai[p] = (sh[p] >> i) & 1; ci[p] = (int)carry[i][p];
+            ri[p] = zkp_nl_prg_bit(tp[p], i);
+        }
+        for (p = 0; p < 3; p++) {
+            int p1 = (p + 1) % 3;
+            ao[p] = (ai[p]&ci[p]) ^ (ai[p]&ci[p1]) ^ (ai[p1]&ci[p]) ^ ri[p] ^ ri[p1];
+            gv[p][i] = (uint8_t)(ai[p] | (ci[p] << 1) | (ao[p] << 2));
+        }
+        for (p = 0; p < 3; p++)
+            carry[i+1][p] = (uint32_t)((Bi & ai[p]) ^ ao[p] ^ (Bi & ci[p]));
+    }
+
+    uint32_t sum_s[3] = {0, 0, 0};
+    for (i = 0; i < n; i++) {
+        int Bi = (B >> i) & 1;
+        for (p = 0; p < 3; p++) {
+            int sb = ((sh[p] >> i) & 1) ^ Bi ^ (int)carry[i][p];
+            sum_s[p] ^= (uint32_t)sb << i;
+        }
+    }
+
+    uint32_t rot_s[3], lin_s[3];
+    uint32_t Bc = (B ^ zkp_nl_rol(B,1,n) ^ zkp_nl_rol(B,n-1,n)) & mask;
+    for (p = 0; p < 3; p++) {
+        rot_s[p] = zkp_nl_rol(sum_s[p], n/4, n);
+        lin_s[p] = (sh[p] ^ zkp_nl_rol(sh[p],1,n) ^ zkp_nl_rol(sh[p],n-1,n)) & mask;
+    }
+    lin_s[0] ^= Bc;
+
+    *out0 = (lin_s[0] ^ rot_s[0]) & mask;
+    *out1 = (lin_s[1] ^ rot_s[1]) & mask;
+    *out2 = (lin_s[2] ^ rot_s[2]) & mask;
+}
+
+/* Pack one party's view: share(nb) || tape(32) || out_share(nb) || gate_bytes(n-1). */
+static void zkp_nl_pack_view(uint8_t *buf, uint32_t share, const uint8_t tape[32],
+                              uint32_t out_share, const uint8_t *gate_bytes, int n, int nb)
+{
+    int k;
+    for (k = 0; k < nb; k++) buf[k] = (uint8_t)(share >> (8*(nb-1-k)));
+    memcpy(buf + nb, tape, 32);
+    for (k = 0; k < nb; k++) buf[nb+32+k] = (uint8_t)(out_share >> (8*(nb-1-k)));
+    if (n > 1) memcpy(buf + nb + 32 + nb, gate_bytes, (size_t)(n-1));
+}
+
+/* Unpack a view buffer; returns pointers into buf for tape and gate_bytes. */
+static void zkp_nl_unpack_view(const uint8_t *buf, int n, int nb,
+                                uint32_t *share_out, const uint8_t **tape_out,
+                                uint32_t *out_share_out, const uint8_t **gv_out)
+{
+    int k; uint32_t v = 0;
+    for (k = 0; k < nb; k++) v = (v << 8) | buf[k];
+    *share_out = v;
+    *tape_out  = buf + nb;
+    v = 0;
+    for (k = 0; k < nb; k++) v = (v << 8) | buf[nb+32+k];
+    *out_share_out = v;
+    *gv_out        = buf + nb + 32 + nb;
+}
+
+/* Direct evaluation of nl_fscx_v1(A, B) as a scalar (for keygen). */
+static uint32_t zkp_nl_f1(uint32_t A, uint32_t B, int n)
+{
+    uint32_t mask = (n == 32) ? 0xFFFFFFFFU : (1u << n) - 1u;
+    uint32_t lin = (A ^ B ^ zkp_nl_rol(A,1,n) ^ zkp_nl_rol(B,1,n)
+                    ^ zkp_nl_rol(A,n-1,n) ^ zkp_nl_rol(B,n-1,n)) & mask;
+    return (lin ^ zkp_nl_rol((A+B)&mask, n/4, n)) & mask;
+}
+
+/* Generate a ZKP-NL keypair (n ≤ ZKP_NL_MAX_N).
+ * A is the private witness; (B, y) is the public statement. */
+static void zkp_nl_keygen(int n, FILE *urnd, uint32_t *A_out, uint32_t *B_out, uint32_t *y_out)
+{
+    uint32_t mask = (n == 32) ? 0xFFFFFFFFU : (1u << n) - 1u;
+    int nb = (n + 7) / 8, k;
+    uint32_t A = 0, B = 0;
+    uint8_t rb;
+    for (k = 0; k < nb; k++) {
+        if (fread(&rb, 1, 1, urnd) != 1) { fputs("urandom\n", stderr); exit(1); }
+        A = (A << 8) | rb;
+    }
+    for (k = 0; k < nb; k++) {
+        if (fread(&rb, 1, 1, urnd) != 1) { fputs("urandom\n", stderr); exit(1); }
+        B = (B << 8) | rb;
+    }
+    A &= mask; B &= mask;
+    *A_out = A; *B_out = B; *y_out = zkp_nl_f1(A, B, n);
+}
+
+/* Prove knowledge of A s.t. F1(A, B) = y.
+ * Returns a heap-allocated array of `rounds` ZkpNlRound structs; free with zkp_nl_proof_free. */
+static ZkpNlRound *zkp_nl_prove(uint32_t A, uint32_t B, uint32_t y, int n, int rounds,
+                                 const uint8_t *msg, size_t mlen, FILE *urnd)
+{
+    int nb = (n + 7) / 8;
+    size_t gv_stride = (n > 1) ? (size_t)(n-1) : 1;
+    size_t view_len  = (size_t)(2*nb) + 32 + (n > 1 ? (size_t)(n-1) : 0);
+    uint32_t mask = (n == 32) ? 0xFFFFFFFFU : (1u << n) - 1u;
+
+    ZkpNlRound *proof = (ZkpNlRound *)malloc((size_t)rounds * sizeof(ZkpNlRound));
+    uint8_t *all_coms  = (uint8_t *)malloc((size_t)rounds * 3 * 32);
+    uint32_t *all_sh   = (uint32_t *)malloc((size_t)rounds * 3 * sizeof(uint32_t));
+    uint8_t  *all_tp   = (uint8_t *)malloc((size_t)rounds * 3 * 32);
+    uint32_t *all_out  = (uint32_t *)malloc((size_t)rounds * 3 * sizeof(uint32_t));
+    uint8_t  *all_gv   = (uint8_t *)malloc((size_t)rounds * 3 * gv_stride);
+    if (!proof||!all_coms||!all_sh||!all_tp||!all_out||!all_gv)
+        { fputs("zkp_nl_prove OOM\n", stderr); exit(1); }
+    memset(all_gv, 0, (size_t)rounds * 3 * gv_stride);
+
+    int j, p, k;
+    /* Phase 1: generate shares, tapes, evaluate circuit, commit. */
+    for (j = 0; j < rounds; j++) {
+        uint32_t s0 = 0, s1 = 0;
+        uint8_t rb;
+        for (k = 0; k < nb; k++) {
+            if (fread(&rb,1,1,urnd)!=1){fputs("urandom\n",stderr);exit(1);} s0=(s0<<8)|rb;
+        }
+        for (k = 0; k < nb; k++) {
+            if (fread(&rb,1,1,urnd)!=1){fputs("urandom\n",stderr);exit(1);} s1=(s1<<8)|rb;
+        }
+        s0 &= mask; s1 &= mask;
+        uint32_t s2 = (A ^ s0 ^ s1) & mask;
+        all_sh[j*3+0] = s0; all_sh[j*3+1] = s1; all_sh[j*3+2] = s2;
+        for (p = 0; p < 3; p++)
+            if (fread(all_tp+(j*3+p)*32, 1, 32, urnd) != 32)
+                { fputs("urandom tape\n", stderr); exit(1); }
+
+        zkp_nl_eval_3p(s0, s1, s2,
+                        all_tp+(j*3+0)*32, all_tp+(j*3+1)*32, all_tp+(j*3+2)*32,
+                        B, n,
+                        &all_out[j*3+0], &all_out[j*3+1], &all_out[j*3+2],
+                        all_gv+(j*3+0)*gv_stride,
+                        all_gv+(j*3+1)*gv_stride,
+                        all_gv+(j*3+2)*gv_stride);
+
+        for (p = 0; p < 3; p++)
+            zkp_nl_commit(all_coms+(j*3+p)*32, j, p,
+                          all_tp+(j*3+p)*32, all_out[j*3+p], nb);
+    }
+
+    /* Phase 2: Fiat-Shamir challenge seed = hash(all_coms || B_bytes || y_bytes || msg). */
+    size_t ch_len = (size_t)rounds*3*32 + (size_t)nb + (size_t)nb + mlen;
+    uint8_t *ch_buf = (uint8_t *)malloc(ch_len);
+    if (!ch_buf) { fputs("OOM\n", stderr); exit(1); }
+    memcpy(ch_buf, all_coms, (size_t)rounds*3*32);
+    for (k = 0; k < nb; k++) ch_buf[rounds*3*32+k]    = (uint8_t)(B >> (8*(nb-1-k)));
+    for (k = 0; k < nb; k++) ch_buf[rounds*3*32+nb+k]  = (uint8_t)(y >> (8*(nb-1-k)));
+    if (mlen) memcpy(ch_buf+rounds*3*32+nb+nb, msg, mlen);
+    uint8_t ch_seed[32];
+    hfscx_256(ch_buf, ch_len, NULL, ch_seed);
+    free(ch_buf);
+
+    /* Phase 3: derive per-round challenges and pack views. */
+    for (j = 0; j < rounds; j++) {
+        uint8_t ext[36], h[32];
+        memcpy(ext, ch_seed, 32);
+        ext[32]=(uint8_t)(j>>24); ext[33]=(uint8_t)(j>>16);
+        ext[34]=(uint8_t)(j>>8);  ext[35]=(uint8_t)j;
+        hfscx_256(ext, 36, NULL, h);
+        int e = h[0] % 3, p1 = (e+1)%3, p2 = (e+2)%3;
+
+        memcpy(proof[j].com_0, all_coms+(j*3+0)*32, 32);
+        memcpy(proof[j].com_1, all_coms+(j*3+1)*32, 32);
+        memcpy(proof[j].com_2, all_coms+(j*3+2)*32, 32);
+        proof[j].e        = (uint8_t)e;
+        proof[j].view_len = view_len;
+        proof[j].view_p1  = (uint8_t *)malloc(view_len);
+        proof[j].view_p2  = (uint8_t *)malloc(view_len);
+        if (!proof[j].view_p1 || !proof[j].view_p2)
+            { fputs("OOM view\n", stderr); exit(1); }
+
+        zkp_nl_pack_view(proof[j].view_p1, all_sh[j*3+p1], all_tp+(j*3+p1)*32,
+                          all_out[j*3+p1], all_gv+(j*3+p1)*gv_stride, n, nb);
+        zkp_nl_pack_view(proof[j].view_p2, all_sh[j*3+p2], all_tp+(j*3+p2)*32,
+                          all_out[j*3+p2], all_gv+(j*3+p2)*gv_stride, n, nb);
+    }
+    free(all_coms); free(all_sh); free(all_tp); free(all_out); free(all_gv);
+    return proof;
+}
+
+/* Verify a ZKBoo proof.  Returns 1 if valid, 0 otherwise. */
+static int zkp_nl_verify(uint32_t B, uint32_t y, int n, int rounds,
+                          const uint8_t *msg, size_t mlen, ZkpNlRound *proof)
+{
+    int nb = (n + 7) / 8, j, k;
+
+    /* Recompute FS challenge seed. */
+    size_t ch_len = (size_t)rounds*3*32 + (size_t)nb + (size_t)nb + mlen;
+    uint8_t *ch_buf = (uint8_t *)malloc(ch_len);
+    if (!ch_buf) { fputs("OOM\n", stderr); exit(1); }
+    for (j = 0; j < rounds; j++) {
+        memcpy(ch_buf+j*3*32+0*32, proof[j].com_0, 32);
+        memcpy(ch_buf+j*3*32+1*32, proof[j].com_1, 32);
+        memcpy(ch_buf+j*3*32+2*32, proof[j].com_2, 32);
+    }
+    for (k = 0; k < nb; k++) ch_buf[rounds*3*32+k]    = (uint8_t)(B >> (8*(nb-1-k)));
+    for (k = 0; k < nb; k++) ch_buf[rounds*3*32+nb+k]  = (uint8_t)(y >> (8*(nb-1-k)));
+    if (mlen) memcpy(ch_buf+rounds*3*32+nb+nb, msg, mlen);
+    uint8_t ch_seed[32];
+    hfscx_256(ch_buf, ch_len, NULL, ch_seed);
+    free(ch_buf);
+
+    for (j = 0; j < rounds; j++) {
+        uint8_t ext[36], h[32];
+        memcpy(ext, ch_seed, 32);
+        ext[32]=(uint8_t)(j>>24); ext[33]=(uint8_t)(j>>16);
+        ext[34]=(uint8_t)(j>>8);  ext[35]=(uint8_t)j;
+        hfscx_256(ext, 36, NULL, h);
+        if (h[0] % 3 != (int)proof[j].e) return 0;
+
+        int e = proof[j].e, p1 = (e+1)%3, p2 = (e+2)%3;
+        uint32_t sh_p1, sh_p2, out_p1, out_p2;
+        const uint8_t *tp_p1, *tp_p2, *gv_p1, *gv_p2;
+        zkp_nl_unpack_view(proof[j].view_p1, n, nb, &sh_p1, &tp_p1, &out_p1, &gv_p1);
+        zkp_nl_unpack_view(proof[j].view_p2, n, nb, &sh_p2, &tp_p2, &out_p2, &gv_p2);
+
+        uint8_t c_p1[32], c_p2[32];
+        zkp_nl_commit(c_p1, j, p1, tp_p1, out_p1, nb);
+        zkp_nl_commit(c_p2, j, p2, tp_p2, out_p2, nb);
+        const uint8_t *coms[3] = { proof[j].com_0, proof[j].com_1, proof[j].com_2 };
+        if (memcmp(c_p1, coms[p1], 32) || memcmp(c_p2, coms[p2], 32)) return 0;
+
+        /* Re-evaluate p1's AND gates using both revealed shares/tapes; check gate views. */
+        uint32_t carry_p1 = 0, carry_p2 = 0;
+        int i;
+        for (i = 0; i < n - 1; i++) {
+            int ai_p1 = (sh_p1 >> i) & 1, ai_p2 = (sh_p2 >> i) & 1;
+            int ci_p1 = (int)carry_p1,     ci_p2 = (int)carry_p2;
+            int Bi    = (B >> i) & 1;
+            int ri_p1 = zkp_nl_prg_bit(tp_p1, i), ri_p2 = zkp_nl_prg_bit(tp_p2, i);
+
+            int exp_ao_p1 = (ai_p1&ci_p1)^(ai_p1&ci_p2)^(ai_p2&ci_p1)^ri_p1^ri_p2;
+            if (((gv_p1[i] >> 2) & 1) != exp_ao_p1) return 0;
+
+            carry_p1 = (uint32_t)((Bi&ai_p1) ^ exp_ao_p1 ^ (Bi&ci_p1));
+            int ao_p2 = (gv_p2[i] >> 2) & 1;
+            carry_p2 = (uint32_t)((Bi&ai_p2) ^ ao_p2      ^ (Bi&ci_p2));
+        }
+    }
+    return 1;
+}
+
 #endif /* HERRADURA_H */

--- a/herradura/codec.go
+++ b/herradura/codec.go
@@ -43,6 +43,11 @@ const (
 	PemSignature     = "HERRADURA SIGNATURE"
 	PemCiphertext    = "HERRADURA CIPHERTEXT"
 	PemDigest        = "HERRADURA DIGEST"
+
+	PemZkpRnlProof = "HERRADURA ZKP-RNL PROOF"
+	PemZkpNlPriv   = "HERRADURA ZKP-NL PRIVATE KEY"
+	PemZkpNlPub    = "HERRADURA ZKP-NL PUBLIC KEY"
+	PemZkpNlProof  = "HERRADURA ZKP-NL PROOF"
 )
 
 // ---------------------------------------------------------------------------

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -1022,3 +1022,576 @@ func HpkeSternFEncap(seed *BitArray, n int) (*BitArray, *big.Int, *BitArray) {
 func HpkeSternFDecapKnown(ePrime, seed *BitArray) *BitArray {
 	return SternHash(4, seed, ePrime)
 }
+
+// ---------------------------------------------------------------------------
+// ZKP-RNL: Ring-LWR Σ-protocol (Lyubashevsky-style, Fiat-Shamir compiled)
+// SecurityProofs-3.md §11.10.2
+// ---------------------------------------------------------------------------
+
+const sigmaMaxAttempts = 1000
+
+// ZkpRnlParams returns (gamma, t) for the Ring-LWR Σ-protocol at bit-width n.
+func ZkpRnlParams(n int) (gamma, t int) {
+	if n <= 32 {
+		return 4096, 4
+	}
+	return 8192, 16
+}
+
+// sigmaPolyBytes serializes a polynomial (possibly signed) to bytes for hashing (4 B/coeff).
+func sigmaPolyBytes(poly []int) []byte {
+	out := make([]byte, len(poly)*4)
+	for i, c := range poly {
+		v := uint32(c) // two's complement handles negative
+		out[4*i+0] = byte(v >> 24)
+		out[4*i+1] = byte(v >> 16)
+		out[4*i+2] = byte(v >> 8)
+		out[4*i+3] = byte(v)
+	}
+	return out
+}
+
+// sigmaPolyMulN multiplies two polynomials in Z_q[x]/(x^n+1) using O(n²) schoolbook.
+// Used for n<256 where NTT twiddles are not precomputed.
+func sigmaPolyMulN(f, g []int, n, q int) []int {
+	h := make([]int, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			idx := i + j
+			v := int64(f[i]) * int64(g[j])
+			if idx >= n {
+				idx -= n
+				v = -v
+			}
+			h[idx] = int((int64(h[idx]) + v + int64(q)*int64(q)) % int64(q))
+		}
+	}
+	return h
+}
+
+// sigmaChallenge derives a sparse ternary challenge polynomial from (m, C, w, msg).
+// Returns a []int of length n in {0, 1, q-1} with exactly t nonzero entries.
+func sigmaChallenge(mPoly, cPoly, wPoly []int, n, q, t int, msg []byte) []int {
+	buf := make([]byte, 4)
+	buf[0] = byte(n >> 24); buf[1] = byte(n >> 16)
+	buf[2] = byte(n >> 8);  buf[3] = byte(n)
+	data := make([]byte, 0, 4+len(mPoly)*12+len(msg))
+	data = append(data, buf...)
+	data = append(data, sigmaPolyBytes(mPoly)...)
+	data = append(data, sigmaPolyBytes(cPoly)...)
+	data = append(data, sigmaPolyBytes(wPoly)...)
+	data = append(data, msg...)
+	seed := Hfscx256(data, nil)
+
+	// Expand seed to t distinct positions
+	positions := make([]int, 0, t)
+	seen := make(map[int]bool, t)
+	for idx := 0; len(positions) < t; idx++ {
+		ext := Hfscx256(append(seed, append([]byte("pos"), []byte{byte(idx >> 24), byte(idx >> 16), byte(idx >> 8), byte(idx)}...)...), nil)
+		v := (int(ext[0])<<24 | int(ext[1])<<16 | int(ext[2])<<8 | int(ext[3])) & 0x7FFFFFFF
+		v = v % n
+		if !seen[v] {
+			seen[v] = true
+			positions = append(positions, v)
+		}
+	}
+
+	// Assign ±1 signs (stored as Z_q: +1 or q-1)
+	out := make([]int, n)
+	for k, pos := range positions {
+		ext := Hfscx256(append(seed, append([]byte("sgn"), []byte{byte(k >> 24), byte(k >> 16), byte(k >> 8), byte(k)}...)...), nil)
+		if ext[0]&1 == 0 {
+			out[pos] = 1
+		} else {
+			out[pos] = q - 1
+		}
+	}
+	return out
+}
+
+// RnlSigmaSign produces a ZKP-RNL Σ-protocol proof of knowledge of s s.t. C = round_p(m·s).
+// Returns (wPoly, cPoly, zPoly). Returns error if rejection limit is exceeded.
+func RnlSigmaSign(sPoly, mPoly, cPoly []int, n int, msg []byte) (w, c, z []int, err error) {
+	q := RnlQ
+	gamma, t := ZkpRnlParams(n)
+	bound := gamma - t
+	half := q / 2
+
+	polyMul := func(f, g []int) []int {
+		if n == 256 {
+			return RnlPolyMul(f, g, q, n)
+		}
+		return sigmaPolyMulN(f, g, n, q)
+	}
+
+	rangeSz := 2*gamma + 1
+	buf := make([]byte, 4)
+	for attempt := 0; attempt < sigmaMaxAttempts; attempt++ {
+		y := make([]int, n)
+		for i := range y {
+			if _, rerr := rand.Read(buf); rerr != nil {
+				return nil, nil, nil, rerr
+			}
+			v := int(binary.BigEndian.Uint32(buf)) % rangeSz
+			y[i] = v - gamma
+		}
+		yQ := make([]int, n)
+		for i, yi := range y {
+			yQ[i] = ((yi % q) + q) % q
+		}
+		my := polyMul(mPoly, yQ)
+		wLocal := make([]int, n)
+		for i, c := range my {
+			if c > half {
+				wLocal[i] = c - q
+			} else {
+				wLocal[i] = c
+			}
+		}
+		cLocal := sigmaChallenge(mPoly, cPoly, wLocal, n, q, t, msg)
+		cs := polyMul(cLocal, sPoly)
+		csC := make([]int, n)
+		for i, x := range cs {
+			if x > half {
+				csC[i] = x - q
+			} else {
+				csC[i] = x
+			}
+		}
+		zLocal := make([]int, n)
+		ok := true
+		for i := range zLocal {
+			zLocal[i] = y[i] + csC[i]
+			if zLocal[i] > bound || zLocal[i] < -bound {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return wLocal, cLocal, zLocal, nil
+		}
+	}
+	return nil, nil, nil, fmt.Errorf("RnlSigmaSign: rejection sampling limit (%d) reached", sigmaMaxAttempts)
+}
+
+// RnlSigmaVerify verifies a ZKP-RNL Σ-protocol proof (w, c, z) for statement (m, C, msg).
+func RnlSigmaVerify(mPoly, cpoly []int, n int, msg []byte, wPoly, cPoly, zPoly []int) bool {
+	q := RnlQ
+	p := RnlP
+	gamma, t := ZkpRnlParams(n)
+	bound := gamma - t
+	slack := t * (q/(2*p) + 1)
+	half := q / 2
+
+	polyMul := func(f, g []int) []int {
+		if n == 256 {
+			return RnlPolyMul(f, g, q, n)
+		}
+		return sigmaPolyMulN(f, g, n, q)
+	}
+
+	// (1) infinity-norm bound
+	for _, zi := range zPoly {
+		if zi > bound || zi < -bound {
+			return false
+		}
+	}
+	// (2) Fiat-Shamir consistency
+	cRecomputed := sigmaChallenge(mPoly, cpoly, wPoly, n, q, t, msg)
+	for i := range cRecomputed {
+		if cRecomputed[i] != cPoly[i] {
+			return false
+		}
+	}
+	// (3) rounding slack: ||m·z − w − c·lift(C)||∞ ≤ slack
+	zQ := make([]int, n)
+	for i, zi := range zPoly {
+		zQ[i] = ((zi % q) + q) % q
+	}
+	mz := polyMul(mPoly, zQ)
+	lift := RnlLift(cpoly, p, q)
+	ct := polyMul(cPoly, lift)
+	wQ := make([]int, n)
+	for i, wi := range wPoly {
+		wQ[i] = ((wi % q) + q) % q
+	}
+	for i := range mz {
+		d := ((mz[i] - ct[i] - wQ[i]) % q + q) % q
+		dc := d
+		if dc > half {
+			dc = dc - q
+		}
+		if dc > slack || dc < -slack {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// ZKP-NL: NL-FSCX ZKBoo (MPC-in-the-head, 3-party Boolean circuit)
+// SecurityProofs-3.md §11.10.3
+// ---------------------------------------------------------------------------
+
+const (
+	ZkpNlDefaultN   = 8
+	ZkpNlDemoRounds = 4
+	ZkpNlProdRounds = 219
+	ZkpNlMaxN       = 32
+)
+
+// ZkpNlRound holds one round of a ZKBoo proof.
+type ZkpNlRound struct {
+	Com0, Com1, Com2 [32]byte
+	E                int
+	ViewP1, ViewP2   []byte
+}
+
+func zkpNlRol(x uint32, r, n int) uint32 {
+	r = ((r % n) + n) % n
+	if r == 0 {
+		return x
+	}
+	mask := uint32((1 << uint(n)) - 1)
+	return ((x << uint(r)) | (x >> uint(n-r))) & mask
+}
+
+func zkpNlH(parts ...[]byte) []byte {
+	var buf []byte
+	for _, p := range parts {
+		buf = append(buf, p...)
+	}
+	return Hfscx256(buf, nil)
+}
+
+func zkpNlPrgBit(tape []byte, gateID int) int {
+	gidBuf := []byte{byte(gateID >> 24), byte(gateID >> 16), byte(gateID >> 8), byte(gateID)}
+	h := zkpNlH(tape, gidBuf)
+	return int(h[0] & 1)
+}
+
+// zkpNlEvalCircuit evaluates nl_fscx_v1(A, B) in 3-party ZKBoo decomposition.
+// shares: XOR shares of A (A = s0^s1^s2), tapes: 3×32-byte tapes.
+// Returns (outShares[3], gateViews[3][n-1]) where each gate view byte = ai|(ci<<1)|(andOut<<2).
+func zkpNlEvalCircuit(shares [3]uint32, tapes [3][]byte, B uint32, n int) ([3]uint32, [3][]byte) {
+	mask := uint32((1 << uint(n)) - 1)
+	carry := [3]uint32{} // current carry bits per party; starts at 0
+	gateViews := [3][]byte{
+		make([]byte, n-1),
+		make([]byte, n-1),
+		make([]byte, n-1),
+	}
+
+	for i := 0; i < n-1; i++ {
+		var ai, ci, ri [3]int
+		Bi := int((B >> uint(i)) & 1)
+		for p := 0; p < 3; p++ {
+			ai[p] = int((shares[p] >> uint(i)) & 1)
+			ci[p] = int((carry[p] >> uint(i)) & 1)
+			ri[p] = zkpNlPrgBit(tapes[p], i)
+		}
+		var andOut [3]int
+		for p := 0; p < 3; p++ {
+			p1 := (p + 1) % 3
+			andOut[p] = (ai[p]&ci[p])^(ai[p]&ci[p1])^(ai[p1]&ci[p])^ri[p]^ri[p1]
+		}
+		for p := 0; p < 3; p++ {
+			gateViews[p][i] = byte(ai[p] | (ci[p] << 1) | (andOut[p] << 2))
+		}
+		// c_{i+1} = Bi*ai XOR andOut XOR Bi*ci
+		for p := 0; p < 3; p++ {
+			cNext := (Bi*ai[p])^andOut[p]^(Bi*ci[p])
+			if cNext == 1 {
+				carry[p] |= 1 << uint(i+1)
+			} else {
+				carry[p] &^= 1 << uint(i+1)
+			}
+		}
+	}
+
+	// Sum shares: bit i of (A+B) mod 2^n = A_i XOR B_i XOR carry_i (linear)
+	var sumShares [3]uint32
+	for i := 0; i < n; i++ {
+		Bi := uint32((B >> uint(i)) & 1)
+		for p := 0; p < 3; p++ {
+			bit := ((shares[p] >> uint(i)) & 1) ^ Bi ^ ((carry[p] >> uint(i)) & 1)
+			sumShares[p] ^= bit << uint(i)
+		}
+	}
+
+	// ROL_{n/4} (linear — apply identically to each share)
+	var rotShares [3]uint32
+	for p := 0; p < 3; p++ {
+		rotShares[p] = zkpNlRol(sumShares[p], n/4, n)
+	}
+
+	// Linear part: fscx(A, B) with B constant
+	Bconst := (B ^ zkpNlRol(B, 1, n) ^ zkpNlRol(B, n-1, n)) & mask
+	var linShares [3]uint32
+	for p := 0; p < 3; p++ {
+		Aterms := (shares[p] ^ zkpNlRol(shares[p], 1, n) ^ zkpNlRol(shares[p], n-1, n)) & mask
+		linShares[p] = Aterms
+	}
+	linShares[0] ^= Bconst // absorb public constant into party 0 only
+
+	var outShares [3]uint32
+	for p := 0; p < 3; p++ {
+		outShares[p] = (linShares[p] ^ rotShares[p]) & mask
+	}
+	return outShares, gateViews
+}
+
+func zkpNlPackView(share uint32, tape []byte, outShare uint32, gateBytes []byte, n, nb int) []byte {
+	buf := make([]byte, nb+32+nb+len(gateBytes))
+	// share (nb bytes big-endian)
+	for i := nb - 1; i >= 0; i-- {
+		buf[i] = byte(share)
+		share >>= 8
+	}
+	copy(buf[nb:nb+32], tape)
+	// out_share (nb bytes big-endian)
+	os := outShare
+	for i := nb + 32 + nb - 1; i >= nb+32; i-- {
+		buf[i] = byte(os)
+		os >>= 8
+	}
+	copy(buf[nb+32+nb:], gateBytes)
+	return buf
+}
+
+func zkpNlUnpackView(buf []byte, n, nb int) (share uint32, tape []byte, outShare uint32, gv []byte) {
+	share = 0
+	for i := 0; i < nb; i++ {
+		share = (share << 8) | uint32(buf[i])
+	}
+	tape = buf[nb : nb+32]
+	outShare = 0
+	for i := nb + 32; i < nb+32+nb; i++ {
+		outShare = (outShare << 8) | uint32(buf[i])
+	}
+	gv = buf[nb+32+nb:]
+	return
+}
+
+// ZkpNlKeygen generates (A private, B public, y = nl_fscx_v1(A,B) public).
+func ZkpNlKeygen(n int) (A, B, y uint32, err error) {
+	nb := (n + 7) / 8
+	mask := uint32((1 << uint(n)) - 1)
+	buf := make([]byte, nb*2)
+	if _, err = rand.Read(buf); err != nil {
+		return
+	}
+	A = 0
+	for i := 0; i < nb; i++ {
+		A = (A << 8) | uint32(buf[i])
+	}
+	A &= mask
+	B = 0
+	for i := 0; i < nb; i++ {
+		B = (B << 8) | uint32(buf[nb+i])
+	}
+	B &= mask
+	// nl_fscx_v1(A, B) as uint32
+	aBA := NewBitArray(n, new(big.Int).SetUint64(uint64(A)))
+	bBA := NewBitArray(n, new(big.Int).SetUint64(uint64(B)))
+	yBA := NlFscxV1(aBA, bBA)
+	y = uint32(yBA.Val.Uint64()) & mask
+	return
+}
+
+// ZkpNlProve produces a ZKBoo proof that the prover knows A s.t. nl_fscx_v1(A, B) = y.
+func ZkpNlProve(A, B, y uint32, n, rounds int, msg []byte) ([]ZkpNlRound, error) {
+	mask := uint32((1 << uint(n)) - 1)
+	nb := (n + 7) / 8
+
+	type roundData struct {
+		coms      [3][32]byte
+		shares    [3]uint32
+		tapes     [3][]byte
+		outShares [3]uint32
+		gateViews [3][]byte
+	}
+	allData := make([]roundData, rounds)
+	var comBlock []byte
+
+	buf := make([]byte, nb)
+	for j := 0; j < rounds; j++ {
+		var s [3]uint32
+		for k := 0; k < 2; k++ {
+			if _, err := rand.Read(buf); err != nil {
+				return nil, err
+			}
+			s[k] = 0
+			for i := 0; i < nb; i++ {
+				s[k] = (s[k] << 8) | uint32(buf[i])
+			}
+			s[k] &= mask
+		}
+		s[2] = (A ^ s[0] ^ s[1]) & mask
+
+		var tapes [3][]byte
+		for k := 0; k < 3; k++ {
+			tapes[k] = make([]byte, 32)
+			if _, err := rand.Read(tapes[k]); err != nil {
+				return nil, err
+			}
+		}
+
+		outShares, gateViews := zkpNlEvalCircuit(s, tapes, B, n)
+
+		var rd roundData
+		rd.shares = s
+		rd.tapes = tapes
+		rd.outShares = outShares
+		rd.gateViews = gateViews
+
+		jBuf := []byte{byte(j >> 24), byte(j >> 16), byte(j >> 8), byte(j)}
+		for p := 0; p < 3; p++ {
+			osBuf := make([]byte, nb)
+			os := outShares[p]
+			for i := nb - 1; i >= 0; i-- {
+				osBuf[i] = byte(os)
+				os >>= 8
+			}
+			h := zkpNlH(jBuf, []byte{byte(p)}, tapes[p], osBuf)
+			copy(rd.coms[p][:], h)
+			comBlock = append(comBlock, h...)
+		}
+		allData[j] = rd
+	}
+
+	// Fiat-Shamir challenge seed
+	nBuf := make([]byte, nb)
+	bVal := B
+	for i := nb - 1; i >= 0; i-- {
+		nBuf[i] = byte(bVal)
+		bVal >>= 8
+	}
+	yBuf := make([]byte, nb)
+	yVal := y
+	for i := nb - 1; i >= 0; i-- {
+		yBuf[i] = byte(yVal)
+		yVal >>= 8
+	}
+	chSeed := zkpNlH(comBlock, nBuf, yBuf, msg)
+
+	result := make([]ZkpNlRound, rounds)
+	for j := 0; j < rounds; j++ {
+		jBuf := []byte{byte(j >> 24), byte(j >> 16), byte(j >> 8), byte(j)}
+		h := zkpNlH(chSeed, jBuf)
+		e := int(h[0]) % 3
+		p1 := (e + 1) % 3
+		p2 := (e + 2) % 3
+
+		rd := allData[j]
+		result[j].Com0 = rd.coms[0]
+		result[j].Com1 = rd.coms[1]
+		result[j].Com2 = rd.coms[2]
+		result[j].E = e
+		result[j].ViewP1 = zkpNlPackView(rd.shares[p1], rd.tapes[p1], rd.outShares[p1], rd.gateViews[p1], n, nb)
+		result[j].ViewP2 = zkpNlPackView(rd.shares[p2], rd.tapes[p2], rd.outShares[p2], rd.gateViews[p2], n, nb)
+	}
+	return result, nil
+}
+
+// ZkpNlVerify verifies a ZKBoo proof that prover knows A s.t. nl_fscx_v1(A, B) = y.
+func ZkpNlVerify(B, y uint32, n, rounds int, msg []byte, proof []ZkpNlRound) bool {
+	nb := (n + 7) / 8
+
+	// Reconstruct commitment block and Fiat-Shamir seed
+	var comBlock []byte
+	for _, r := range proof {
+		comBlock = append(comBlock, r.Com0[:]...)
+		comBlock = append(comBlock, r.Com1[:]...)
+		comBlock = append(comBlock, r.Com2[:]...)
+	}
+	nBuf := make([]byte, nb)
+	bVal := B
+	for i := nb - 1; i >= 0; i-- {
+		nBuf[i] = byte(bVal); bVal >>= 8
+	}
+	yBuf := make([]byte, nb)
+	yVal := y
+	for i := nb - 1; i >= 0; i-- {
+		yBuf[i] = byte(yVal); yVal >>= 8
+	}
+	chSeed := zkpNlH(comBlock, nBuf, yBuf, msg)
+
+	eqBytes := func(a []byte, b [32]byte) bool {
+		if len(a) < 32 {
+			return false
+		}
+		for i := 0; i < 32; i++ {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	osBuf := func(v uint32) []byte {
+		b := make([]byte, nb)
+		for i := nb - 1; i >= 0; i-- {
+			b[i] = byte(v); v >>= 8
+		}
+		return b
+	}
+
+	for j, r := range proof {
+		jBuf := []byte{byte(j >> 24), byte(j >> 16), byte(j >> 8), byte(j)}
+		h := zkpNlH(chSeed, jBuf)
+		e := int(h[0]) % 3
+		if e != r.E {
+			return false
+		}
+		p1 := (e + 1) % 3
+		p2 := (e + 2) % 3
+
+		shareP1, tapeP1, outP1, gvP1 := zkpNlUnpackView(r.ViewP1, n, nb)
+		shareP2, tapeP2, outP2, gvP2 := zkpNlUnpackView(r.ViewP2, n, nb)
+
+		// Verify commitments for revealed parties
+		c1h := zkpNlH(jBuf, []byte{byte(p1)}, tapeP1, osBuf(outP1))
+		if !eqBytes(c1h, r.comAt(p1)) {
+			return false
+		}
+		c2h := zkpNlH(jBuf, []byte{byte(p2)}, tapeP2, osBuf(outP2))
+		if !eqBytes(c2h, r.comAt(p2)) {
+			return false
+		}
+
+		// Re-evaluate p1's AND gates using both revealed shares
+		var carryP1, carryP2 uint32
+		for i := 0; i < n-1; i++ {
+			aiP1 := int((shareP1 >> uint(i)) & 1)
+			aiP2 := int((shareP2 >> uint(i)) & 1)
+			ciP1 := int((carryP1 >> uint(i)) & 1)
+			ciP2 := int((carryP2 >> uint(i)) & 1)
+			Bi   := int((B >> uint(i)) & 1)
+
+			riP1 := zkpNlPrgBit(tapeP1, i)
+			riP2 := zkpNlPrgBit(tapeP2, i)
+
+			expAndP1 := (aiP1&ciP1) ^ (aiP1&ciP2) ^ (aiP2&ciP1) ^ riP1 ^ riP2
+			if int((gvP1[i]>>2)&1) != expAndP1 {
+				return false
+			}
+			andOutP2 := int((gvP2[i] >> 2) & 1)
+
+			cNextP1 := (Bi*aiP1) ^ expAndP1 ^ (Bi * ciP1)
+			if cNextP1 == 1 { carryP1 |= 1 << uint(i+1) } else { carryP1 &^= 1 << uint(i+1) }
+			cNextP2 := (Bi*aiP2) ^ andOutP2 ^ (Bi * ciP2)
+			if cNextP2 == 1 { carryP2 |= 1 << uint(i+1) } else { carryP2 &^= 1 << uint(i+1) }
+		}
+	}
+	return true
+}
+
+// comAt returns the commitment for party p (0, 1, or 2).
+func (r *ZkpNlRound) comAt(p int) [32]byte {
+	switch p {
+	case 0: return r.Com0
+	case 1: return r.Com1
+	default: return r.Com2
+	}
+}


### PR DESCRIPTION
## Summary

Completes TODO #77 in 9 batches across all language targets, CLI, test suite, and documentation.

- **Batches 1–3 (v1.9.5–v1.9.7):** ZKP-RNL (Ring-LWR Σ-protocol) and ZKP-NL (NL-FSCX ZKBoo) library implementation in Python, C (`herradura.h`), and Go (`herradura/herradura.go`), plus CLI extensions in all three CLIs (`genpkey hpks-zkp-nl`, `sign/verify rnl-sigma`, `sign/verify nl-zkboo`).
- **Batches 4–5 (v1.9.8–v1.9.9):** ARM Thumb-2 and NASM i386 targets — `rnl_sigma_sign_32`/`rnl_sigma_verify_32` (ZKP-RNL at n=32).
- **Batch 6 (v1.9.10):** Arduino `.ino` — ZKP-RNL (n=32) + ZKBoo (n=8, R=4 demo), all-static allocation for Arduino Mega.
- **Batch 7 (v1.9.11):** `CryptosuiteTests/` — ZKP-RNL + ZKP-NL security tests [21][22] and benchmarks [33][34] (C); [20][21] / [32][33] (Go, Python). Tests call production library functions.
- **Batch 8 (v1.9.12):** 5 new `CliTest/` scripts including a 14-way cross-language interop test (Python↔C↔Go for both ZKP-RNL and ZKP-NL). Python CLI `"Proof OK"` → `"Signature OK"` consistency fix.
- **Batch 9 (v1.9.13):** `docs/TUTORIAL.md` — new `## ZKP Protocols` section with C/Go/Py API walk-through, CLI usage, and proof-size comparison table. `SecurityProofs-3.md` — new §11.10.4 Suite Implementation subsection; §11.10.4→§11.10.5/§11.10.6 renumber; applicability matrix updated to "Implemented v1.9.x".

**Proof sizes:** ZKP-RNL at n=256 = **1,056 B** (smaller than ML-DSA-44 at 2,420 B and HPKS-Stern-F at 78 KB). ZKP-NL at n=8 R=219 = 35.5 KB; at n=256 R=219 = 920 KB (awaits ZKB++ optimisation).

## Test plan

- [ ] `bash CliTest/test_zkp_rnl.sh` — Python CLI ZKP-RNL round-trip (3 checks: correct, wrong-msg, wrong-key)
- [ ] `bash CliTest/test_zkp_nl.sh` — Python CLI ZKP-NL round-trip (3 checks)
- [ ] `bash CliTest/test_c_zkp_rnl.sh` — C CLI ZKP-RNL round-trip (requires `build_c.sh`)
- [ ] `bash CliTest/test_go_zkp_rnl.sh` — Go CLI ZKP-RNL round-trip (requires `build_go.sh`)
- [ ] `bash CliTest/test_zkp_interop.sh` — 14-way cross-language interop (all 3 CLIs built)
- [ ] `./CryptosuiteTests/Herradura_tests_c` — tests [21][22] ZKP-RNL+ZKP-NL correctness; benches [33][34]
- [ ] `python3 CryptosuiteTests/Herradura_tests.py` — tests [20][21]; benches [32][33]

🤖 Generated with [Claude Code](https://claude.com/claude-code)