### PR TITLE
Fix spurious FAIL in Python test [25] Masked HSKE under time-limited runs — v1.9.29 (TODO #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.29] - 2026-06-10
+
+### Fix — Spurious FAIL in Python test [25] Masked HSKE under time-limited runs (TODO #84)
+
+- **`CryptosuiteTests/Herradura_tests.py`**: `test_masked_hske` compared `ok == N` (requested iterations) rather than `ok == n_run` (actual iterations run). When a `-t` time limit causes `_trange` to stop early (e.g., after 128 or 192 of 200 requested iterations), all passed iterations were reported as failures. Added `n_run` counter matching the pattern used by every other `_trange`-based test in the suite; PASS condition is now `ok == n_run`.
+
+---
+
 ## [1.9.28] - 2026-06-10
 
 ### Security — Fix three vulnerabilities identified in security review (TODO #81, #82, #83)

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1820,8 +1820,9 @@ def test_accumulator_correctness():
 def test_masked_hske():
     print("[25] Masked HSKE (78.H) — GF(2)-linearity masking correctness  [NEW]")
     N = _iters(200)
-    ok = 0
+    ok = 0; n_run = 0
     for _ in _trange(N):
+        n_run += 1
         pt   = BitArray.random(_KEYBITS)
         key  = BitArray.random(_KEYBITS)
         mask = BitArray.random(_KEYBITS)
@@ -1829,8 +1830,8 @@ def test_masked_hske():
         rec = fscx_revolve_masked_test(ct,  key, mask, _R_VALUE)
         if rec.uint == pt.uint:
             ok += 1
-    status = "PASS" if ok == N else "FAIL"
-    print(f"    round-trips={ok}/{N}  [{status}]")
+    status = "PASS" if ok == n_run else "FAIL"
+    print(f"    round-trips={ok}/{n_run}  [{status}]")
     # linearity check: F(A⊕r,B,n) ⊕ F(r,0,n) == F(A,B,n)
     zero = BitArray(_KEYBITS, 0)
     lin_ok = 0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.28)
+# Herradura Cryptographic Suite (v1.9.29)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5515,4 +5515,4 @@ or patched by another test.
    correction, or similar), and add a deterministic regression test that runs the specific
    failing inputs.
 
-Status: **Open**
+Status: **DONE v1.9.29** — Root cause: `test_masked_hske` compared `ok == N` (requested iterations) instead of `ok == n_run` (actual iterations run by `_trange`). When `-t` limits wall-clock time, `_trange` stops at a 64-iteration checkpoint (e.g., i=191 → 192 iterations, i=127 → 128 iterations) and returns early; since the masked round-trip is mathematically guaranteed to succeed, `ok` equals the early-stop count, but `ok < N` → spurious FAIL. Fix: added `n_run` counter and changed PASS condition to `ok == n_run`, matching every other `_trange`-based test in the suite. Confirmed: with a tight time limit the test now reports e.g. `128/128 [PASS]` instead of `128/200 [FAIL]`.


### PR DESCRIPTION
## Summary

- `test_masked_hske` compared `ok == N` (requested iterations) instead of `ok == n_run` (actual iterations run by `_trange`). When a `-t` time limit causes `_trange` to stop early at a 64-iteration checkpoint, `ok` equalled the early-stop count (all passes — the math is unconditionally correct) but `ok < N` triggered a spurious FAIL, e.g. `192/200 [FAIL]` or `128/200 [FAIL]`.
- Added `n_run` counter and changed PASS condition to `ok == n_run`, matching the pattern used by every other `_trange`-based test in the suite.
- With a tight 0.2 s limit the test now correctly reports `128/128 [PASS]` instead of `128/200 [FAIL]`.

## Test plan

- [x] `python3 CryptosuiteTests/Herradura_tests.py -r 200` → test [25] `200/200 [PASS]`
- [x] `python3 CryptosuiteTests/Herradura_tests.py -r 200 -t 2.0` → test [25] `N/N [PASS]` for whatever N `_trange` stops at
- [x] Full suite passes without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)