### PR TITLE
TODO #80: OPRF + aPAKE library and CLI (Python/C/Go, Batches 1-4, 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.24] - 2026-06-09
+
+### Feature — OPRF library + Python CLI (TODO #80 Batch 1)
+
+- **Python suite** (`Herradura cryptographic suite.py`): added 2HashDH OPRF over GF(2^256)* — `oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`; demo block in `main()` validates blind/eval/unblind round-trip and aPAKE pw_key derivation.
+- **`HerraduraCli/primitives.py`**: exports all five `oprf_*` symbols.
+- **Python CLI** (`HerraduraCli/herradura.py`): `genpkey --algo oprf` generates OPRF server key (PEM label `HERRADURA OPRF PRIVATE KEY`); `oprf-blind` (client blinding → `HERRADURA OPRF CLIENT STATE`), `oprf-eval` (server evaluation → `HERRADURA OPRF EVALUATION`), `oprf-unblind` (client unblinding → PRF output hex).
+- **`CliTest/test_oprf.sh`**: 8 Python CLI integration tests — keygen, blind, eval, unblind, determinism, different-input, different-key, pkey inspect — all passing.
+
+---
+
 ## [1.9.23] - 2026-06-09
 
 ### Research — Non-Abelian KEX analysis: orbit sweep, non-abelianness, Ko-Lee viability (TODO #78.E)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.25] - 2026-06-09
+
+### Feature — OPRF C+Go library + CLI + cross-language interop tests (TODO #80 Batches 2, 3, 6)
+
+- **`herradura.h`**: added `ba_cmp256`, `_ba33_cmp`, `_ba33_iszero`, `ba_modinv_ord` (binary extended GCD mod 2^256-1 with coprimality retry), `oprf_hash_to_field`, `oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`; OPRF demo block added to `Herradura cryptographic suite.c` `main()`.
+- **`HerraduraCli/herradura_codec.h`**: added `PEM_OPRF_PRIV`, `PEM_OPRF_STATE`, `PEM_OPRF_EVAL` label constants.
+- **`HerraduraCli/herradura_cli.c`**: `genpkey --algo oprf`, `oprf-blind`, `oprf-eval`, `oprf-unblind` subcommands; `ba_from_der_item` helper; usage text updated.
+- **`herradura/herradura.go`**: added `OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`, `oprfOrd`, `oprfHashToField`; OPRF demo block added to `Herradura cryptographic suite.go` `main()`.
+- **`HerraduraCli/herradura_cli.go`**: `lblOprfPriv`/`lblOprfState`/`lblOprfEval` constants; `genpkey --algo oprf`; `cmdOprfBlind`, `cmdOprfEval`, `cmdOprfUnblind` functions; dispatch cases.
+- **`CliTest/test_c_oprf.sh`**: 7 C CLI integration tests — all passing.
+- **`CliTest/test_go_oprf.sh`**: 7 Go CLI integration tests — all passing.
+- **`CliTest/test_oprf_interop.sh`**: 8 cross-language interop tests (Python/C/Go key × blind × eval × unblind) — all passing.
+
+---
+
 ## [1.9.24] - 2026-06-09
 
 ### Feature — OPRF library + Python CLI (TODO #80 Batch 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.26] - 2026-06-09
+
+### Feature — aPAKE Python suite + CLI (TODO #80 Batch 4)
+
+- **Python suite** (`Herradura cryptographic suite.py`): added `hpake_register`, `hpake_login_demo`, `_hpake_derive_zkp_witness`, `_hpake_rnl_kdf` — aPAKE (augmented PAKE) using HKEX-RNL + ZKBoo + OPRF; demo block in `main()` validates correct-password login and wrong-password rejection; module docstring updated.
+- **`HerraduraCli/primitives.py`**: exports `hpake_register`, `hpake_login_demo`.
+- **Python CLI** (`HerraduraCli/herradura.py`): `pake-register` (outputs `HERRADURA PAKE RECORD` PEM), `pake-demo` (runs full both-sides auth demo); `_LABEL_PAKE_RECORD` constant; dispatch table entries.
+- **`CliTest/test_pake.sh`**: 7 Python CLI aPAKE integration tests — all passing.
+
+---
+
 ## [1.9.25] - 2026-06-09
 
 ### Feature — OPRF C+Go library + CLI + cross-language interop tests (TODO #80 Batches 2, 3, 6)

--- a/CliTest/test_c_oprf.sh
+++ b/CliTest/test_c_oprf.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# CliTest/test_c_oprf.sh — C CLI OPRF integration tests (TODO #80 Batch 2)
+set -euo pipefail
+
+CLI="./HerraduraCli/herradura_cli"
+PASS=0; FAIL=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc"; FAIL=$((FAIL+1))
+    fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+echo "=== OPRF C CLI tests ==="
+
+# 1. Key generation
+$CLI genpkey --algo oprf --out "$T/srv.pem"
+check "genpkey --algo oprf produces OPRF PRIVATE KEY PEM" \
+    grep -q "HERRADURA OPRF PRIVATE KEY" "$T/srv.pem"
+
+# 2. Blind
+printf '%s' "test-input-value" > "$T/input.bin"
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state.pem"
+check "oprf-blind produces CLIENT STATE PEM" \
+    grep -q "HERRADURA OPRF CLIENT STATE" "$T/state.pem"
+
+# 3. Eval
+$CLI oprf-eval --key "$T/srv.pem" --in "$T/state.pem" --out "$T/eval.pem"
+check "oprf-eval produces EVALUATION PEM" \
+    grep -q "HERRADURA OPRF EVALUATION" "$T/eval.pem"
+
+# 4. Unblind produces 64-char hex
+OUT=$($CLI oprf-unblind --state "$T/state.pem" --eval "$T/eval.pem" | tr -d '\n')
+check "oprf-unblind output is 64-char hex" test "${#OUT}" -eq 64
+
+# 5. Determinism
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state2.pem"
+$CLI oprf-eval  --key "$T/srv.pem"  --in "$T/state2.pem" --out "$T/eval2.pem"
+OUT2=$($CLI oprf-unblind --state "$T/state2.pem" --eval "$T/eval2.pem" | tr -d '\n')
+check "OPRF is deterministic: same input+key → same output" test "$OUT" = "$OUT2"
+
+# 6. Different input → different output
+printf '%s' "different-input" > "$T/input2.bin"
+$CLI oprf-blind --in "$T/input2.bin" --out "$T/state3.pem"
+$CLI oprf-eval  --key "$T/srv.pem"   --in "$T/state3.pem" --out "$T/eval3.pem"
+OUT3=$($CLI oprf-unblind --state "$T/state3.pem" --eval "$T/eval3.pem" | tr -d '\n')
+check "Different input → different PRF output" test "$OUT" != "$OUT3"
+
+# 7. Different key → different output
+$CLI genpkey --algo oprf --out "$T/srv2.pem"
+$CLI oprf-blind --in "$T/input.bin"  --out "$T/state4.pem"
+$CLI oprf-eval  --key "$T/srv2.pem"  --in "$T/state4.pem" --out "$T/eval4.pem"
+OUT4=$($CLI oprf-unblind --state "$T/state4.pem" --eval "$T/eval4.pem" | tr -d '\n')
+check "Different server key → different PRF output" test "$OUT" != "$OUT4"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/CliTest/test_go_oprf.sh
+++ b/CliTest/test_go_oprf.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# CliTest/test_go_oprf.sh — Go CLI OPRF integration tests (TODO #80 Batch 3)
+set -euo pipefail
+
+CLI="./HerraduraCli/herradura_cli_go"
+PASS=0; FAIL=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc"; FAIL=$((FAIL+1))
+    fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+echo "=== OPRF Go CLI tests ==="
+
+# 1. Key generation
+$CLI genpkey --algo oprf --out "$T/srv.pem"
+check "genpkey --algo oprf produces OPRF PRIVATE KEY PEM" \
+    grep -q "HERRADURA OPRF PRIVATE KEY" "$T/srv.pem"
+
+# 2. Blind
+printf '%s' "test-input-value" > "$T/input.bin"
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state.pem"
+check "oprf-blind produces CLIENT STATE PEM" \
+    grep -q "HERRADURA OPRF CLIENT STATE" "$T/state.pem"
+
+# 3. Eval
+$CLI oprf-eval --key "$T/srv.pem" --in "$T/state.pem" --out "$T/eval.pem"
+check "oprf-eval produces EVALUATION PEM" \
+    grep -q "HERRADURA OPRF EVALUATION" "$T/eval.pem"
+
+# 4. Unblind produces 64-char hex
+OUT=$($CLI oprf-unblind --state "$T/state.pem" --eval "$T/eval.pem" | tr -d '\n')
+check "oprf-unblind output is 64-char hex" test "${#OUT}" -eq 64
+
+# 5. Determinism
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state2.pem"
+$CLI oprf-eval  --key "$T/srv.pem"  --in "$T/state2.pem" --out "$T/eval2.pem"
+OUT2=$($CLI oprf-unblind --state "$T/state2.pem" --eval "$T/eval2.pem" | tr -d '\n')
+check "OPRF is deterministic: same input+key → same output" test "$OUT" = "$OUT2"
+
+# 6. Different input → different output
+printf '%s' "different-input" > "$T/input2.bin"
+$CLI oprf-blind --in "$T/input2.bin" --out "$T/state3.pem"
+$CLI oprf-eval  --key "$T/srv.pem"   --in "$T/state3.pem" --out "$T/eval3.pem"
+OUT3=$($CLI oprf-unblind --state "$T/state3.pem" --eval "$T/eval3.pem" | tr -d '\n')
+check "Different input → different PRF output" test "$OUT" != "$OUT3"
+
+# 7. Different key → different output
+$CLI genpkey --algo oprf --out "$T/srv2.pem"
+$CLI oprf-blind --in "$T/input.bin"  --out "$T/state4.pem"
+$CLI oprf-eval  --key "$T/srv2.pem"  --in "$T/state4.pem" --out "$T/eval4.pem"
+OUT4=$($CLI oprf-unblind --state "$T/state4.pem" --eval "$T/eval4.pem" | tr -d '\n')
+check "Different server key → different PRF output" test "$OUT" != "$OUT4"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/CliTest/test_oprf.sh
+++ b/CliTest/test_oprf.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# CliTest/test_oprf.sh — Python CLI OPRF integration tests (TODO #80)
+set -euo pipefail
+
+CLI="python3 HerraduraCli/herradura.py"
+PASS=0; FAIL=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc"; FAIL=$((FAIL+1))
+    fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+echo "=== OPRF Python CLI tests ==="
+
+# 1. Key generation
+$CLI genpkey --algo oprf --out "$T/srv.pem"
+check "genpkey --algo oprf produces OPRF PRIVATE KEY PEM" \
+    grep -q "HERRADURA OPRF PRIVATE KEY" "$T/srv.pem"
+
+# 2. Blind
+echo -n "test-input-value" > "$T/input.bin"
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state.pem"
+check "oprf-blind produces CLIENT STATE PEM" \
+    grep -q "HERRADURA OPRF CLIENT STATE" "$T/state.pem"
+
+# 3. Eval
+$CLI oprf-eval --key "$T/srv.pem" --in "$T/state.pem" --out "$T/eval.pem"
+check "oprf-eval produces EVALUATION PEM" \
+    grep -q "HERRADURA OPRF EVALUATION" "$T/eval.pem"
+
+# 4. Unblind produces 64-char hex
+OUT=$($CLI oprf-unblind --state "$T/state.pem" --eval "$T/eval.pem")
+check "oprf-unblind output is 64-char hex" test "${#OUT}" -eq 64
+
+# 5. Determinism: same input + same key → same PRF output
+$CLI oprf-blind --in "$T/input.bin" --out "$T/state2.pem"
+$CLI oprf-eval  --key "$T/srv.pem"  --in "$T/state2.pem" --out "$T/eval2.pem"
+OUT2=$($CLI oprf-unblind --state "$T/state2.pem" --eval "$T/eval2.pem")
+check "OPRF is deterministic: same input+key → same output" test "$OUT" = "$OUT2"
+
+# 6. Different input → different PRF output
+echo -n "different-input" > "$T/input2.bin"
+$CLI oprf-blind --in "$T/input2.bin" --out "$T/state3.pem"
+$CLI oprf-eval  --key "$T/srv.pem"   --in "$T/state3.pem" --out "$T/eval3.pem"
+OUT3=$($CLI oprf-unblind --state "$T/state3.pem" --eval "$T/eval3.pem")
+check "Different input → different PRF output" test "$OUT" != "$OUT3"
+
+# 7. Different key → different PRF output
+$CLI genpkey --algo oprf --out "$T/srv2.pem"
+$CLI oprf-blind --in "$T/input.bin"  --out "$T/state4.pem"
+$CLI oprf-eval  --key "$T/srv2.pem"  --in "$T/state4.pem" --out "$T/eval4.pem"
+OUT4=$($CLI oprf-unblind --state "$T/state4.pem" --eval "$T/eval4.pem")
+check "Different server key → different PRF output" test "$OUT" != "$OUT4"
+
+# 8. pkey inspect works on OPRF key
+check "pkey --text works on OPRF key" \
+    bash -c '$0 pkey --in "$1" --text > /dev/null' "$CLI" "$T/srv.pem"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/CliTest/test_oprf_interop.sh
+++ b/CliTest/test_oprf_interop.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# CliTest/test_oprf_interop.sh — Cross-language OPRF interoperability tests (TODO #80 Batch 6)
+# Tests all 6 key×blind×eval×unblind language combinations across Python, C, Go.
+set -euo pipefail
+
+PY="python3 HerraduraCli/herradura.py"
+CC="./HerraduraCli/herradura_cli"
+GO="./HerraduraCli/herradura_cli_go"
+PASS=0; FAIL=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc"; FAIL=$((FAIL+1))
+    fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+printf '%s' "interop-test-input" > "$T/input.bin"
+
+echo "=== OPRF cross-language interop tests ==="
+
+run_combo() {
+    local key_cli="$1" blind_cli="$2" eval_cli="$3" unblind_cli="$4" label="$5"
+    $key_cli genpkey --algo oprf --out "$T/srv_${label}.pem"
+    $blind_cli oprf-blind --in "$T/input.bin" --out "$T/state_${label}.pem"
+    $eval_cli oprf-eval --key "$T/srv_${label}.pem" --in "$T/state_${label}.pem" --out "$T/eval_${label}.pem"
+    local out
+    out=$($unblind_cli oprf-unblind --state "$T/state_${label}.pem" --eval "$T/eval_${label}.pem" | tr -d '\n')
+    echo "$out"
+}
+
+# Reference: all-Python
+REF=$(run_combo "$PY" "$PY" "$PY" "$PY" "pp")
+check "Python→Python (baseline, 64 chars)" test "${#REF}" -eq 64
+
+# Python key, C blind+eval, Go unblind
+OUT=$(run_combo "$PY" "$CC" "$CC" "$GO" "pcc_gu")
+check "Python key / C blind+eval / Go unblind" test "${#OUT}" -eq 64
+
+# Python key, Go blind+eval, C unblind
+OUT=$(run_combo "$PY" "$GO" "$GO" "$CC" "pgg_cu")
+check "Python key / Go blind+eval / C unblind" test "${#OUT}" -eq 64
+
+# C key, Python blind+eval, Go unblind
+OUT=$(run_combo "$CC" "$PY" "$PY" "$GO" "cpp_gu")
+check "C key / Python blind+eval / Go unblind" test "${#OUT}" -eq 64
+
+# C key, Go blind+eval, Python unblind
+OUT=$(run_combo "$CC" "$GO" "$GO" "$PY" "cgg_pu")
+check "C key / Go blind+eval / Python unblind" test "${#OUT}" -eq 64
+
+# Go key, Python blind+eval, C unblind
+OUT=$(run_combo "$GO" "$PY" "$PY" "$CC" "gpp_cu")
+check "Go key / Python blind+eval / C unblind" test "${#OUT}" -eq 64
+
+# Go key, C blind+eval, Python unblind
+OUT=$(run_combo "$GO" "$CC" "$CC" "$PY" "gcc_pu")
+check "Go key / C blind+eval / Python unblind" test "${#OUT}" -eq 64
+
+# Cross-language eval: Python blind, C eval, Go unblind (mixed eval)
+$PY genpkey --algo oprf --out "$T/srv_x.pem"
+$PY oprf-blind --in "$T/input.bin" --out "$T/state_x.pem"
+$CC oprf-eval --key "$T/srv_x.pem" --in "$T/state_x.pem" --out "$T/eval_xc.pem"
+OUT_C=$($GO oprf-unblind --state "$T/state_x.pem" --eval "$T/eval_xc.pem" | tr -d '\n')
+$GO oprf-eval --key "$T/srv_x.pem" --in "$T/state_x.pem" --out "$T/eval_xg.pem"
+OUT_G=$($PY oprf-unblind --state "$T/state_x.pem" --eval "$T/eval_xg.pem" | tr -d '\n')
+check "C eval == Go eval (same alpha+key → same beta)" test "$OUT_C" = "$OUT_G"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/CliTest/test_pake.sh
+++ b/CliTest/test_pake.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# CliTest/test_pake.sh — Python CLI aPAKE integration tests (TODO #80 Batch 4)
+set -euo pipefail
+
+CLI="python3 HerraduraCli/herradura.py"
+PASS=0; FAIL=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $desc"; FAIL=$((FAIL+1))
+    fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+echo "=== aPAKE Python CLI tests ==="
+
+# 1. Generate OPRF server key
+$CLI genpkey --algo oprf --out "$T/oprf.pem"
+check "OPRF server key generated" grep -q "HERRADURA OPRF PRIVATE KEY" "$T/oprf.pem"
+
+# 2. pake-register: produces PAKE RECORD PEM
+$CLI pake-register --key "$T/oprf.pem" --username alice --password s3cr3t --out "$T/record.pem"
+check "pake-register produces PAKE RECORD PEM" grep -q "HERRADURA PAKE RECORD" "$T/record.pem"
+
+# 3. pake-demo: correct password succeeds
+$CLI pake-demo --key "$T/oprf.pem" --username alice --password s3cr3t > "$T/demo_out.txt"
+check "pake-demo: correct password shows session key" \
+    grep -q "aPAKE login succeeded" "$T/demo_out.txt"
+check "pake-demo: wrong password correctly rejected" \
+    grep -q "correctly rejects wrong password" "$T/demo_out.txt"
+
+# 4. pake-demo: session key is 64-char hex
+SK=$(grep "session key:" "$T/demo_out.txt" | sed 's/.*session key: //' | tr -d '\n')
+check "pake-demo: session key is 64-char hex" test "${#SK}" -eq 64
+
+# 5. Different passwords → different session keys
+$CLI pake-demo --key "$T/oprf.pem" --username bob --password pass1 > "$T/demo1.txt"
+$CLI pake-demo --key "$T/oprf.pem" --username bob --password pass2 > "$T/demo2.txt"
+SK1=$(grep "session key:" "$T/demo1.txt" | sed 's/.*session key: //' | tr -d '\n')
+SK2=$(grep "session key:" "$T/demo2.txt" | sed 's/.*session key: //' | tr -d '\n')
+check "Different passwords → different session keys" test "$SK1" != "$SK2"
+
+# 6. Different OPRF keys → different session keys for same password
+$CLI genpkey --algo oprf --out "$T/oprf2.pem"
+$CLI pake-demo --key "$T/oprf.pem"  --password same-pw > "$T/demo3.txt"
+$CLI pake-demo --key "$T/oprf2.pem" --password same-pw > "$T/demo4.txt"
+SK3=$(grep "session key:" "$T/demo3.txt" | sed 's/.*session key: //' | tr -d '\n')
+SK4=$(grep "session key:" "$T/demo4.txt" | sed 's/.*session key: //' | tr -d '\n')
+check "Different OPRF keys → different session keys" test "$SK3" != "$SK4"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -758,6 +758,24 @@ int main(void)
 #undef RING_K
     }
 
+    /* 80 — OPRF demo (blind / eval / unblind round-trip) */
+    puts("*** OPRF (80) — 2HashDH over GF(2^256)*");
+    {
+        BitArray oprf_k, oprf_r, oprf_alpha, oprf_beta, oprf_F, oprf_check;
+        const char *oprf_msg = "oprf-demo-input";
+        oprf_keygen(&oprf_k, urnd);
+        oprf_blind((const uint8_t*)oprf_msg, strlen(oprf_msg), &oprf_r, &oprf_alpha, urnd);
+        oprf_eval(&oprf_beta, &oprf_alpha, &oprf_k);
+        oprf_unblind(&oprf_F, &oprf_beta, &oprf_r);
+        oprf_direct(&oprf_check, (const uint8_t*)oprf_msg, strlen(oprf_msg), &oprf_k);
+        if (memcmp(oprf_F.b, oprf_check.b, KEYBYTES) == 0)
+            puts("- OPRF blind/eval/unblind round-trip correct");
+        else
+            puts("+ OPRF round-trip failed!");
+        explicit_bzero(&oprf_k, sizeof(oprf_k));
+        explicit_bzero(&oprf_r, sizeof(oprf_r));
+    }
+
     fclose(urnd);
     /* SA-09: clear private key material from stack before return */
     explicit_bzero(&a,         sizeof(a));

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -511,4 +511,28 @@ func main() {
 			fmt.Println("+ Ratchet: duplicate message keys!")
 		}
 	}
+
+	// ── 80 — OPRF demo ───────────────────────────────────────────────────────
+	fmt.Println("\n*** OPRF (80) — 2HashDH over GF(2^256)*")
+	{
+		oprfMsg := []byte("oprf-demo-input")
+		k, err := OprfKeygen(256)
+		if err != nil {
+			fmt.Println("+ OprfKeygen error:", err)
+		} else {
+			r, alpha, err2 := OprfBlind(oprfMsg, 256)
+			if err2 != nil {
+				fmt.Println("+ OprfBlind error:", err2)
+			} else {
+				beta   := OprfEval(alpha, k, 256)
+				F      := OprfUnblind(beta, r, 256)
+				Fdirect := OprfDirect(oprfMsg, k, 256)
+				if F.Cmp(Fdirect) == 0 {
+					fmt.Println("- OPRF blind/eval/unblind round-trip correct")
+				} else {
+					fmt.Println("+ OPRF round-trip failed!")
+				}
+			}
+		}
+	}
 }

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -153,6 +153,7 @@
         rnl_sigma_sign, rnl_sigma_verify  (ZKP-RNL: Ring-LWR Σ-protocol)
         zkp_nl_keygen, zkp_nl_prove, zkp_nl_verify  (ZKP-NL: NL-FSCX ZKBoo)
         oprf_keygen, oprf_blind, oprf_eval, oprf_unblind, oprf_direct  (OPRF: 2HashDH over GF(2^n)*)
+        hpake_register, hpake_login_demo  (aPAKE: HKEX-RNL + ZKBoo + OPRF augmented PAKE)
 
     Key module constants: KEYBITS, I_VALUE, R_VALUE, GF_POLY, GF_GEN, ORD,
         RNLQ, RNLP, RNLPP, RNLB, SDFNR, SDFT, SDFR.
@@ -1845,6 +1846,105 @@ def oprf_direct(x: bytes, k: int) -> int:
 
 
 # ---------------------------------------------------------------------------
+# 80 — aPAKE (augmented PAKE) over HKEX-RNL + ZKBoo + OPRF  (TODO #80 Batch 4)
+# OPRF upgrade: server record stores OPRF output F(oprf_key, password) instead
+# of a plain password hash, preventing offline dictionary attacks even if the
+# server database is compromised (attacker cannot evaluate F without oprf_key).
+# ---------------------------------------------------------------------------
+
+_HPAKE_ZKP_N       = 32     # ZKBoo witness width (demo; production: 256)
+_HPAKE_ROUNDS      = 16     # ZKBoo rounds (soundness (2/3)^16 ≈ 0.15%; production: 219)
+_HPAKE_ZKP_A_LABEL = b"ZKP-A"
+_HPAKE_AUTH_LABEL  = b"PAKE-AUTH-v1"
+_HPAKE_SESSION_LBL = b"PAKE-SESSION-v1"
+
+
+def _hpake_derive_zkp_witness(pw_oprf_output: bytes) -> int:
+    """Domain-separate a _HPAKE_ZKP_N-bit ZKBoo witness from the OPRF output."""
+    mask = (1 << _HPAKE_ZKP_N) - 1
+    return int.from_bytes(hfscx_256(pw_oprf_output + _HPAKE_ZKP_A_LABEL), 'big') & mask
+
+
+def _hpake_rnl_kdf(K_raw: 'BitArray') -> bytes:
+    """HKEX-RNL session KDF (matches suite demo pattern)."""
+    sk = nl_fscx_revolve_v1(
+        BitArray(KEYBITS, K_raw.rotated(KEYBITS // 8).uint ^ _RNL_KDF_DC_256),
+        K_raw, KEYBITS // 4)
+    return sk.bytes
+
+
+def hpake_register(username: str, password: bytes, oprf_key: int) -> dict:
+    """
+    aPAKE registration.  Returns a server record containing (username, salt, B, y).
+    The OPRF output is used as the password hash — server cannot offline-attack
+    passwords without the oprf_key.
+    username: client identifier (stored in record for lookup).
+    password: raw password bytes.
+    oprf_key: server OPRF private key (integer from oprf_keygen()).
+    """
+    salt           = os.urandom(32)
+    pw_oprf_out    = oprf_direct(password, oprf_key)
+    pw_oprf_bytes  = pw_oprf_out.to_bytes(KEYBITS // 8, 'big')
+    zkp_A          = _hpake_derive_zkp_witness(pw_oprf_bytes)
+    mask           = (1 << _HPAKE_ZKP_N) - 1
+    B              = int.from_bytes(os.urandom(_HPAKE_ZKP_N // 8), 'big') & mask
+    y              = nl_fscx_v1(BitArray(_HPAKE_ZKP_N, zkp_A),
+                                 BitArray(_HPAKE_ZKP_N, B)).uint
+    return {'username': username, 'salt': salt, 'B': B, 'y': y}
+
+
+def hpake_login_demo(record: dict, password: bytes, oprf_key: int) -> 'bytes | None':
+    """
+    aPAKE login (both-sides demo — client and server in one call).
+    Performs the full 3-message HKEX-RNL + ZKBoo exchange and returns the
+    shared session key on success, or None if the password is wrong.
+    record:   server record from hpake_register().
+    password: raw password bytes (client-side input).
+    oprf_key: server OPRF private key (same key used during registration).
+    """
+    salt, B, y = record['salt'], record['B'], record['y']
+
+    # Client: OPRF evaluation to derive pw_oprf_out
+    pw_oprf_out   = oprf_direct(password, oprf_key)
+    pw_oprf_bytes = pw_oprf_out.to_bytes(KEYBITS // 8, 'big')
+    zkp_A         = _hpake_derive_zkp_witness(pw_oprf_bytes)
+
+    # Fast local verifier check (aborts before ZKBoo if wrong password)
+    mask    = (1 << _HPAKE_ZKP_N) - 1
+    y_check = nl_fscx_v1(BitArray(_HPAKE_ZKP_N, zkp_A),
+                          BitArray(_HPAKE_ZKP_N, B)).uint
+    if y_check != y:
+        return None
+
+    # Client: ephemeral HKEX-RNL keypair
+    m_base  = _rnl_m_poly(KEYBITS)
+    a_rand  = _rnl_rand_poly(KEYBITS, RNLQ)
+    m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
+    s_c, C_c = _rnl_keygen(m_blind, KEYBITS, RNLQ, RNLP, RNLB)
+
+    # Server: ephemeral HKEX-RNL keypair (uses client's m_blind)
+    s_s, C_s = _rnl_keygen(m_blind, KEYBITS, RNLQ, RNLP, RNLB)
+
+    # Client: HKEX-RNL reconciliation (generates hint)
+    K_raw_c, hint = _rnl_agree(s_c, C_s, RNLQ, RNLP, RNLPP, KEYBITS, KEYBITS)
+
+    # Server: HKEX-RNL reconciliation (uses hint)
+    K_raw_s = _rnl_agree(s_s, C_c, RNLQ, RNLP, RNLPP, KEYBITS, KEYBITS, hint)
+
+    # Client: ZKBoo proof of knowledge of zkp_A bound to session key
+    auth_msg = K_raw_c.bytes + _HPAKE_AUTH_LABEL
+    proof    = zkp_nl_prove(zkp_A, B, y, _HPAKE_ZKP_N, _HPAKE_ROUNDS, auth_msg)
+
+    # Server: ZKBoo verification
+    auth_msg_s = K_raw_s.bytes + _HPAKE_AUTH_LABEL
+    if not zkp_nl_verify(B, y, _HPAKE_ZKP_N, _HPAKE_ROUNDS, auth_msg_s, proof):
+        return None
+
+    # Session key: hfscx_256(KDF(K_raw) ‖ label)
+    return hfscx_256(_hpake_rnl_kdf(K_raw_c) + _HPAKE_SESSION_LBL)
+
+
+# ---------------------------------------------------------------------------
 # Protocol documentation
 # ---------------------------------------------------------------------------
 '''
@@ -2369,6 +2469,21 @@ def main():
         print("- OPRF aPAKE: pw_key derived from OPRF output is deterministic")
     else:
         print("+ OPRF aPAKE pw_key mismatch!")
+
+    # 80 — aPAKE demo (register + login with correct password + wrong password)
+    print("*** aPAKE (80) — HKEX-RNL + ZKBoo + OPRF augmented PAKE")
+    _pake_key     = oprf_keygen()
+    _pake_record  = hpake_register("alice", b"s3cr3t-pw", _pake_key)
+    _pake_sk      = hpake_login_demo(_pake_record, b"s3cr3t-pw", _pake_key)
+    if _pake_sk is not None:
+        print("- aPAKE login with correct password: session key established")
+    else:
+        print("+ aPAKE login with correct password: FAILED!")
+    _pake_sk_bad  = hpake_login_demo(_pake_record, b"wrong-pw", _pake_key)
+    if _pake_sk_bad is None:
+        print("- aPAKE login with wrong password: correctly rejected")
+    else:
+        print("+ aPAKE login with wrong password: ACCEPTED (security failure)!")
 
 
 hkex_rnl_keygen = _rnl_keygen   # (m_blind, n, q, p, b) -> (s, C)

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -152,6 +152,7 @@
         hkex_rnl_keygen, hkex_rnl_agree  (public aliases added in v1.7.4)
         rnl_sigma_sign, rnl_sigma_verify  (ZKP-RNL: Ring-LWR Σ-protocol)
         zkp_nl_keygen, zkp_nl_prove, zkp_nl_verify  (ZKP-NL: NL-FSCX ZKBoo)
+        oprf_keygen, oprf_blind, oprf_eval, oprf_unblind, oprf_direct  (OPRF: 2HashDH over GF(2^n)*)
 
     Key module constants: KEYBITS, I_VALUE, R_VALUE, GF_POLY, GF_GEN, ORD,
         RNLQ, RNLP, RNLPP, RNLB, SDFNR, SDFT, SDFR.
@@ -1788,6 +1789,62 @@ def ratchet_advance(state: BitArray) -> tuple:
 
 
 # ---------------------------------------------------------------------------
+# 80 — Oblivious PRF (OPRF) over GF(2^n)*  (TODO #80)
+#
+# F(k, x) = gf_pow(H(x), k)  where  H = HFSCX-256 hash-to-field.
+# Oblivious under CDH in GF(2^n)*: the blinded value alpha = H(x)^r
+# is computationally indistinguishable from random without knowing x or r.
+#
+# Protocol: client calls oprf_blind(x) → (r, alpha); sends alpha to server.
+#           server calls oprf_eval(alpha, k) → beta; returns beta to client.
+#           client calls oprf_unblind(beta, r) → F = H(x)^k = oprf_direct(x, k).
+# ---------------------------------------------------------------------------
+
+def oprf_keygen() -> int:
+    """Random OPRF server key k in [2, 2^KEYBITS − 2]."""
+    while True:
+        k = int.from_bytes(os.urandom(KEYBITS // 8), 'big') & ORD
+        if 1 < k < ORD:
+            return k
+
+
+def _oprf_hash_to_field(data: bytes) -> int:
+    """HFSCX-256(data) → non-zero element of GF(2^KEYBITS)."""
+    val = int.from_bytes(hfscx_256(data), 'big') & ORD
+    return val if val != 0 else 1
+
+
+def oprf_blind(x: bytes) -> tuple:
+    """Client: hash x and blind with random scalar r.
+    Returns (r, alpha) where alpha = H(x)^r in GF(2^KEYBITS)*.
+    r is secret (kept by client); alpha is sent to the server."""
+    poly = GF_POLY[KEYBITS]
+    while True:
+        r = int.from_bytes(os.urandom(KEYBITS // 8), 'big') & ORD
+        if r > 1 and math.gcd(r, ORD) == 1:
+            break
+    alpha = gf_pow(_oprf_hash_to_field(x), r, poly, KEYBITS)
+    return r, alpha
+
+
+def oprf_eval(alpha: int, k: int) -> int:
+    """Server: evaluate alpha^k in GF(2^KEYBITS)*."""
+    return gf_pow(alpha & ORD, k & ORD, GF_POLY[KEYBITS], KEYBITS)
+
+
+def oprf_unblind(beta: int, r: int) -> int:
+    """Client: recover F(k, x) = H(x)^k from beta = H(x)^{kr}.
+    Computes beta^{r^{-1} mod ORD}."""
+    r_inv = pow(r, -1, ORD)
+    return gf_pow(beta & ORD, r_inv, GF_POLY[KEYBITS], KEYBITS)
+
+
+def oprf_direct(x: bytes, k: int) -> int:
+    """Direct PRF evaluation F(k, x) = H(x)^k (server-side; not oblivious)."""
+    return gf_pow(_oprf_hash_to_field(x), k & ORD, GF_POLY[KEYBITS], KEYBITS)
+
+
+# ---------------------------------------------------------------------------
 # Protocol documentation
 # ---------------------------------------------------------------------------
 '''
@@ -2289,6 +2346,29 @@ def main():
         print("+ Eve forged ring signature (Eve wins!)")
     else:
         print("- Eve cannot forge: challenge-sum mismatch  (SD + PRF protection)")
+
+
+    # 80 — OPRF demo (blind / eval / unblind round-trip)
+    print("*** OPRF (80) — 2HashDH over GF(2^256)*")
+    _oprf_k   = oprf_keygen()
+    _oprf_pw  = b"oprf-demo-input"
+    _oprf_r, _oprf_alpha = oprf_blind(_oprf_pw)
+    _oprf_beta  = oprf_eval(_oprf_alpha, _oprf_k)
+    _oprf_F     = oprf_unblind(_oprf_beta, _oprf_r)
+    _oprf_check = oprf_direct(_oprf_pw, _oprf_k)
+    if _oprf_F == _oprf_check:
+        print("- OPRF blind/eval/unblind round-trip correct")
+    else:
+        print("+ OPRF round-trip failed!")
+    # aPAKE: OPRF output replaces direct password hash
+    _oprf_salt   = os.urandom(32)
+    _oprf_pw_key = hfscx_256(_oprf_F.to_bytes(KEYBITS // 8, 'big') + _oprf_salt)
+    _oprf_F2     = oprf_direct(_oprf_pw, _oprf_k)
+    _oprf_pw_key2 = hfscx_256(_oprf_F2.to_bytes(KEYBITS // 8, 'big') + _oprf_salt)
+    if _oprf_pw_key == _oprf_pw_key2:
+        print("- OPRF aPAKE: pw_key derived from OPRF output is deterministic")
+    else:
+        print("+ OPRF aPAKE pw_key mismatch!")
 
 
 hkex_rnl_keygen = _rnl_keygen   # (m_blind, n, q, p, b) -> (s, C)

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -59,6 +59,7 @@ from primitives import (
     fpe_encrypt, fpe_decrypt, twk_encrypt, twk_decrypt,
     haccum_leaf, haccum_node, haccum_root, haccum_prove, haccum_verify,
     oprf_keygen, oprf_blind, oprf_eval, oprf_unblind, oprf_direct,
+    hpake_register, hpake_login_demo,
 )
 from primitives import _s as _suite_mod
 
@@ -93,6 +94,7 @@ _LABEL_ZKP_RNL     = 'HERRADURA ZKP-RNL PROOF'
 _LABEL_ZKP_NL      = 'HERRADURA ZKP-NL PROOF'
 _LABEL_OPRF_STATE  = 'HERRADURA OPRF CLIENT STATE'   # (r, alpha, nbits) — client keeps this
 _LABEL_OPRF_EVAL   = 'HERRADURA OPRF EVALUATION'     # (beta, nbits) — server response
+_LABEL_PAKE_RECORD = 'HERRADURA PAKE RECORD'         # (salt, B, y) — server-side aPAKE record
 
 _ZKP_NL_ALGOS      = {'hpks-zkp-nl'}
 _ZKP_CLI_ROUNDS    = _ZKP_NL_PROD_ROUNDS   # CLI default: full 128-bit soundness
@@ -1201,6 +1203,68 @@ def cmd_oprf_unblind(args):
 
 
 # ---------------------------------------------------------------------------
+# Sub-commands: pake-register, pake-demo  (TODO #80 Batch 4)
+# ---------------------------------------------------------------------------
+
+def cmd_pake_register(args):
+    """Register a new user for aPAKE.  Outputs HERRADURA PAKE RECORD PEM."""
+    oprf_key, _nbits = _load_oprf_key(args.key)
+    username = args.username or "user"
+    if args.password:
+        password = args.password.encode()
+    else:
+        import getpass
+        password = getpass.getpass(f"Password for {username!r}: ").encode()
+    record  = hpake_register(username, password, oprf_key)
+    salt_b  = record['salt']
+    B_int   = record['B']
+    y_int   = record['y']
+    # Encode: SEQUENCE(INTEGER(salt), INTEGER(B), INTEGER(y))
+    # salt as 32-byte big-endian integer; B and y as 4-byte (32-bit demo params)
+    der = der_seq(
+        der_int(int.from_bytes(salt_b, 'big'), 32),
+        der_int(B_int, 4),
+        der_int(y_int, 4),
+    )
+    _write_file(args.out, pem_wrap(_LABEL_PAKE_RECORD, der))
+
+
+def _load_pake_record(path):
+    """Return a record dict {'username', 'salt', 'B', 'y'} from PAKE RECORD PEM."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_PAKE_RECORD:
+        sys.exit(f"Expected PAKE RECORD PEM, got {label!r}")
+    salt_int, B_int, y_int = ints
+    return {
+        'username': '',            # not stored in the PEM for simplicity
+        'salt':     salt_int.to_bytes(32, 'big'),
+        'B':        B_int,
+        'y':        y_int,
+    }
+
+
+def cmd_pake_demo(args):
+    """aPAKE demo: run full registration + login on both sides and show session key."""
+    oprf_key, _nbits = _load_oprf_key(args.key)
+    username  = args.username or "demo-user"
+    password  = (args.password or "demo-password").encode()
+    record    = hpake_register(username, password, oprf_key)
+    sk        = hpake_login_demo(record, password, oprf_key)
+    if sk is not None:
+        print(f"- aPAKE login succeeded; session key: {sk.hex()}")
+    else:
+        print("+ aPAKE login failed!")
+        sys.exit(1)
+    # Also test wrong password
+    wrong_sk  = hpake_login_demo(record, b"wrong-password", oprf_key)
+    if wrong_sk is None:
+        print("- aPAKE correctly rejects wrong password")
+    else:
+        print("+ aPAKE accepted wrong password! (security failure)")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
 
@@ -1368,6 +1432,28 @@ def build_parser():
     ou.add_argument('--out', default='-',
                     help='PRF output as hex (default: stdout)')
 
+    # pake-register (80)
+    pr = sub.add_parser('pake-register',
+                        help='aPAKE: register user and output server record PEM (TODO #80 Batch 4)')
+    pr.add_argument('--key',      required=True,
+                    help='OPRF PRIVATE KEY PEM (server OPRF key)')
+    pr.add_argument('--username', default='user',
+                    help='Username to register (default: "user")')
+    pr.add_argument('--password', default=None,
+                    help='Password (omit to prompt interactively)')
+    pr.add_argument('--out', default='-',
+                    help='PAKE RECORD PEM output')
+
+    # pake-demo (80)
+    pd = sub.add_parser('pake-demo',
+                        help='aPAKE: run full register+login demo (both sides) (TODO #80 Batch 4)')
+    pd.add_argument('--key',      required=True,
+                    help='OPRF PRIVATE KEY PEM')
+    pd.add_argument('--username', default='demo-user',
+                    help='Demo username (default: "demo-user")')
+    pd.add_argument('--password', default='demo-password',
+                    help='Demo password (default: "demo-password")')
+
     return p
 
 
@@ -1384,9 +1470,11 @@ _DISPATCH = {
     'dgst':    cmd_dgst,
     'fpe':          cmd_fpe,
     'twk':          cmd_twk,
-    'oprf-blind':   cmd_oprf_blind,
-    'oprf-eval':    cmd_oprf_eval,
-    'oprf-unblind': cmd_oprf_unblind,
+    'oprf-blind':     cmd_oprf_blind,
+    'oprf-eval':      cmd_oprf_eval,
+    'oprf-unblind':   cmd_oprf_unblind,
+    'pake-register':  cmd_pake_register,
+    'pake-demo':      cmd_pake_demo,
 }
 
 

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -58,6 +58,7 @@ from primitives import (
     _ZKP_NL_DEFAULT_N, _ZKP_NL_PROD_ROUNDS,
     fpe_encrypt, fpe_decrypt, twk_encrypt, twk_decrypt,
     haccum_leaf, haccum_node, haccum_root, haccum_prove, haccum_verify,
+    oprf_keygen, oprf_blind, oprf_eval, oprf_unblind, oprf_direct,
 )
 from primitives import _s as _suite_mod
 
@@ -75,6 +76,7 @@ _PRIV_ALGOS = {
     'hpks-stern':  'HERRADURA HPKS-STERN PRIVATE KEY',
     'hpke-stern':  'HERRADURA HPKE-STERN PRIVATE KEY',
     'hpks-zkp-nl': 'HERRADURA ZKP-NL PRIVATE KEY',
+    'oprf':        'HERRADURA OPRF PRIVATE KEY',
 }
 
 _PUB_ALGOS = {k: v.replace('PRIVATE', 'PUBLIC') for k, v in _PRIV_ALGOS.items()}
@@ -89,6 +91,8 @@ _LABEL_CT          = 'HERRADURA CIPHERTEXT'
 _LABEL_DIGEST      = 'HERRADURA DIGEST'
 _LABEL_ZKP_RNL     = 'HERRADURA ZKP-RNL PROOF'
 _LABEL_ZKP_NL      = 'HERRADURA ZKP-NL PROOF'
+_LABEL_OPRF_STATE  = 'HERRADURA OPRF CLIENT STATE'   # (r, alpha, nbits) — client keeps this
+_LABEL_OPRF_EVAL   = 'HERRADURA OPRF EVALUATION'     # (beta, nbits) — server response
 
 _ZKP_NL_ALGOS      = {'hpks-zkp-nl'}
 _ZKP_CLI_ROUNDS    = _ZKP_NL_PROD_ROUNDS   # CLI default: full 128-bit soundness
@@ -519,6 +523,11 @@ def cmd_genpkey(args):
         n = bits if bits != KEYBITS else _ZKP_NL_DEFAULT_N
         A, B, y = zkp_nl_keygen(n)
         pem_out = encode_zkp_nl_privkey(A, B, y, n)
+
+    elif algo == 'oprf':
+        k   = oprf_keygen()
+        der = der_seq(der_int(k, bits // 8), der_int(bits))
+        pem_out = pem_wrap(_PRIV_ALGOS['oprf'], der)
 
     else:
         sys.exit(f"Unknown algorithm: {algo!r}")
@@ -1137,6 +1146,61 @@ def cmd_twk(args):
 
 
 # ---------------------------------------------------------------------------
+# Sub-commands: oprf-blind, oprf-eval, oprf-unblind  (TODO #80)
+# ---------------------------------------------------------------------------
+
+def _load_oprf_key(path):
+    """Return (k_int, nbits) from an OPRF PRIVATE KEY PEM."""
+    label, ints = _read_pem_ints(path)
+    if label != _PRIV_ALGOS['oprf']:
+        sys.exit(f"Expected OPRF PRIVATE KEY PEM, got {label!r}")
+    k_int, nbits = ints
+    return k_int, nbits
+
+
+def cmd_oprf_blind(args):
+    """Client step 1: hash input and blind with random scalar r.
+    Writes OPRF CLIENT STATE PEM (r + alpha) to --out; alpha is sent to server."""
+    in_bytes = _read_file(getattr(args, 'in'))
+    r, alpha = oprf_blind(in_bytes)
+    nbits    = KEYBITS
+    der      = der_seq(der_int(r,     nbits // 8),
+                       der_int(alpha, nbits // 8),
+                       der_int(nbits))
+    pem_out  = pem_wrap(_LABEL_OPRF_STATE, der)
+    _write_file(args.out, pem_out)
+
+
+def cmd_oprf_eval(args):
+    """Server step: evaluate alpha^k and write OPRF EVALUATION PEM to --out."""
+    k_int, nbits = _load_oprf_key(args.key)
+    label, ints  = _read_pem_ints(getattr(args, 'in'))
+    if label != _LABEL_OPRF_STATE:
+        sys.exit(f"Expected OPRF CLIENT STATE PEM, got {label!r}")
+    _r, alpha, _nb = ints
+    beta  = oprf_eval(alpha, k_int)
+    der   = der_seq(der_int(beta, nbits // 8), der_int(nbits))
+    _write_file(args.out, pem_wrap(_LABEL_OPRF_EVAL, der))
+
+
+def cmd_oprf_unblind(args):
+    """Client step 2: recover F(k, x) = H(x)^k and print hex to stdout (or --out)."""
+    label_s, ints_s = _read_pem_ints(args.state)
+    if label_s != _LABEL_OPRF_STATE:
+        sys.exit(f"Expected OPRF CLIENT STATE PEM, got {label_s!r}")
+    r, alpha, nbits = ints_s
+
+    label_e, ints_e = _read_pem_ints(getattr(args, 'eval'))
+    if label_e != _LABEL_OPRF_EVAL:
+        sys.exit(f"Expected OPRF EVALUATION PEM, got {label_e!r}")
+    beta, _nb = ints_e
+
+    F      = oprf_unblind(beta, r)
+    F_hex  = F.to_bytes(nbits // 8, 'big').hex()
+    _write_file(args.out, F_hex + '\n')
+
+
+# ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
 
@@ -1276,6 +1340,34 @@ def build_parser():
     tw_mode.add_argument('--encrypt', action='store_true')
     tw_mode.add_argument('--decrypt', action='store_true')
 
+    # oprf-blind (80)
+    ob = sub.add_parser('oprf-blind',
+                        help='OPRF client step 1: hash input and blind (TODO #80)')
+    ob.add_argument('--in',  required=True, dest='in',
+                    help='Input bytes to blind (file or - for stdin)')
+    ob.add_argument('--out', default='-',
+                    help='OPRF CLIENT STATE PEM output (keep secret; contains r + alpha)')
+
+    # oprf-eval (80)
+    oe = sub.add_parser('oprf-eval',
+                        help='OPRF server step: evaluate blinded input with OPRF key (TODO #80)')
+    oe.add_argument('--key', required=True,
+                    help='OPRF PRIVATE KEY PEM (server key)')
+    oe.add_argument('--in',  required=True, dest='in',
+                    help='OPRF CLIENT STATE PEM (from oprf-blind)')
+    oe.add_argument('--out', default='-',
+                    help='OPRF EVALUATION PEM output')
+
+    # oprf-unblind (80)
+    ou = sub.add_parser('oprf-unblind',
+                        help='OPRF client step 2: unblind server response to get PRF output (TODO #80)')
+    ou.add_argument('--state', required=True,
+                    help='OPRF CLIENT STATE PEM (from oprf-blind)')
+    ou.add_argument('--eval',  required=True,
+                    help='OPRF EVALUATION PEM (from oprf-eval)')
+    ou.add_argument('--out', default='-',
+                    help='PRF output as hex (default: stdout)')
+
     return p
 
 
@@ -1290,8 +1382,11 @@ _DISPATCH = {
     'encfile': cmd_encfile,
     'decfile': cmd_decfile,
     'dgst':    cmd_dgst,
-    'fpe':     cmd_fpe,
-    'twk':     cmd_twk,
+    'fpe':          cmd_fpe,
+    'twk':          cmd_twk,
+    'oprf-blind':   cmd_oprf_blind,
+    'oprf-eval':    cmd_oprf_eval,
+    'oprf-unblind': cmd_oprf_unblind,
 }
 
 

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -375,6 +375,21 @@ static void cmd_genpkey(int argc, char **argv)
         free(body); fclose(urnd); return;
     }
 
+    /* OPRF server key: SEQUENCE(INTEGER(k), INTEGER(256)) */
+    if (strcmp(algo, "oprf") == 0) {
+        BitArray k;
+        oprf_keygen(&k, urnd);
+        uint8_t ik[DER_INT_LEN(KEYBYTES)], in[8];
+        size_t lk, ln;
+        der_i32(k.b, ik, &lk);
+        der_i_n256(in, &ln);
+        const uint8_t *it[2] = {ik, in};
+        size_t il[2] = {lk, ln};
+        seq_and_write(it, il, 2, PEM_OPRF_PRIV, out);
+        explicit_bzero(&k, sizeof(k));
+        fclose(urnd); return;
+    }
+
     fclose(urnd);
     dief("genpkey: unsupported algorithm: %s", algo);
 }
@@ -1707,6 +1722,128 @@ static void cmd_twk(int argc, char **argv)
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+ * oprf-blind / oprf-eval / oprf-unblind  (TODO #80)
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+static void cmd_oprf_blind(int argc, char **argv)
+{
+    const char *in_path  = get_arg(argc, argv, "--in");
+    const char *out_path = get_arg(argc, argv, "--out");
+    if (!in_path) die("oprf-blind: --in required");
+
+    FILE *urnd = fopen("/dev/urandom", "rb");
+    if (!urnd) die("cannot open /dev/urandom");
+
+    size_t in_len;
+    uint8_t *in_buf = read_binary_file(in_path, &in_len);
+
+    BitArray r, alpha;
+    oprf_blind(in_buf, in_len, &r, &alpha, urnd);
+    free(in_buf);
+    fclose(urnd);
+
+    /* CLIENT STATE: SEQUENCE(INTEGER(r), INTEGER(alpha), INTEGER(256)) */
+    uint8_t ir[DER_INT_LEN(KEYBYTES)], ialpha[DER_INT_LEN(KEYBYTES)], in[8];
+    size_t lr, lalpha, ln;
+    der_i32(r.b, ir, &lr);
+    der_i32(alpha.b, ialpha, &lalpha);
+    der_i_n256(in, &ln);
+    const uint8_t *it[3] = {ir, ialpha, in};
+    size_t il[3] = {lr, lalpha, ln};
+    seq_and_write(it, il, 3, PEM_OPRF_STATE, out_path);
+
+    explicit_bzero(&r, sizeof(r));
+}
+
+static void ba_from_der_item(BitArray *dst, const uint8_t *val, size_t vlen)
+{
+    /* DER INTEGER may have a leading 0x00 pad byte (sign bit); skip it. */
+    if (vlen > 0 && val[0] == 0x00) { val++; vlen--; }
+    size_t copy = vlen < KEYBYTES ? vlen : KEYBYTES;
+    memset(dst->b, 0, KEYBYTES);
+    memcpy(dst->b + KEYBYTES - copy, val, copy);
+}
+
+static void cmd_oprf_eval(int argc, char **argv)
+{
+    const char *key_path = get_arg(argc, argv, "--key");
+    const char *in_path  = get_arg(argc, argv, "--in");
+    const char *out_path = get_arg(argc, argv, "--out");
+    if (!key_path) die("oprf-eval: --key required");
+    if (!in_path)  die("oprf-eval: --in required");
+
+    /* Load server key: SEQUENCE(INTEGER(k), INTEGER(256)) */
+    PemKey kpem; pem_key_load(&kpem, key_path);
+    if (strcmp(kpem.label, PEM_OPRF_PRIV) != 0)
+        dief("oprf-eval: expected OPRF PRIVATE KEY PEM, got '%s'", kpem.label);
+    if (kpem.n_items < 1) die("oprf-eval: malformed OPRF private key");
+    BitArray k;
+    ba_from_der_item(&k, kpem.vals[0], kpem.vlens[0]);
+    pem_key_free(&kpem);
+
+    /* Load CLIENT STATE: SEQUENCE(INTEGER(r), INTEGER(alpha), INTEGER(256)) */
+    PemKey spem; pem_key_load(&spem, in_path);
+    if (strcmp(spem.label, PEM_OPRF_STATE) != 0)
+        dief("oprf-eval: expected OPRF CLIENT STATE PEM, got '%s'", spem.label);
+    if (spem.n_items < 2) die("oprf-eval: malformed CLIENT STATE PEM");
+    BitArray alpha;
+    ba_from_der_item(&alpha, spem.vals[1], spem.vlens[1]);
+    pem_key_free(&spem);
+
+    BitArray beta;
+    oprf_eval(&beta, &alpha, &k);
+    explicit_bzero(&k, sizeof(k));
+
+    /* EVALUATION: SEQUENCE(INTEGER(beta), INTEGER(256)) */
+    uint8_t ibeta[DER_INT_LEN(KEYBYTES)], in[8];
+    size_t lbeta, ln;
+    der_i32(beta.b, ibeta, &lbeta);
+    der_i_n256(in, &ln);
+    const uint8_t *it[2] = {ibeta, in};
+    size_t il[2] = {lbeta, ln};
+    seq_and_write(it, il, 2, PEM_OPRF_EVAL, out_path);
+}
+
+static void cmd_oprf_unblind(int argc, char **argv)
+{
+    const char *state_path = get_arg(argc, argv, "--state");
+    const char *eval_path  = get_arg(argc, argv, "--eval");
+    const char *out_path   = get_arg(argc, argv, "--out");
+    if (!state_path) die("oprf-unblind: --state required");
+    if (!eval_path)  die("oprf-unblind: --eval required");
+
+    /* Load CLIENT STATE: SEQUENCE(INTEGER(r), INTEGER(alpha), INTEGER(256)) */
+    PemKey spem; pem_key_load(&spem, state_path);
+    if (strcmp(spem.label, PEM_OPRF_STATE) != 0)
+        dief("oprf-unblind: expected OPRF CLIENT STATE PEM, got '%s'", spem.label);
+    if (spem.n_items < 1) die("oprf-unblind: malformed CLIENT STATE PEM");
+    BitArray r;
+    ba_from_der_item(&r, spem.vals[0], spem.vlens[0]);
+    pem_key_free(&spem);
+
+    /* Load EVALUATION: SEQUENCE(INTEGER(beta), INTEGER(256)) */
+    PemKey epem; pem_key_load(&epem, eval_path);
+    if (strcmp(epem.label, PEM_OPRF_EVAL) != 0)
+        dief("oprf-unblind: expected OPRF EVALUATION PEM, got '%s'", epem.label);
+    if (epem.n_items < 1) die("oprf-unblind: malformed EVALUATION PEM");
+    BitArray beta;
+    ba_from_der_item(&beta, epem.vals[0], epem.vlens[0]);
+    pem_key_free(&epem);
+
+    BitArray F;
+    oprf_unblind(&F, &beta, &r);
+    explicit_bzero(&r, sizeof(r));
+
+    /* Output: hex string (+ newline) */
+    int i;
+    char hex[KEYBYTES * 2 + 2];
+    for (i = 0; i < KEYBYTES; i++) sprintf(hex + 2*i, "%02x", F.b[i]);
+    hex[KEYBYTES * 2] = '\n';
+    hex[KEYBYTES * 2 + 1] = '\0';
+    write_binary_file(out_path, (const uint8_t*)hex, strlen(hex));
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
  * Usage
  * ───────────────────────────────────────────────────────────────────────────── */
 
@@ -1768,6 +1905,17 @@ static void usage(void)
 "    Tweakable wide-block cipher (78.B).  Unique tweak per (sector, block-index).\n"
 "    Key: HERRADURA SESSION KEY PEM.\n"
 "\n"
+"  oprf-blind --in FILE [--out FILE]\n"
+"    OPRF client step 1: hash input and blind with random scalar r.\n"
+"    Outputs HERRADURA OPRF CLIENT STATE PEM; send alpha field to server.\n"
+"\n"
+"  oprf-eval --key OPRF_KEY --in STATE_PEM [--out FILE]\n"
+"    OPRF server step: evaluate alpha^k and output HERRADURA OPRF EVALUATION PEM.\n"
+"    Key: HERRADURA OPRF PRIVATE KEY PEM.\n"
+"\n"
+"  oprf-unblind --state STATE_PEM --eval EVAL_PEM [--out FILE]\n"
+"    OPRF client step 2: recover F(k,x) and output as 64-char hex.\n"
+"\n"
 "PEM output goes to stdout when --out is absent or '-'.\n"
 "All keys are 256-bit.\n"
     );
@@ -1794,8 +1942,11 @@ int main(int argc, char **argv)
     if (strcmp(cmd, "dgst")    == 0) { cmd_dgst(argc, argv);    return 0; }
     if (strcmp(cmd, "encfile") == 0) { cmd_encfile(argc, argv); return 0; }
     if (strcmp(cmd, "decfile") == 0) { cmd_decfile(argc, argv); return 0; }
-    if (strcmp(cmd, "fpe")     == 0) { cmd_fpe(argc, argv);     return 0; }
-    if (strcmp(cmd, "twk")     == 0) { cmd_twk(argc, argv);     return 0; }
+    if (strcmp(cmd, "fpe")          == 0) { cmd_fpe(argc, argv);          return 0; }
+    if (strcmp(cmd, "twk")          == 0) { cmd_twk(argc, argv);          return 0; }
+    if (strcmp(cmd, "oprf-blind")   == 0) { cmd_oprf_blind(argc, argv);   return 0; }
+    if (strcmp(cmd, "oprf-eval")    == 0) { cmd_oprf_eval(argc, argv);    return 0; }
+    if (strcmp(cmd, "oprf-unblind") == 0) { cmd_oprf_unblind(argc, argv); return 0; }
 
     dief("unknown command: %s", cmd);
     return 1;

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -62,6 +62,10 @@ const (
 	lblZkpNlPriv   = "HERRADURA ZKP-NL PRIVATE KEY"
 	lblZkpNlPub    = "HERRADURA ZKP-NL PUBLIC KEY"
 	lblZkpNlProof  = "HERRADURA ZKP-NL PROOF"
+
+	lblOprfPriv  = "HERRADURA OPRF PRIVATE KEY"
+	lblOprfState = "HERRADURA OPRF CLIENT STATE"
+	lblOprfEval  = "HERRADURA OPRF EVALUATION"
 )
 
 var privToAlgo = map[string]string{
@@ -428,6 +432,25 @@ func cmdGenpkey(args []string) {
 			os.Exit(1)
 		}
 		pem = encodeZkpNlPriv(A, B, y, ZkpNlDefaultN)
+
+	case *algo == "oprf":
+		k, kerr := OprfKeygen(n)
+		if kerr != nil {
+			fmt.Fprintln(os.Stderr, "genpkey:", kerr)
+			os.Exit(1)
+		}
+		kDer, e1 := derIntBig(k, n/8)
+		nDer, e2 := derIntSmall(n)
+		if e1 != nil || e2 != nil {
+			fmt.Fprintln(os.Stderr, "genpkey: DER encode error")
+			os.Exit(1)
+		}
+		seq, e3 := DerSeqEnc(kDer, nDer)
+		if e3 != nil {
+			fmt.Fprintln(os.Stderr, "genpkey: DER seq error")
+			os.Exit(1)
+		}
+		pem = PemWrap(lblOprfPriv, seq)
 
 	default:
 		fmt.Fprintf(os.Stderr, "genpkey: unknown algorithm %q\n", *algo)
@@ -1995,6 +2018,152 @@ func cmdTwk(args []string) {
 	}
 }
 
+// ── oprf-blind / oprf-eval / oprf-unblind  (TODO #80) ────────────────────────
+
+func cmdOprfBlind(args []string) {
+	fs    := flag.NewFlagSet("oprf-blind", flag.ExitOnError)
+	inF   := fs.String("in", "", "Input bytes file (- for stdin)")
+	outF  := fs.String("out", "-", "Output OPRF CLIENT STATE PEM")
+	fs.Parse(args)
+	if *inF == "" {
+		fmt.Fprintln(os.Stderr, "oprf-blind: --in required")
+		os.Exit(1)
+	}
+	data, err := readFile(*inF)
+	if err != nil {
+		die("oprf-blind", err)
+	}
+	r, alpha, err := OprfBlind(data, 256)
+	if err != nil {
+		die("oprf-blind", err)
+	}
+	rDer, e1    := derIntBig(r, 32)
+	aDer, e2    := derIntBig(alpha, 32)
+	nDer, e3    := derIntSmall(256)
+	if e1 != nil || e2 != nil || e3 != nil {
+		fmt.Fprintln(os.Stderr, "oprf-blind: DER encode error")
+		os.Exit(1)
+	}
+	seq, e4 := DerSeqEnc(rDer, aDer, nDer)
+	if e4 != nil {
+		die("oprf-blind", e4)
+	}
+	if err := writeString(*outF, PemWrap(lblOprfState, seq)); err != nil {
+		die("oprf-blind", err)
+	}
+}
+
+func cmdOprfEval(args []string) {
+	fs    := flag.NewFlagSet("oprf-eval", flag.ExitOnError)
+	keyF  := fs.String("key", "", "OPRF PRIVATE KEY PEM (server key)")
+	inF   := fs.String("in", "", "OPRF CLIENT STATE PEM")
+	outF  := fs.String("out", "-", "Output OPRF EVALUATION PEM")
+	fs.Parse(args)
+	if *keyF == "" {
+		fmt.Fprintln(os.Stderr, "oprf-eval: --key required")
+		os.Exit(1)
+	}
+	if *inF == "" {
+		fmt.Fprintln(os.Stderr, "oprf-eval: --in required")
+		os.Exit(1)
+	}
+	/* Load server key: SEQUENCE(INTEGER(k), INTEGER(256)) */
+	kLabel, kInts, err := readPEMInts(*keyF)
+	if err != nil {
+		die("oprf-eval", err)
+	}
+	if kLabel != lblOprfPriv {
+		fmt.Fprintf(os.Stderr, "oprf-eval: expected OPRF PRIVATE KEY PEM, got %q\n", kLabel)
+		os.Exit(1)
+	}
+	if len(kInts) < 1 {
+		fmt.Fprintln(os.Stderr, "oprf-eval: malformed OPRF private key")
+		os.Exit(1)
+	}
+	k := new(big.Int).SetBytes(kInts[0])
+
+	/* Load CLIENT STATE: SEQUENCE(INTEGER(r), INTEGER(alpha), INTEGER(256)) */
+	sLabel, sInts, err := readPEMInts(*inF)
+	if err != nil {
+		die("oprf-eval", err)
+	}
+	if sLabel != lblOprfState {
+		fmt.Fprintf(os.Stderr, "oprf-eval: expected OPRF CLIENT STATE PEM, got %q\n", sLabel)
+		os.Exit(1)
+	}
+	if len(sInts) < 2 {
+		fmt.Fprintln(os.Stderr, "oprf-eval: malformed CLIENT STATE PEM")
+		os.Exit(1)
+	}
+	alpha := new(big.Int).SetBytes(sInts[1])
+
+	beta := OprfEval(alpha, k, 256)
+	bDer, e1 := derIntBig(beta, 32)
+	nDer, e2 := derIntSmall(256)
+	if e1 != nil || e2 != nil {
+		fmt.Fprintln(os.Stderr, "oprf-eval: DER encode error")
+		os.Exit(1)
+	}
+	seq, e3 := DerSeqEnc(bDer, nDer)
+	if e3 != nil {
+		die("oprf-eval", e3)
+	}
+	if err := writeString(*outF, PemWrap(lblOprfEval, seq)); err != nil {
+		die("oprf-eval", err)
+	}
+}
+
+func cmdOprfUnblind(args []string) {
+	fs     := flag.NewFlagSet("oprf-unblind", flag.ExitOnError)
+	stateF := fs.String("state", "", "OPRF CLIENT STATE PEM")
+	evalF  := fs.String("eval",  "", "OPRF EVALUATION PEM")
+	outF   := fs.String("out", "-", "Output PRF hex")
+	fs.Parse(args)
+	if *stateF == "" {
+		fmt.Fprintln(os.Stderr, "oprf-unblind: --state required")
+		os.Exit(1)
+	}
+	if *evalF == "" {
+		fmt.Fprintln(os.Stderr, "oprf-unblind: --eval required")
+		os.Exit(1)
+	}
+	/* CLIENT STATE: (r, alpha, nbits) */
+	sLabel, sInts, err := readPEMInts(*stateF)
+	if err != nil {
+		die("oprf-unblind", err)
+	}
+	if sLabel != lblOprfState {
+		fmt.Fprintf(os.Stderr, "oprf-unblind: expected OPRF CLIENT STATE PEM, got %q\n", sLabel)
+		os.Exit(1)
+	}
+	if len(sInts) < 1 {
+		fmt.Fprintln(os.Stderr, "oprf-unblind: malformed CLIENT STATE PEM")
+		os.Exit(1)
+	}
+	r := new(big.Int).SetBytes(sInts[0])
+
+	/* EVALUATION: (beta, nbits) */
+	eLabel, eInts, err := readPEMInts(*evalF)
+	if err != nil {
+		die("oprf-unblind", err)
+	}
+	if eLabel != lblOprfEval {
+		fmt.Fprintf(os.Stderr, "oprf-unblind: expected OPRF EVALUATION PEM, got %q\n", eLabel)
+		os.Exit(1)
+	}
+	if len(eInts) < 1 {
+		fmt.Fprintln(os.Stderr, "oprf-unblind: malformed EVALUATION PEM")
+		os.Exit(1)
+	}
+	beta := new(big.Int).SetBytes(eInts[0])
+
+	F := OprfUnblind(beta, r, 256)
+	hex := fmt.Sprintf("%064x\n", F)
+	if err := writeString(*outF, hex); err != nil {
+		die("oprf-unblind", err)
+	}
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 func die(prefix string, err error) {
@@ -2059,6 +2228,12 @@ func main() {
 		cmdFpe(rest)
 	case "twk":
 		cmdTwk(rest)
+	case "oprf-blind":
+		cmdOprfBlind(rest)
+	case "oprf-eval":
+		cmdOprfEval(rest)
+	case "oprf-unblind":
+		cmdOprfUnblind(rest)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", cmd)
 		usage()

--- a/HerraduraCli/herradura_codec.h
+++ b/HerraduraCli/herradura_codec.h
@@ -50,6 +50,9 @@
 #define PEM_ZKP_NL_PRIV     "HERRADURA ZKP-NL PRIVATE KEY"
 #define PEM_ZKP_NL_PUB      "HERRADURA ZKP-NL PUBLIC KEY"
 #define PEM_ZKP_NL_PROOF    "HERRADURA ZKP-NL PROOF"
+#define PEM_OPRF_PRIV       "HERRADURA OPRF PRIVATE KEY"
+#define PEM_OPRF_STATE      "HERRADURA OPRF CLIENT STATE"
+#define PEM_OPRF_EVAL       "HERRADURA OPRF EVALUATION"
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * Buffer-size macros

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -97,3 +97,7 @@ oprf_blind           = _s.oprf_blind
 oprf_eval            = _s.oprf_eval
 oprf_unblind         = _s.oprf_unblind
 oprf_direct          = _s.oprf_direct
+
+# ── 80 aPAKE ─────────────────────────────────────────────────────────────────
+hpake_register       = _s.hpake_register
+hpake_login_demo     = _s.hpake_login_demo

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -90,3 +90,10 @@ hske_encrypt_masked  = _s.hske_encrypt_masked
 hske_decrypt_masked  = _s.hske_decrypt_masked
 ratchet_init         = _s.ratchet_init
 ratchet_advance      = _s.ratchet_advance
+
+# ── 80 OPRF ──────────────────────────────────────────────────────────────────
+oprf_keygen          = _s.oprf_keygen
+oprf_blind           = _s.oprf_blind
+oprf_eval            = _s.oprf_eval
+oprf_unblind         = _s.oprf_unblind
+oprf_direct          = _s.oprf_direct

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.23)
+# Herradura Cryptographic Suite (v1.9.24)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.25)
+# Herradura Cryptographic Suite (v1.9.26)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.24)
+# Herradura Cryptographic Suite (v1.9.25)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5146,7 +5146,7 @@ stdin/stdout (similar to how `kex` outputs the session key).
 
 ---
 
-#### Batch 2 — OPRF: C (`herradura.h` + `herradura_cli.c`)
+#### Batch 2 — OPRF: C (`herradura.h` + `herradura_cli.c`) ✅ DONE v1.9.25
 
 **`herradura.h` functions:**
 
@@ -5174,7 +5174,7 @@ void oprf_direct(const uint8_t *x, size_t xlen, const BitArray *k, BitArray *F);
 
 ---
 
-#### Batch 3 — OPRF: Go (`herradura/herradura.go` + `herradura_cli.go`)
+#### Batch 3 — OPRF: Go (`herradura/herradura.go` + `herradura_cli.go`) ✅ DONE v1.9.25
 
 **Package functions:**
 
@@ -5251,7 +5251,7 @@ message. n=32 GF(2^32)* CDH is trivially brute-forcible.
 
 ---
 
-#### Batch 6 — CLI integration tests (`CliTest/`)
+#### Batch 6 — CLI integration tests (`CliTest/`) ✅ DONE v1.9.25
 
 New test scripts:
 - `CliTest/test_oprf.sh` — Python CLI keygen + blind + eval + unblind round-trip
@@ -5271,4 +5271,4 @@ New test scripts:
 5. **Batch 4** (aPAKE) — higher complexity; schedule after OPRF stabilises.
 6. **Batch 5** (Assembly/Arduino demo) — lowest priority; n=32 only.
 
-Status: **Batch 1 DONE v1.9.24** — Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`oprf-blind`, `oprf-eval`, `oprf-unblind` subcommands, `genpkey --algo oprf`) + `HerraduraCli/primitives.py` exports + `CliTest/test_oprf.sh` (8/8 passing). TODO
+Status: **Batch 1 DONE v1.9.24 · Batch 2 DONE v1.9.25 · Batch 3 DONE v1.9.25 · Batch 6 DONE v1.9.25** — Batch 1: Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`oprf-blind`, `oprf-eval`, `oprf-unblind`, `genpkey --algo oprf`) + `primitives.py` exports + `test_oprf.sh` (8/8). Batch 2: `herradura.h` OPRF functions (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`, `ba_modinv_ord`) + C suite demo + `herradura_cli.c` + `herradura_codec.h` PEM labels + `test_c_oprf.sh` (7/7). Batch 3: `herradura/herradura.go` (`OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`) + Go suite demo + `herradura_cli.go` + `test_go_oprf.sh` (7/7). Batch 6: `test_oprf_interop.sh` (8/8 cross-language combinations). TODO (Batch 4 aPAKE, Batch 5 Assembly)

--- a/TODO.md
+++ b/TODO.md
@@ -5093,7 +5093,7 @@ The following SecurityProofsCode scripts are **NOT** suitable for promotion:
 
 ---
 
-#### Batch 1 — OPRF: Python suite (`Herradura cryptographic suite.py`) + CLI (`herradura.py`)
+#### Batch 1 — OPRF: Python suite (`Herradura cryptographic suite.py`) + CLI (`herradura.py`) ✅ DONE v1.9.24
 
 **Suite functions to add** (prefix `oprf_`, following suite naming conventions):
 
@@ -5271,4 +5271,4 @@ New test scripts:
 5. **Batch 4** (aPAKE) — higher complexity; schedule after OPRF stabilises.
 6. **Batch 5** (Assembly/Arduino demo) — lowest priority; n=32 only.
 
-Status: TODO
+Status: **Batch 1 DONE v1.9.24** — Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`oprf-blind`, `oprf-eval`, `oprf-unblind` subcommands, `genpkey --algo oprf`) + `HerraduraCli/primitives.py` exports + `CliTest/test_oprf.sh` (8/8 passing). TODO

--- a/TODO.md
+++ b/TODO.md
@@ -5195,7 +5195,7 @@ BitArray/`[32]byte` type for GF elements alpha, beta, F.
 
 ---
 
-#### Batch 4 — aPAKE: Python/C/Go suite + CLI
+#### Batch 4 — aPAKE: Python suite + Python CLI ✅ DONE v1.9.26 (C/Go deferred)
 
 **Dependency:** Batches 1–3 (OPRF) must be complete first.
 
@@ -5271,4 +5271,4 @@ New test scripts:
 5. **Batch 4** (aPAKE) — higher complexity; schedule after OPRF stabilises.
 6. **Batch 5** (Assembly/Arduino demo) — lowest priority; n=32 only.
 
-Status: **Batch 1 DONE v1.9.24 · Batch 2 DONE v1.9.25 · Batch 3 DONE v1.9.25 · Batch 6 DONE v1.9.25** — Batch 1: Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`oprf-blind`, `oprf-eval`, `oprf-unblind`, `genpkey --algo oprf`) + `primitives.py` exports + `test_oprf.sh` (8/8). Batch 2: `herradura.h` OPRF functions (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`, `ba_modinv_ord`) + C suite demo + `herradura_cli.c` + `herradura_codec.h` PEM labels + `test_c_oprf.sh` (7/7). Batch 3: `herradura/herradura.go` (`OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`) + Go suite demo + `herradura_cli.go` + `test_go_oprf.sh` (7/7). Batch 6: `test_oprf_interop.sh` (8/8 cross-language combinations). TODO (Batch 4 aPAKE, Batch 5 Assembly)
+Status: **Batch 1 DONE v1.9.24 · Batch 2 DONE v1.9.25 · Batch 3 DONE v1.9.25 · Batch 4 DONE v1.9.26 (Python only) · Batch 6 DONE v1.9.25** — Batch 1: Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`oprf-blind`, `oprf-eval`, `oprf-unblind`, `genpkey --algo oprf`) + `primitives.py` exports + `test_oprf.sh` (8/8). Batch 2: `herradura.h` OPRF functions (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`, `ba_modinv_ord`) + C suite demo + `herradura_cli.c` + `herradura_codec.h` PEM labels + `test_c_oprf.sh` (7/7). Batch 3: `herradura/herradura.go` (`OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`) + Go suite demo + `herradura_cli.go` + `test_go_oprf.sh` (7/7). Batch 6: `test_oprf_interop.sh` (8/8 cross-language combinations). TODO (Batch 4 aPAKE, Batch 5 Assembly)

--- a/TODO.md
+++ b/TODO.md
@@ -5074,3 +5074,201 @@ was generating files that were already incompatible with Go and Python.
 their respective test suites without errors.
 
 Status: **DONE v1.9.18** — 79.A: all ZKP-NL types promoted to `uint64_t`, `ZKP_NL_MAX_N` bumped to 64; 79.B: `ba_rnl_kdf_seed` substituted for `ba_rol_k` in both `cmd_encfile` and `cmd_decfile`; stale comment at `herradura.h:633` updated.  All C tests pass (test [22] n=64 PASS); all encfile interop tests pass (4/4 C↔Python, 10/10 Go↔C↔Python).
+
+---
+
+### 80. Promote OPRF and PAKE to suite library and CLI (Feature, High)
+
+**Context:** TODO #78 produced two SecurityProofsCode demo scripts whose core functions are
+ready for promotion to the main library and CLI:
+
+- `SecurityProofsCode/oprf_demo.py` (`oprf_blind/eval/unblind/direct`) — 2HashDH OPRF over
+  GF(2^n)* using the existing `gf_pow` primitive.  Self-contained, clean API.
+- `SecurityProofsCode/hkex_pake_demo.py` (`pake_register/client_msg*/server_*`) — 3-message
+  PAKE using HKEX-RNL + ZKBoo + HFSCX-256.  Depends on OPRF for aPAKE upgrade.
+
+The following SecurityProofsCode scripts are **NOT** suitable for promotion:
+- `vdf_demo.py` — FSCX VDF broken by matrix attack; NL-FSCX v1 VDF lacks efficient verification.
+- `nl_fscx_v2_kex.py` / `nl_fscx_v2_orbit.py` — no working non-abelian protocol; research only.
+
+---
+
+#### Batch 1 — OPRF: Python suite (`Herradura cryptographic suite.py`) + CLI (`herradura.py`)
+
+**Suite functions to add** (prefix `oprf_`, following suite naming conventions):
+
+```python
+def oprf_keygen(n: int = KEYBITS) -> int:
+    """Random OPRF server key in [2, 2^n − 2]."""
+
+def oprf_blind(x: bytes, n: int = KEYBITS) -> tuple[int, int]:
+    """Client: hash x to GF(2^n)* and blind with random exponent r.
+    Returns (r, alpha) where alpha = H(x)^r.  r is the unblinding scalar."""
+
+def oprf_eval(alpha: int, k: int, n: int = KEYBITS) -> int:
+    """Server: evaluate alpha^k in GF(2^n)*  (one gf_pow call)."""
+
+def oprf_unblind(beta: int, r: int, n: int = KEYBITS) -> int:
+    """Client: recover F(k, x) = H(x)^k from beta = H(x)^{kr} by computing beta^{r^{-1}}."""
+
+def oprf_direct(x: bytes, k: int, n: int = KEYBITS) -> int:
+    """Direct PRF evaluation F(k, x) = H(x)^k (server-side only; not oblivious)."""
+```
+
+**Internal helper** (not exported):
+```python
+def _oprf_hash_to_field(data: bytes, n: int) -> int:
+    """HFSCX-256(data) → non-zero element of GF(2^n)."""
+```
+
+**Suite `main()` demo block** — show a complete blind/eval/unblind round-trip and the
+aPAKE use case (pw_key via OPRF instead of direct hash).
+
+**CLI subcommands** to add to `herradura.py`:
+
+```
+# Generate OPRF server private key
+herradura oprf-keygen [--algo oprf-gf256] > server_oprf.pem
+
+# Client: hash and blind input; outputs (r_scalar.hex, alpha.hex) to stdout
+herradura oprf-blind --input "password_or_bytes" > blind_out.txt
+
+# Server: evaluate blinded input with OPRF key
+herradura oprf-eval --key server_oprf.pem --alpha <hex> > beta.hex
+
+# Client: unblind server response to recover PRF output
+herradura oprf-unblind --alpha <hex> --beta <hex> --scalar <r_hex> > prf_out.hex
+```
+
+PEM label: `OPRF PRIVATE KEY` for the server key.
+The blinded value `alpha`, scalar `r`, and evaluation `beta` are passed as hex on
+stdin/stdout (similar to how `kex` outputs the session key).
+
+---
+
+#### Batch 2 — OPRF: C (`herradura.h` + `herradura_cli.c`)
+
+**`herradura.h` functions:**
+
+```c
+/* OPRF server key: random integer in [2, 2^KEYBITS - 2] stored in a BitArray. */
+void oprf_keygen(BitArray *key);
+
+/* Client blind: H(x,xlen) → GF(2^n) element, multiply by random exponent r.
+   Writes r_scalar (unblinding key) and alpha (blinded value) into caller-provided BitArrays. */
+void oprf_blind(const uint8_t *x, size_t xlen, BitArray *r_scalar, BitArray *alpha);
+
+/* Server eval: beta = alpha^k in GF(2^n)*. */
+void oprf_eval(const BitArray *alpha, const BitArray *k, BitArray *beta);
+
+/* Client unblind: F = beta^{r_inv} = H(x)^k. */
+void oprf_unblind(const BitArray *beta, const BitArray *r_scalar, BitArray *F);
+
+/* Direct PRF (server-side, non-oblivious): F = H(x)^k. */
+void oprf_direct(const uint8_t *x, size_t xlen, const BitArray *k, BitArray *F);
+```
+
+**`herradura_cli.c`** — add `cmd_oprf_keygen`, `cmd_oprf_blind`, `cmd_oprf_eval`,
+`cmd_oprf_unblind` and register them in the dispatch table.  PEM codec reuse from
+`herradura_codec.h`.
+
+---
+
+#### Batch 3 — OPRF: Go (`herradura/herradura.go` + `herradura_cli.go`)
+
+**Package functions:**
+
+```go
+func OprfKeygen() *big.Int                          // server key
+func OprfBlind(x []byte) (r, alpha *big.Int)        // client blind
+func OprfEval(alpha, k *big.Int) *big.Int            // server eval
+func OprfUnblind(beta, r *big.Int) *big.Int          // client unblind
+func OprfDirect(x []byte, k *big.Int) *big.Int       // direct PRF (non-oblivious)
+```
+
+**`herradura_cli.go`** — add `cmdOprfKeygen`, `cmdOprfBlind`, `cmdOprfEval`,
+`cmdOprfUnblind` and register them.
+
+**Note on `*big.Int` vs `BitArray`:** OPRF scalars are integers mod GF_ORDER = 2^n − 1,
+not GF(2^n) field elements.  Use `*big.Int` for scalars r and k; use the existing
+BitArray/`[32]byte` type for GF elements alpha, beta, F.
+
+---
+
+#### Batch 4 — aPAKE: Python/C/Go suite + CLI
+
+**Dependency:** Batches 1–3 (OPRF) must be complete first.
+
+**Protocol** (3-message aPAKE using HKEX-RNL + OPRF + ZKBoo):
+
+```
+Registration (one-time, client-server):
+    client → server: alpha = oprf_blind(password)
+    server → client: beta  = oprf_eval(alpha, k_s)
+    client: pw_oprf = oprf_unblind(beta, r); pw_key = hfscx_256(pw_oprf ‖ salt)
+    client: zkp_A = hfscx_256(pw_key ‖ "ZKP-A") & mask; B = random; y = nl_fscx_v1(zkp_A, B)
+    server stores: (username, salt, B, y)   [no password, no H(password)]
+
+Login (3 messages):
+    msg1 client→server: HKEX-RNL C_client
+    msg2 server→client: HKEX-RNL C_server + alpha_r = oprf_blind(password)  ← OPRF blind
+                        NOTE: server cannot compute alpha_r itself (client-only step)
+    [actually 4-message for aPAKE — see note below]
+```
+
+**Protocol note:** Full aPAKE requires the client to blind the password and send alpha to
+the server for OPRF evaluation, then unblind.  This adds one extra round-trip vs. the
+plain PAKE in `hkex_pake_demo.py`.  The CLI demo mode runs both sides in a single process
+(like `kex` with `--our`/`--their`).
+
+**Suite functions** (prefix `hpake_`):
+```python
+def hpake_register(username, password, oprf_key) -> dict  # server record
+def hpake_login_demo(record, password, oprf_key) -> bytes | None  # full 4-msg demo
+```
+
+**CLI:**
+```
+herradura pake register --oprf-key server_oprf.pem --username alice > record.pem  # reads pw from stdin
+herradura pake login   --oprf-key server_oprf.pem --record record.pem             # reads pw from stdin
+herradura pake demo    --oprf-key server_oprf.pem  # runs both sides, shows session key match
+```
+
+**ZKBoo performance caveat:** In Python, ZKBoo at n=256 requires C/Go extensions or
+reduced rounds.  The Python suite will use n=32 demo parameters with a visible warning;
+C and Go will use n=256.
+
+---
+
+#### Batch 5 — Assembly/Arduino n=32 OPRF demo (Low priority)
+
+`gf_pow` at n=32 already exists in ARM Thumb-2, NASM i386, and Arduino targets.  A minimal
+n=32 OPRF demo block (blind/eval/unblind) can be added to each, following the pattern of
+the FPE/Tweakable demos added in TODO #78.
+
+**Security advisory required:** Output a clear `[DEMO n=32 — NOT PRODUCTION SECURE]`
+message. n=32 GF(2^32)* CDH is trivially brute-forcible.
+
+---
+
+#### Batch 6 — CLI integration tests (`CliTest/`)
+
+New test scripts:
+- `CliTest/test_oprf.sh` — Python CLI keygen + blind + eval + unblind round-trip
+- `CliTest/test_c_oprf.sh` — C CLI equivalent
+- `CliTest/test_go_oprf.sh` — Go CLI equivalent
+- `CliTest/test_oprf_interop.sh` — cross-language: Python key, C eval, Go unblind (and permutations)
+- `CliTest/test_pake.sh` — Python CLI aPAKE register + login demo
+
+---
+
+#### Priority order
+
+1. **Batch 1** (Python OPRF) — unblocks aPAKE and is the simplest starting point.
+2. **Batch 2** (C OPRF) — adds `herradura.h` exports; enables C CLI and interop tests.
+3. **Batch 3** (Go OPRF) — completes the three-language tier.
+4. **Batch 6** (CLI tests) — validates interop; run after each language batch.
+5. **Batch 4** (aPAKE) — higher complexity; schedule after OPRF stabilises.
+6. **Batch 5** (Assembly/Arduino demo) — lowest priority; n=32 only.
+
+Status: TODO

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -11,6 +11,8 @@ The suite implements four protocol families plus a hash primitive:
 | Schnorr signature | HPKS | HPKS-NL | HPKS-Stern-F |
 | El Gamal encryption | HPKE | HPKE-NL | HPKE-Stern-F |
 | Hash / MAC | — | HFSCX-256 | — |
+| OPRF | — | 2HashDH over GF(2^256) | — |
+| aPAKE | — | HKEX-RNL + ZKBoo + OPRF | — |
 
 **Security note:** The classical protocols (HKEX-GF, HSKE, HPKS, HPKE) are vulnerable to quantum
 attacks. Use the NL/PQC or code-based variants for new deployments. See [Security notes](#security-notes).
@@ -28,9 +30,10 @@ with toy examples and verified references.
 2. [Go integration](#go-integration)
 3. [Python integration](#python-integration)
 4. [ZKP Protocols](#zkp-protocols)
-5. [Protocol reference](#protocol-reference)
-6. [Parameter reference](#parameter-reference)
-7. [Security notes](#security-notes)
+5. [OPRF and aPAKE](#oprf-and-apake)
+6. [Protocol reference](#protocol-reference)
+7. [Parameter reference](#parameter-reference)
+8. [Security notes](#security-notes)
 
 ---
 
@@ -209,6 +212,42 @@ for (int i = 0; i < KEYBYTES; i++)
 hfscx_256(msg, sizeof msg - 1, mac_iv, digest);
 ```
 
+### OPRF (2HashDH oblivious PRF)
+
+The OPRF protocol lets a client evaluate `F(k, x) = gf_pow(H(x), k)` without
+revealing `x` to the server or `k` to the client.
+
+```c
+#include "herradura.h"
+
+FILE *urnd = fopen("/dev/urandom", "rb");
+BitArray oprf_k, oprf_r, oprf_alpha, oprf_beta, oprf_F, oprf_check;
+
+/* Key generation (server side) */
+oprf_keygen(&oprf_k, urnd);
+
+/* Blinding (client side) */
+const char *input = "my-password";
+oprf_blind((const uint8_t *)input, strlen(input), &oprf_r, &oprf_alpha, urnd);
+
+/* Evaluation (server side) */
+oprf_eval(&oprf_beta, &oprf_alpha, &oprf_k);
+
+/* Unblinding (client side): yields F(k, input) */
+oprf_unblind(&oprf_F, &oprf_beta, &oprf_r);
+
+/* Direct evaluation (server, no blinding) — result matches */
+oprf_direct(&oprf_check, (const uint8_t *)input, strlen(input), &oprf_k);
+/* memcmp(oprf_F.b, oprf_check.b, KEYBYTES) == 0 */
+```
+
+`oprf_blind` retries internally until the random blinding factor `r` is coprime
+to ORD = 2^256−1 (expected two attempts on average, since ORD has small factors
+3, 5, 17, 257, 641).
+
+All OPRF functions are declared in `herradura.h`; the PEM wire format for OPRF
+keys is identical across C, Go, and Python CLIs.
+
 ### Complete runnable example
 
 See [`docs/examples/c/hello_herradura.c`](examples/c/hello_herradura.c).
@@ -346,6 +385,31 @@ for i := range macIV {
 mac := Hfscx256(data, macIV)
 ```
 
+### OPRF (2HashDH oblivious PRF)
+
+```go
+import "herradurakex"
+
+// Key generation (server side)
+k, _ := herradurakex.OprfKeygen(256)
+
+// Blinding (client side)
+r, alpha, _ := herradurakex.OprfBlind([]byte("my-password"), 256)
+
+// Evaluation (server side)
+beta := herradurakex.OprfEval(alpha, k, 256)
+
+// Unblinding (client side): yields F(k, input)
+F := herradurakex.OprfUnblind(beta, r, 256)
+
+// Direct evaluation — result matches
+check := herradurakex.OprfDirect([]byte("my-password"), k, 256)
+// F.Cmp(check) == 0
+```
+
+`OprfBlind` retries internally until `r` is coprime to ORD = 2^256−1.
+All return values are `*big.Int`.
+
 ### Complete runnable example
 
 ```bash
@@ -468,6 +532,59 @@ digest = h.hfscx_256(data)
 mac_iv = h.BitArray(n, alice_shared.uint ^ int.from_bytes(h._HFSCX256_IV_BYTES, 'big'))
 mac = h.hfscx_256(data, iv=mac_iv)
 ```
+
+### OPRF (2HashDH oblivious PRF)
+
+```python
+# Key generation (server side)
+k = h.oprf_keygen()                      # random element of GF(2^256)*
+
+# Blinding (client side)
+r, alpha = h.oprf_blind(b"my-password")  # alpha = H(x)^r
+
+# Evaluation (server side)
+beta = h.oprf_eval(alpha, k)             # beta = alpha^k
+
+# Unblinding (client side): yields F(k, x) = H(x)^k
+F = h.oprf_unblind(beta, r)             # F = beta^{r^{-1}}
+
+# Direct evaluation (same result, no blinding)
+check = h.oprf_direct(b"my-password", k)
+assert F == check
+```
+
+`oprf_blind` retries internally until `r` is coprime to ORD = 2^256−1.
+All scalars are Python `int`; the hash-to-field function is `HFSCX-256`.
+
+### aPAKE (augmented password-authenticated key exchange)
+
+The aPAKE construction combines HKEX-RNL (Ring-LWR channel), ZKBoo (zero-knowledge
+proof of password knowledge), and OPRF (server-side augmentation).  The server
+database stores an OPRF output — not a password hash — so a stolen database cannot
+be attacked offline without also compromising the OPRF key.
+
+```python
+# --- Registration (server side) ---
+oprf_key = h.oprf_keygen()
+record = h.hpake_register("alice", "s3cr3t", oprf_key)
+# record = {"salt": <int>, "B": <int>, "y": <int>}
+# Store record in your user database; oprf_key stays on the server.
+
+# --- Login (both sides) ---
+session_key = h.hpake_login_demo(record, "s3cr3t", oprf_key)
+# Returns 32-byte session key on success, None on failure.
+assert session_key is not None
+
+wrong_pw = h.hpake_login_demo(record, "wrong", oprf_key)
+assert wrong_pw is None
+```
+
+`hpake_register` and `hpake_login_demo` are defined in
+`Herradura cryptographic suite.py`.  The Python CLI (`herradura.py`) exposes the
+same flow via `pake-register` and `pake-demo` subcommands — see the
+[OPRF and aPAKE](#oprf-and-apake) section for CLI examples.
+
+Demo parameters: `_HPAKE_ZKP_N = 32`, `_HPAKE_ROUNDS = 16`.
 
 ### NumPy acceleration
 
@@ -666,6 +783,85 @@ For NL-FSCX witness statements, ZKP-NL is the only applicable construction.
 
 ---
 
+## OPRF and aPAKE
+
+### OPRF overview
+
+The **2HashDH OPRF** (Oblivious Pseudo-Random Function) lets a client compute
+`F(k, x) = gf_pow(H(x), k)` without learning the server key `k` and without
+the server learning the input `x`.
+
+```
+client                           server
+------                           ------
+r ← coprime random scalar
+alpha = H(x)^r          ─── alpha ──►   beta = alpha^k
+F = beta^{r^{-1}}       ◄── beta ────
+```
+
+`H` maps arbitrary bytes to a non-zero GF(2^256)* element via HFSCX-256.
+The blinding factor `r` must be coprime to ORD = 2^256−1; all three
+implementations retry automatically (expected two attempts on average).
+
+### OPRF CLI usage (Python, C, Go)
+
+All three CLIs share the same subcommands and PEM wire format:
+
+```bash
+# --- Python CLI ---
+# 1. Generate OPRF server key
+python3 HerraduraCli/herradura.py genpkey --algo oprf --out server.pem
+
+# 2. Client blinds its input
+python3 HerraduraCli/herradura.py oprf-blind --input "my-password" --out state.pem
+
+# 3. Server evaluates (state.pem contains alpha; server.pem contains k)
+python3 HerraduraCli/herradura.py oprf-eval --key server.pem --in state.pem --out eval.pem
+
+# 4. Client unblinds to obtain F(k, x) as 64-char hex
+python3 HerraduraCli/herradura.py oprf-unblind --state state.pem --eval eval.pem
+
+# --- C CLI (identical subcommands) ---
+./HerraduraCli/herradura_cli genpkey   --algo oprf --out server.pem
+./HerraduraCli/herradura_cli oprf-blind  --input "my-password" --out state.pem
+./HerraduraCli/herradura_cli oprf-eval   --key server.pem --in state.pem --out eval.pem
+./HerraduraCli/herradura_cli oprf-unblind --state state.pem --eval eval.pem
+
+# --- Go CLI (identical subcommands) ---
+./HerraduraCli/herradura_cli_go genpkey    --algo oprf --out server.pem
+./HerraduraCli/herradura_cli_go oprf-blind  --input "my-password" --out state.pem
+./HerraduraCli/herradura_cli_go oprf-eval   --key server.pem --in state.pem --out eval.pem
+./HerraduraCli/herradura_cli_go oprf-unblind --state state.pem --eval eval.pem
+```
+
+PEM files produced by any implementation are byte-for-byte compatible with the
+others.  See `CliTest/test_oprf_interop.sh` for a 6-way cross-language
+interop test (Python/C/Go key × blind × eval × unblind).
+
+### aPAKE CLI usage (Python CLI)
+
+The aPAKE flow requires the Python CLI.  The C and Go CLIs support OPRF
+but not the full aPAKE registration/login flow.
+
+```bash
+# 1. Generate OPRF server key (one time)
+python3 HerraduraCli/herradura.py genpkey --algo oprf --out server.pem
+
+# 2. Register a user (stores PAKE RECORD PEM — no plaintext password)
+python3 HerraduraCli/herradura.py pake-register \
+    --key server.pem --username alice --password s3cr3t --out record.pem
+
+# 3. Demo login (runs both sides in one command for testing)
+python3 HerraduraCli/herradura.py pake-demo \
+    --key server.pem --username alice --password s3cr3t
+```
+
+`pake-demo` reads the record generated by the most recent `pake-register` for
+the given username and prints the session key on success, or reports rejection
+for a wrong password.  See `CliTest/test_pake.sh` for the full integration test.
+
+---
+
 ## Protocol reference
 
 ### Classical protocols
@@ -700,6 +896,18 @@ For NL-FSCX witness statements, ZKP-NL is the only applicable construction.
 |---|---|---|---|---|
 | ZKP-RNL (Ring-LWR Σ-protocol) | `hkex-rnl` | `rnl_sigma_sign` | `rnl_sigma_verify` | 1,056 B (n=256) |
 | ZKP-NL (NL-FSCX ZKBoo) | `hpks-zkp-nl` | `zkp_nl_prove` | `zkp_nl_verify` | 35.5 KB (n=8, R=219) |
+
+### OPRF and aPAKE
+
+| Protocol | Key type | Hard problem | Availability |
+|----------|----------|--------------|--------------|
+| OPRF (2HashDH) | `oprf` | DLP in GF(2^256) | C, Go, Python, all CLIs |
+| aPAKE | `oprf` | DLP + Ring-LWR + NL-FSCX OWF | Python suite + Python CLI |
+
+The OPRF output is `F(k, x) = gf_pow(H(x), k)` where `H` is HFSCX-256 hash-to-field.
+The aPAKE protocol uses HKEX-RNL for the key exchange channel, ZKBoo for the
+zero-knowledge proof of password knowledge, and the OPRF to augment the server
+record (demo parameters: `_HPAKE_ZKP_N = 32`, `_HPAKE_ROUNDS = 16`).
 
 ### Hash primitive
 
@@ -738,6 +946,14 @@ void hpks_stern_f_sign   (SternSig *sig, const BitArray *msg, const BitArray *e,
                            const BitArray *seed, FILE *urnd);
 int  hpks_stern_f_verify (const SternSig *sig, const BitArray *msg,
                            const BitArray *seed, const uint8_t *syndr);
+
+/* OPRF (2HashDH) */
+void oprf_keygen (BitArray *k, FILE *urnd);
+void oprf_blind  (const uint8_t *x, size_t xlen,
+                  BitArray *r, BitArray *alpha, FILE *urnd);
+void oprf_eval   (BitArray *beta, const BitArray *alpha, const BitArray *k);
+void oprf_unblind(BitArray *F, const BitArray *beta, const BitArray *r);
+void oprf_direct (BitArray *F, const uint8_t *x, size_t xlen, const BitArray *k);
 ```
 
 ---
@@ -758,6 +974,9 @@ int  hpks_stern_f_verify (const SternSig *sig, const BitArray *msg,
 | Stern ZKP rounds (demo) | `SDF_ROUNDS` | `SdfRounds` | `SDFR` | 32 (N=256) |
 | GF generator | `GF_GEN` (BitArray) | `GfGen = 3` | `GF_GEN = 3` | 3 |
 | HFSCX-256 domain IV | `_HFSCX256_IV[32]` | `Hfscx256IV` | `_HFSCX256_IV_BYTES` | `b'HFSCX-256/HERRADURA-SUITE\x00…'` |
+| OPRF field order | `ORD` (2^256−1) | computed from `n=256` | computed from `KEYBITS` | 2^256−1 |
+| aPAKE ZKBoo width | — | — | `_HPAKE_ZKP_N` | 32 (demo) |
+| aPAKE ZKP rounds | — | — | `_HPAKE_ROUNDS` | 16 (demo) |
 
 Stern-F parameters scale with N: T = N/16, rows = N/4.  C/Go/Python support
 N ∈ {32, 64, 128, 256}; assembly and Arduino targets are fixed at N=32 (T=2, rounds=4).
@@ -804,6 +1023,26 @@ models that exclude quantum adversaries.
   Production requires `rounds ≥ 219` for 128-bit soundness.
 - **HPKE-Stern-F decapsulation** in the demo uses a known error vector (`e'`).
   A production deployment requires a QC-MDPC or similar decoder.
+
+### OPRF and aPAKE
+
+- **OPRF security** rests on the DLP in GF(2^256)* — the same assumption as
+  HKEX-GF.  It is **not** quantum-resistant; a quantum adversary who breaks DLP
+  can recover the server key `k` from any blinded query.
+- **ORD = 2^256−1 is composite** with small factors (3, 5, 17, 257, 641, …).
+  Roughly 50% of random 256-bit scalars share a factor with ORD and cannot be
+  inverted.  All three implementations retry until `gcd(r, ORD) = 1`.  Never
+  supply a static or low-entropy blinding factor; always generate `r` from a
+  cryptographic RNG.
+- **OPRF blinding factor leakage:** The client's blinding factor `r` must be kept
+  secret.  If `r` is leaked, the server can recover `x` from `alpha = H(x)^r`.
+- **aPAKE demo parameters** (`_HPAKE_ZKP_N = 32`, `_HPAKE_ROUNDS = 16`) are for
+  testing only.  The ZKBoo soundness error with these parameters is not suitable
+  for production — use `_HPAKE_ROUNDS ≥ 219` for 128-bit soundness.
+- **aPAKE OPRF key compromise:** If the OPRF key `k` is stolen, an attacker can
+  compute `F(k, pw)` for any guessed password offline.  The aPAKE record stores
+  the OPRF output, not the raw password hash, to prevent offline dictionary attacks
+  on a stolen database *alone* — but the OPRF key must still be protected.
 
 ### Constant-time status
 

--- a/herradura.h
+++ b/herradura.h
@@ -2509,4 +2509,201 @@ static inline void ratchet_erase(BitArray *state)
     explicit_bzero(state->b, KEYBYTES);
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 80 — Oblivious PRF (OPRF) over GF(2^KEYBITS)*  (TODO #80)
+ * Protocol: 2HashDH — F(k, x) = gf_pow(H(x), k)
+ *   Client blinds: alpha = H(x)^r   (r random, gcd(r, ORD) == 1)
+ *   Server evals:  beta  = alpha^k
+ *   Client unblinds: F   = beta^{r^{-1} mod ORD}
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+/* ba_cmp256: return -1, 0, +1 for a<b, a==b, a>b (big-endian). */
+static int ba_cmp256(const BitArray *a, const BitArray *b)
+{
+    int i;
+    for (i = 0; i < KEYBYTES; i++) {
+        if (a->b[i] < b->b[i]) return -1;
+        if (a->b[i] > b->b[i]) return  1;
+    }
+    return 0;
+}
+
+/* 33-byte (257-bit) big-endian integer helpers used only by ba_modinv_ord. */
+static int _ba33_cmp(const uint8_t *a, const uint8_t *b)
+{
+    int i;
+    for (i = 0; i < 33; i++) {
+        if (a[i] < b[i]) return -1;
+        if (a[i] > b[i]) return  1;
+    }
+    return 0;
+}
+static int _ba33_iszero(const uint8_t *a)
+{
+    int i;
+    for (i = 0; i < 33; i++) if (a[i]) return 0;
+    return 1;
+}
+
+/* ba_modinv_ord: compute dst = a^{-1} mod (2^KEYBITS-1) via binary extended GCD.
+   Requires gcd(a, ORD) == 1; result is undefined if gcd != 1.
+   ORD = 2^256-1 is all-0xFF bytes.
+   Uses 33-byte (257-bit) big-endian arrays for the Bezout coefficients to
+   avoid overflow when adding ORD to make them positive. */
+static void ba_modinv_ord(BitArray *dst, const BitArray *a)
+{
+    static const uint8_t ORD33[33] = {
+        0x00,
+        0xFF,0xFF,0xFF,0xFF, 0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF, 0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF, 0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF, 0xFF,0xFF,0xFF,0xFF
+    };
+    /* 257-bit big-endian unsigned arithmetic helpers (inline, avoiding recursion) */
+#define ADD33(dst33, a33, b33) do { \
+        uint16_t _c = 0; int _i; \
+        for (_i = 32; _i >= 0; _i--) { \
+            uint16_t _s = (uint16_t)(a33)[_i] + (b33)[_i] + _c; \
+            (dst33)[_i] = (uint8_t)_s; _c = _s >> 8; \
+        } \
+    } while(0)
+#define SUB33(dst33, a33, b33) do { \
+        int16_t _bor = 0; int _i; \
+        for (_i = 32; _i >= 0; _i--) { \
+            int16_t _s = (int16_t)(a33)[_i] - (int16_t)(b33)[_i] - _bor; \
+            (dst33)[_i] = (uint8_t)_s; _bor = (_s < 0) ? 1 : 0; \
+        } \
+    } while(0)
+#define SHR1_33(arr) do { \
+        int _i; \
+        for (_i = 32; _i > 0; _i--) \
+            (arr)[_i] = (uint8_t)(((arr)[_i] >> 1) | ((arr)[_i-1] << 7)); \
+        (arr)[0] >>= 1; \
+    } while(0)
+#define IS_ODD33(arr)  ((arr)[32] & 1u)
+
+    /* non-macro helpers for CMP33 and IS_ZERO33 to avoid GNU statement-expr */
+#define CMP33(a33, b33) _ba33_cmp(a33, b33)
+#define IS_ZERO33(arr)  _ba33_iszero(arr)
+
+
+    /* u, v: 33-byte big-endian integers (u = a, v = ORD) */
+    uint8_t u[33], v[33], x1[33], x2[33], tmp[33];
+    int i;
+
+    /* u = a (zero-extend to 33 bytes) */
+    u[0] = 0;
+    memcpy(u + 1, a->b, KEYBYTES);
+    /* v = ORD */
+    memcpy(v, ORD33, 33);
+    /* x1 = 1, x2 = 0 */
+    memset(x1, 0, 33); x1[32] = 1;
+    memset(x2, 0, 33);
+
+    /* Binary extended GCD: invariant a*x1 ≡ u (mod ORD), a*x2 ≡ v (mod ORD) */
+    for (i = 0; i < 2 * KEYBITS + 64; i++) {
+        if (IS_ZERO33(u)) break;
+
+        if (!IS_ODD33(u)) {
+            SHR1_33(u);
+            if (IS_ODD33(x1)) { ADD33(tmp, x1, ORD33); memcpy(x1, tmp, 33); }
+            SHR1_33(x1);
+            continue;
+        }
+        if (!IS_ODD33(v)) {
+            SHR1_33(v);
+            if (IS_ODD33(x2)) { ADD33(tmp, x2, ORD33); memcpy(x2, tmp, 33); }
+            SHR1_33(x2);
+            continue;
+        }
+        if (CMP33(u, v) >= 0) {
+            SUB33(u, u, v);
+            /* x1 = (x1 - x2) mod ORD: if x1 < x2, add ORD first */
+            if (CMP33(x1, x2) < 0) { ADD33(tmp, x1, ORD33); memcpy(x1, tmp, 33); }
+            SUB33(x1, x1, x2);
+        } else {
+            SUB33(v, v, u);
+            if (CMP33(x2, x1) < 0) { ADD33(tmp, x2, ORD33); memcpy(x2, tmp, 33); }
+            SUB33(x2, x2, x1);
+        }
+    }
+    /* At exit: if u != 0, gcd was found via u; coefficient is x1.
+       Otherwise v == gcd (should be 1) and x2 is the inverse. */
+    if (!IS_ZERO33(u))
+        memcpy(dst->b, u + 1, KEYBYTES);  /* fallback: shouldn't happen if gcd==1 */
+    else
+        memcpy(dst->b, x2 + 1, KEYBYTES);
+
+    /* Reduce mod ORD: if result is all-0xFF (== ORD), set to 0
+       (ORD ≡ 0 mod ORD; this can't be a valid inverse of any element != 0) */
+    { int all_ff = 1;
+      for (i = 0; i < KEYBYTES; i++) all_ff &= (dst->b[i] == 0xFF);
+      if (all_ff) memset(dst->b, 0, KEYBYTES);
+    }
+
+#undef ADD33
+#undef SUB33
+#undef SHR1_33
+#undef CMP33
+#undef IS_ZERO33
+#undef IS_ODD33
+}
+
+/* oprf_hash_to_field: HFSCX-256(data) → non-zero element of GF(2^KEYBITS)*. */
+static void oprf_hash_to_field(BitArray *dst, const uint8_t *data, size_t dlen)
+{
+    hfscx_256(data, dlen, NULL, dst->b);
+    if (ba_is_zero(dst))
+        dst->b[KEYBYTES - 1] = 1;   /* map 0 → 1 (negligible probability) */
+}
+
+/* oprf_keygen: fill key with a random element of [2, 2^KEYBITS-2].
+   urnd must be an open handle to /dev/urandom (or equivalent). */
+static void oprf_keygen(BitArray *key, FILE *urnd)
+{
+    do { ba_rand(key, urnd); } while (ba_is_zero(key) || ba_cmp256(key, &ONE_BA) == 0);
+}
+
+/* oprf_blind: client step — hash x and blind with random scalar r.
+   Outputs r (blinding scalar, keep secret) and alpha = H(x)^r.
+   gcd(r, ORD) == 1 is ensured by verifying r * r^{-1} == 1 mod ORD and retrying.
+   ORD = 2^256-1 factors include 3, 5, 17, 257, 641 — ~50% of random values are coprime.
+   Expected retries: ~2 attempts on average. */
+static void oprf_blind(const uint8_t *x, size_t xlen,
+                       BitArray *r_out, BitArray *alpha_out, FILE *urnd)
+{
+    BitArray hx, r_inv, check;
+    oprf_hash_to_field(&hx, x, xlen);
+    do {
+        ba_rand(r_out, urnd);
+        if (ba_is_zero(r_out) || ba_cmp256(r_out, &ONE_BA) == 0) continue;
+        /* verify gcd(r, ORD) == 1 by checking r * r^{-1} == 1 mod ORD */
+        ba_modinv_ord(&r_inv, r_out);
+        ba_mul_mod_ord(&check, r_out, &r_inv);
+    } while (ba_cmp256(&check, &ONE_BA) != 0);
+    gf_pow_ba(alpha_out, &hx, r_out);
+}
+
+/* oprf_eval: server step — compute beta = alpha^k. */
+static void oprf_eval(BitArray *beta, const BitArray *alpha, const BitArray *k)
+{
+    gf_pow_ba(beta, alpha, k);
+}
+
+/* oprf_unblind: client step — recover F(k,x) = beta^{r^{-1} mod ORD}. */
+static void oprf_unblind(BitArray *F, const BitArray *beta, const BitArray *r)
+{
+    BitArray r_inv;
+    ba_modinv_ord(&r_inv, r);
+    gf_pow_ba(F, beta, &r_inv);
+}
+
+/* oprf_direct: direct PRF evaluation F(k, x) = H(x)^k (server-only, not oblivious). */
+static void oprf_direct(BitArray *F, const uint8_t *x, size_t xlen, const BitArray *k)
+{
+    BitArray hx;
+    oprf_hash_to_field(&hx, x, xlen);
+    gf_pow_ba(F, &hx, k);
+}
+
 #endif /* HERRADURA_H */

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -2033,6 +2033,85 @@ var ratchetDomain = func() *BitArray {
 	return NewBitArray(256, new(big.Int).SetBytes(d[:32]))
 }()
 
+// ── 80 — Oblivious PRF (OPRF) over GF(2^n)*  ─────────────────────────────────
+// Protocol: 2HashDH — F(k, x) = GfPow(H(x), k)
+//   Client blinds: alpha = H(x)^r  (r random, gcd(r, ord) == 1)
+//   Server evals:  beta  = alpha^k
+//   Client unblinds: F   = beta^{r^{-1} mod ord}
+
+func oprfOrd(n int) *big.Int {
+	return new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(n)), big.NewInt(1))
+}
+
+func oprfHashToField(data []byte, n int) *big.Int {
+	h   := Hfscx256(data, nil)
+	v   := new(big.Int).SetBytes(h)
+	v.And(v, oprfOrd(n))
+	if v.Sign() == 0 {
+		v.SetInt64(1)
+	}
+	return v
+}
+
+// OprfKeygen returns a random OPRF server key in [2, 2^n-2].
+func OprfKeygen(n int) (*big.Int, error) {
+	ord := oprfOrd(n)
+	for {
+		k, err := rand.Int(rand.Reader, ord)
+		if err != nil {
+			return nil, err
+		}
+		if k.Cmp(big.NewInt(1)) > 0 {
+			return k, nil
+		}
+	}
+}
+
+// OprfBlind hashes x to GF(2^n)* and blinds with a random coprime scalar r.
+// Returns (r, alpha) where alpha = H(x)^r.
+func OprfBlind(x []byte, n int) (r, alpha *big.Int, err error) {
+	ord  := oprfOrd(n)
+	poly := GfPoly[n]
+	hx   := oprfHashToField(x, n)
+	for {
+		rCand, e := rand.Int(rand.Reader, ord)
+		if e != nil {
+			return nil, nil, e
+		}
+		if rCand.Cmp(big.NewInt(1)) <= 0 {
+			continue
+		}
+		rInv := new(big.Int).ModInverse(rCand, ord)
+		if rInv == nil {
+			continue // gcd(r, ord) != 1
+		}
+		r = rCand
+		alpha = GfPow(hx, r, poly, n)
+		return r, alpha, nil
+	}
+}
+
+// OprfEval computes beta = alpha^k in GF(2^n)*.
+func OprfEval(alpha, k *big.Int, n int) *big.Int {
+	return GfPow(alpha, k, GfPoly[n], n)
+}
+
+// OprfUnblind recovers F(k, x) = beta^{r^{-1} mod ord}.
+func OprfUnblind(beta, r *big.Int, n int) *big.Int {
+	ord  := oprfOrd(n)
+	rInv := new(big.Int).ModInverse(r, ord)
+	if rInv == nil {
+		return big.NewInt(0) // should not happen if r came from OprfBlind
+	}
+	return GfPow(beta, rInv, GfPoly[n], n)
+}
+
+// OprfDirect computes F(k, x) = H(x)^k directly (server-only, not oblivious).
+func OprfDirect(x []byte, k *big.Int, n int) *big.Int {
+	hx := oprfHashToField(x, n)
+	return GfPow(hx, k, GfPoly[n], n)
+}
+
 // RatchetInit derives an initial ratchet state from seed via Hfscx256(seed||0x02).
 func RatchetInit(seed []byte) *BitArray {
 	buf := append(append([]byte(nil), seed...), 0x02)


### PR DESCRIPTION
## Summary

- **Batch 1 (v1.9.24)**: 2HashDH OPRF over GF(2^256)* in Python suite (`oprf_keygen`, `oprf_blind`, `oprf_eval`, `oprf_unblind`, `oprf_direct`) + Python CLI (`genpkey --algo oprf`, `oprf-blind`, `oprf-eval`, `oprf-unblind`) + `CliTest/test_oprf.sh` (8/8)
- **Batch 2 (v1.9.25)**: C implementation in `herradura.h` (`ba_modinv_ord` via binary ext. GCD with coprimality retry, full OPRF API) + C CLI + OPRF demo in C suite `main()` + `CliTest/test_c_oprf.sh` (7/7)
- **Batch 3 (v1.9.25)**: Go implementation in `herradura/herradura.go` (`OprfKeygen/Blind/Eval/Unblind/Direct` using `big.Int.ModInverse`) + Go CLI + OPRF demo in Go suite `main()` + `CliTest/test_go_oprf.sh` (7/7)
- **Batch 4 (v1.9.26)**: aPAKE (HKEX-RNL + ZKBoo + OPRF augmented PAKE) in Python suite (`hpake_register`, `hpake_login_demo`) + Python CLI (`pake-register`, `pake-demo`) + `CliTest/test_pake.sh` (7/7)
- **Batch 6 (v1.9.25)**: Cross-language OPRF interop tests `CliTest/test_oprf_interop.sh` — all 6 language-pair combinations (Python/C/Go key × blind × eval × unblind) + C=Go eval consistency — 8/8 passing

Total: 37 integration tests across 5 test scripts, all passing.

## Test plan

- [x] `bash CliTest/test_oprf.sh` — 8/8 Python CLI OPRF tests
- [x] `bash CliTest/test_c_oprf.sh` — 7/7 C CLI OPRF tests
- [x] `bash CliTest/test_go_oprf.sh` — 7/7 Go CLI OPRF tests
- [x] `bash CliTest/test_oprf_interop.sh` — 8/8 cross-language interop tests
- [x] `bash CliTest/test_pake.sh` — 7/7 aPAKE tests
- [x] `./Herradura cryptographic suite_c` — OPRF demo shows "round-trip correct"
- [x] `go run "Herradura cryptographic suite.go"` — OPRF demo shows "round-trip correct"
- [x] `python3 "Herradura cryptographic suite.py"` — OPRF + aPAKE demos correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)