### PR TITLE
HSKE-NL-AEAD authenticated encryption — v1.9.33 (TODO #95 option 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.33] - 2026-06-12
+
+### Feature — HSKE-NL-AEAD: authenticated encryption with associated data (TODO #95 option 1)
+
+- **`Herradura cryptographic suite.py` / `herradura.h` / `herradura/herradura.go`**: new `hske_nl_aead_encrypt` / `hske_nl_aead_decrypt` (Go: `HskeNlAeadEncrypt`/`HskeNlAeadDecrypt`) — byte-level encrypt-then-MAC AEAD over the HSKE-NL-A1 CTR keystream. Tag = keyed HFSCX-256-DM over `HSKE-NL-AEAD-v1` DS prefix ‖ nonce ‖ len-framed AD ‖ len-framed ciphertext; MAC key uses the existing domain-separated `mac_key` schedule, DS-prefix-separated from the `.hkx` encfile MAC. Key-committing (the tag binds the MAC key through the collision-resistant keyed chain — a property AES-GCM lacks). Verify-then-decrypt with constant-time tag comparison (`hmac.compare_digest` / `ct_eq32` / `crypto/subtle`). All three implementations are byte-for-byte interoperable (shared KAT).
+- **`HerraduraCli` (Python/C/Go)**: `enc --algo hske-nla1 --aead [--ad STR]` emits ciphertext PEM format tag 2 — `SEQ(2, nonce, E, tag, nbits)`; `dec` auto-detects format tag 2, verifies (optionally with `--ad`) before decrypting, and fails closed on tag mismatch. PEM outputs are cross-CLI compatible.
+- **`CryptosuiteTests`**: new security test [28] (C/Go/Python) — cross-language KAT, round-trip over irregular lengths, and tamper rejection (ciphertext, tag, AD, nonce, key). Benchmarks renumbered [28]–[39] → [29]–[40]; stale C benchmark comments fixed to current labels.
+- **`CliTest/test_aead.sh`**: new — all 9 producer/consumer CLI pairs, wrong-AD and wrong-key rejection (19 checks).
+- **`SecurityProofs-2.md` §11.9.6**: HSKE-NL-AEAD note — construction, key-commitment argument, and TODO #95 option 2 (NL-FSCX v2 sponge/duplex AEAD) recorded as open research gated on TODO #99.
+- **`CLAUDE.md`**: test numbering updated to [1]–[28] / [29]–[40].
+
+---
+
 ## [1.9.32] - 2026-06-12
 
 ### Security/Proofs — ZKP-RNL Σ-protocol relaxed special soundness + structured cheat tests (TODO #94, items 1–2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.32] - 2026-06-12
+
+### Security/Proofs — ZKP-RNL Σ-protocol relaxed special soundness + structured cheat tests (TODO #94, items 1–2)
+
+- **`SecurityProofs-3.md` §11.10.2**: The soundness argument is restated as **relaxed special soundness** (Lyubashevsky 2012). The previous sketch extracted (z−z')·(c−c')⁻¹, implicitly assuming challenge differences are invertible in R_q — unjustified for the suite parameters: q = 65537 gives 2n | q−1 for all power-of-two n ≤ 256, so x^n+1 splits into linear factors over F_q and R_q has zero divisors. Measured: 3/2000 random challenge pairs at n=32 yield nonzero non-invertible differences. The extractor now outputs the pair (z−z', c−c') as a relaxed witness (norm bounds stated) without inversion; the factor-2 norm relaxation is flagged for the open formal-reduction work (§11.10.6 item 1). Empirical-results table extended with the new cheat tests.
+- **`SecurityProofsCode/zkp_pqc_exploration.py`**: new §2.4b structured cheating provers — wrong-key witness (honest prover run with fresh s′ ≠ s), tampered commitment w (Fiat-Shamir check), perturbed response z (residual-norm check), and bounded challenge grinding (64 attempts/trial); all 0 passes. New §2.6 challenge-difference invertibility scan: evaluates c−c' at the n roots of x^n+1 over F_q (CRT split), empirically confirming non-invertible differences exist and motivating the relaxed formulation.
+- **`CryptosuiteTests/Herradura_tests.py`** test [21]: ZKP-RNL now also checks wrong-key rejection, tampered-w rejection, and perturbed-z rejection at n=32 and n=256 against the deployed `_rnl_sigma_sign`/`_rnl_sigma_verify`. (C/Go test extension deferred.)
+- **`TODO.md`**: #94 items 1–2 done; #92 gains a related finding — §11.4.3's claim that x^256+1 "does not split into degree-1 factors over F_65537 since 512 ∤ q−1" is arithmetically wrong (512 | 65536; the ring splits fully). KaTeX pipeline validator: SecurityProofs-3.md 158 OK, 0 FAIL.
+
+---
+
 ## [1.9.31] - 2026-06-11
 
 ### Housekeeping — Unify test numbering across C, Go, and Python (TODO #87)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ x86_64-linux-gnu-ld -m elf_i386 -o CryptosuiteTests/Herradura_tests_i386 tests32
 No automated test framework. Tests are manual: run each program and verify console output.
 
 ```bash
-# C/Go/Python — security tests [1]–[27] + benchmarks [28]–[39]
+# C/Go/Python — security tests [1]–[28] + benchmarks [29]–[40]
 # (C also runs one C-only unlabeled test between [20] and [21])
 ./CryptosuiteTests/Herradura_tests_c
 ./CryptosuiteTests/Herradura_tests_c -r 500        # cap each test at 500 iterations
@@ -157,6 +157,7 @@ bash CliTest/test_sign.sh
 bash CliTest/test_encrypt.sh
 bash CliTest/test_encfile.sh
 bash CliTest/test_signfile.sh
+bash CliTest/test_aead.sh      # HSKE-NL-AEAD enc/dec --aead, 9-way cross-CLI interop (needs C+Go CLIs built)
 
 # C CLI — requires HerraduraCli/herradura_cli (build_c.sh)
 bash CliTest/test_c_keygen.sh

--- a/CliTest/test_aead.sh
+++ b/CliTest/test_aead.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# CliTest/test_aead.sh — HSKE-NL-AEAD enc/dec --aead cross-language interop (TODO #95)
+# Covers all 9 producer/consumer pairs across the Python, C, and Go CLIs,
+# plus tamper rejection (wrong --ad, wrong key).
+set -euo pipefail
+
+DIR=$(dirname "$0")
+PY="python3 $DIR/../HerraduraCli/herradura.py"
+C="$DIR/../HerraduraCli/herradura_cli"
+GO="$DIR/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+for bin in "$DIR/../HerraduraCli/herradura_cli" "$DIR/../HerraduraCli/herradura_cli_go"; do
+    if [ ! -x "$bin" ]; then
+        echo "SKIP: $bin not built (run build_c.sh / build_go.sh)"; exit 0
+    fi
+done
+
+# Shared 256-bit symmetric key via HKEX-GF
+$PY genpkey --algo hkex-gf --out "$TMP/alice.pem"
+$PY pkey    --in "$TMP/alice.pem" --pubout --out "$TMP/alice_pub.pem"
+$PY genpkey --algo hkex-gf --out "$TMP/bob.pem"
+$PY pkey    --in "$TMP/bob.pem"   --pubout --out "$TMP/bob_pub.pem"
+$PY kex     --algo hkex-gf --our "$TMP/alice.pem" --their "$TMP/bob_pub.pem" \
+            --out "$TMP/sk.pem"
+
+printf 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' > "$TMP/msg.bin"
+AD="aead-test-context"
+
+declare -A CLI=( [py]="$PY" [c]="$C" [go]="$GO" )
+
+for enc in py c go; do
+    ${CLI[$enc]} enc --algo hske-nla1 --aead --ad "$AD" \
+        --key "$TMP/sk.pem" --in "$TMP/msg.bin" --out "$TMP/ct_$enc.pem"
+    for dec in py c go; do
+        if ${CLI[$dec]} dec --algo hske-nla1 --ad "$AD" \
+              --key "$TMP/sk.pem" --in "$TMP/ct_$enc.pem" --out "$TMP/pt_${enc}_${dec}.bin" \
+           && cmp -s "$TMP/msg.bin" "$TMP/pt_${enc}_${dec}.bin"; then
+            echo "PASS aead $enc-enc -> $dec-dec"; PASS=$((PASS+1))
+        else
+            echo "FAIL aead $enc-enc -> $dec-dec"; FAIL=$((FAIL+1))
+        fi
+        # wrong AD must be rejected
+        if ${CLI[$dec]} dec --algo hske-nla1 --ad "wrong-ad" \
+              --key "$TMP/sk.pem" --in "$TMP/ct_$enc.pem" --out "$TMP/bad.bin" 2>/dev/null; then
+            echo "FAIL aead $enc-enc -> $dec-dec accepted wrong --ad"; FAIL=$((FAIL+1))
+        else
+            echo "PASS aead $enc-enc -> $dec-dec rejects wrong --ad"; PASS=$((PASS+1))
+        fi
+    done
+done
+
+# Wrong key must be rejected (key commitment sanity)
+$PY genpkey --algo hkex-gf --out "$TMP/eve.pem"
+$PY pkey    --in "$TMP/eve.pem" --pubout --out "$TMP/eve_pub.pem"
+$PY kex     --algo hkex-gf --our "$TMP/eve.pem" --their "$TMP/bob_pub.pem" \
+            --out "$TMP/sk_eve.pem"
+if $PY dec --algo hske-nla1 --ad "$AD" \
+      --key "$TMP/sk_eve.pem" --in "$TMP/ct_py.pem" --out "$TMP/bad2.bin" 2>/dev/null; then
+    echo "FAIL aead wrong key accepted"; FAIL=$((FAIL+1))
+else
+    echo "PASS aead wrong key rejected"; PASS=$((PASS+1))
+fi
+
+echo
+echo "test_aead: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,7 +4,9 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.31
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.33
+    v1.9.33: HSKE-NL-AEAD test [28] — round-trip, tamper rejection, cross-language KAT (TODO #95);
+            benchmarks renumbered [29]–[40].
     v1.9.31: Unified test numbering [1]–[27] across C/Go/Python; benchmarks [28]–[39] (TODO #87).
             HPKS-Stern-Ring [28]→[20]; F_stern range unlabeled (C-only); benchmarks shifted +2.
     v1.9.11: ZKP-RNL + ZKP-NL security tests [21][22] and benchmarks [33][34] (TODO #77 Batch 7);
@@ -48,7 +50,7 @@
     v1.5.3: HKEX-RNL secret sampler upgraded to CBD(eta=1); zero-mean distribution.
     v1.5.0: HKEX-GF; Schnorr HPKS; El Gamal HPKE; NL-FSCX non-linear extension; PQC.
 
-    Security tests [1]–[27] (unified with Go and Python):
+    Security tests [1]–[28] (unified with Go and Python):
       [1]  HKEX-GF correctness: g^{ab}==g^{ba} (32/64/256-bit GF).
       [2]  FSCX single-step linear diffusion (exactly 3 bits per flip).
       [3]  Orbit period: FSCX_REVOLVE cycles back to A.
@@ -76,22 +78,23 @@
       [25] Cryptographic Accumulator (78.J) Merkle proof  [NEW].
       [26] Masked HSKE (78.H) GF(2)-linearity masking  [NEW].
       [27] Ratchet (78.C) forward secrecy & key uniqueness  [NEW].
+      [28] HSKE-NL-AEAD (TODO #95) round-trip, tamper rejection, cross-language KAT  [NEW].
       C-only (unlabeled): F_stern(K,·) range compression at n=32 (HyperLogLog, TODO #42).
 
-    Performance benchmarks [28]–[39] (unified with Go and Python):
-      [28] FSCX throughput (256-bit).
-      [29] HKEX-GF gf_pow throughput (32-bit).
-      [30] HKEX-GF full handshake (32-bit).
-      [31] HSKE round-trip (256-bit).
-      [32] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
-      [33] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
-      [33b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
-      [34] HSKE-NL-A1 counter-mode throughput (32-bit).
-      [35] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
-      [36] HKEX-RNL full handshake throughput (n=32).
-      [37] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
-      [38] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
-      [39] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
+    Performance benchmarks [29]–[40] (unified with Go and Python):
+      [29] FSCX throughput (256-bit).
+      [30] HKEX-GF gf_pow throughput (32-bit).
+      [31] HKEX-GF full handshake (32-bit).
+      [32] HSKE round-trip (256-bit).
+      [33] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
+      [34] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
+      [34b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
+      [35] HSKE-NL-A1 counter-mode throughput (32-bit).
+      [36] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
+      [37] HKEX-RNL full handshake throughput (n=32).
+      [38] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
+      [39] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
+      [40] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -3475,7 +3478,7 @@ static void test_fstern_range_n32(void)
            " see TODO #42 Step 2\n");
 }
 
-/* [28] HPKS-Stern-Ring (78.I): OR-composed ring signature, k=3, N=256 */
+/* [20] HPKS-Stern-Ring (78.I): OR-composed ring signature, k=3, N=256 */
 static void test_hpks_stern_ring_correctness(void)
 {
 #define RING_K 3
@@ -3513,14 +3516,14 @@ static void test_hpks_stern_ring_correctness(void)
 #undef RING_K
 }
 
-/* [37] HPKS-Stern-F sign+verify throughput (N=32/64/256) */
+/* [38] HPKS-Stern-F sign+verify throughput (N=32/64/256) */
 static void bench_hpks_stern_f(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[37] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
+    printf("[38] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
     /* N=32 */
     { static SternSig32T bsig32;
       uint32_t seed32 = stern32_rand_seed(), e32 = stern32_rand_error(), msg32;
@@ -3600,7 +3603,7 @@ static void bench_hpks_stern_f(void)
 static const uint8_t zkp_msg[]  = "Herradura ZKP test";
 static const uint8_t zkp_msg2[] = "Herradura ZKP tamper";
 
-/* [38] ZKP-RNL sign+verify throughput (n=256) */
+/* [39] ZKP-RNL sign+verify throughput (n=256) */
 static void bench_zkp_rnl(void)
 {
     struct timespec t0, t1;
@@ -3611,7 +3614,7 @@ static void bench_zkp_rnl(void)
     int32_t s[256], C[256];
     int32_t w[256], c_poly[256], z[256];
     int i;
-    printf("[38] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
+    printf("[39] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
     rnl_m_poly_n(m_base, n);
     rnl_rand_poly_n(a_rand, n);
     rnl_poly_add_n(m_blind, m_base, a_rand, n);
@@ -3638,7 +3641,7 @@ static void bench_zkp_rnl(void)
     putchar('\n');
 }
 
-/* [39] ZKP-NL prove+verify throughput (n=32, rounds=16) */
+/* [40] ZKP-NL prove+verify throughput (n=32, rounds=16) */
 static void bench_zkp_nl(void)
 {
     struct timespec t0, t1;
@@ -3649,7 +3652,7 @@ static void bench_zkp_nl(void)
     uint64_t A, B, y;
     ZkpNlRound *proof;
     int i;
-    printf("[39] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
+    printf("[40] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
            n, rounds);
     zkp_nl_keygen(n, urnd_fp, &A, &B, &y);
     /* warm-up */
@@ -3899,7 +3902,7 @@ static void test_accumulator_correctness(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Security Tests: Masking / Ratchet [26]-[27]                        */
+/* Security Tests: Masking / Ratchet / AEAD [26]-[28]                 */
 /* ------------------------------------------------------------------ */
 
 /* [26] Masked HSKE (78.H) GF(2)-linearity masking correctness */
@@ -3974,18 +3977,81 @@ static void test_ratchet_forward_secrecy(void)
     putchar('\n');
 }
 
+/* [28] HSKE-NL-AEAD (TODO #95) round-trip, tamper rejection, cross-language KAT */
+static void test_hske_nl_aead(void)
+{
+    /* Cross-language KAT — must match the C/Go/Python suite outputs */
+    static const uint8_t kat_ct[45] = {
+        0x75,0xfe,0x38,0xc5,0x20,0x4d,0x65,0x38,0x1f,0xc1,0x1f,0x08,
+        0x41,0x81,0xee,0x0c,0xce,0x44,0x94,0x0c,0x4b,0x62,0xb6,0x97,
+        0xab,0x85,0x17,0x8f,0x20,0x02,0x2c,0xe4,0xcf,0xba,0xd2,0x50,
+        0x99,0xf9,0xe1,0x6d,0x5a,0xd7,0xab,0xf7,0x3d
+    };
+    static const uint8_t kat_tag[32] = {
+        0xb9,0xbc,0x7e,0xb9,0xcf,0x31,0xec,0x44,0x4a,0x50,0xef,0x67,
+        0x07,0x50,0xd6,0x2a,0x18,0x9f,0x45,0x18,0x90,0x8a,0x42,0xd1,
+        0x6e,0xc6,0x87,0x2e,0xb7,0x10,0xd0,0x22
+    };
+    FILE *urnd = fopen("/dev/urandom", "rb");
+    BitArray key, nonce, bad_key, bad_nonce;
+    uint8_t ct[128], tag[32], rec[128], pt[128], ad[17], bad[128];
+    int t, trials, ok_kat, ok_rt = 0, ok_tamper = 0, i;
+
+    printf("[28] HSKE-NL-AEAD (TODO #95) — round-trip, tamper rejection, "
+           "cross-language KAT  [NEW]\n");
+
+    for (i = 0; i < 32; i++) { key.b[i] = (uint8_t)i; nonce.b[i] = (uint8_t)(0xA0 ^ i); }
+    hske_nl_aead_encrypt(&key, &nonce, (const uint8_t *)"hdr", 3,
+                         (const uint8_t *)"HSKE-NL-AEAD cross-language vector, 41 bytes!",
+                         45, ct, tag);
+    ok_kat = (memcmp(ct, kat_ct, 45) == 0 && memcmp(tag, kat_tag, 32) == 0);
+
+    trials = TEST_ROUNDS(50); if (trials > 50) trials = 50;
+    for (t = 0; t < trials; t++) {
+        size_t pt_len = 1 + (size_t)(t * 7) % 97, ad_len = (size_t)t % 17;
+        if (fread(pt, 1, pt_len, urnd) != pt_len) { fputs("urandom error\n", stderr); exit(1); }
+        if (ad_len && fread(ad, 1, ad_len, urnd) != ad_len) { fputs("urandom error\n", stderr); exit(1); }
+        ba_rand(&key, urnd); ba_rand(&nonce, urnd);
+        hske_nl_aead_encrypt(&key, &nonce, ad, ad_len, pt, pt_len, ct, tag);
+        if (hske_nl_aead_decrypt(&key, &nonce, ad, ad_len, ct, pt_len, tag, rec)
+                && memcmp(rec, pt, pt_len) == 0)
+            ok_rt++;
+        bad_key = key;     bad_key.b[KEYBYTES-1]   ^= 1;
+        bad_nonce = nonce; bad_nonce.b[KEYBYTES-1] ^= 1;
+        memcpy(bad, ct, pt_len); bad[0] ^= 1;
+        {
+            uint8_t bad_tag[32], bad_ad[18];
+            int r1, r2, r3, r4, r5;
+            memcpy(bad_tag, tag, 32); bad_tag[0] ^= 1;
+            if (ad_len) memcpy(bad_ad, ad, ad_len);
+            bad_ad[ad_len] = 'x';
+            r1 = hske_nl_aead_decrypt(&key, &nonce, ad, ad_len, bad, pt_len, tag, rec);
+            r2 = hske_nl_aead_decrypt(&key, &nonce, ad, ad_len, ct, pt_len, bad_tag, rec);
+            r3 = hske_nl_aead_decrypt(&key, &nonce, bad_ad, ad_len + 1, ct, pt_len, tag, rec);
+            r4 = hske_nl_aead_decrypt(&key, &bad_nonce, ad, ad_len, ct, pt_len, tag, rec);
+            r5 = hske_nl_aead_decrypt(&bad_key, &nonce, ad, ad_len, ct, pt_len, tag, rec);
+            if (!r1 && !r2 && !r3 && !r4 && !r5) ok_tamper++;
+        }
+    }
+    fclose(urnd);
+    printf("    kat=%s  roundtrip=%d/%d  tamper_reject=%d/%d  [%s]\n",
+           ok_kat ? "PASS" : "FAIL", ok_rt, trials, ok_tamper, trials,
+           (ok_kat && ok_rt == trials && ok_tamper == trials) ? "PASS" : "FAIL");
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [28]-[39]                                    */
+/* Performance benchmarks [29]-[40]                                    */
 /* ------------------------------------------------------------------ */
 
-/* [26] FSCX throughput (64/128/256-bit) */
+/* [29] FSCX throughput (64/128/256-bit) */
 static void bench_fscx_throughput(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[28] FSCX throughput  [CLASSICAL]\n");
+    printf("[29] FSCX throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), tmp;
       for (i = 0; i < 10; i++) { tmp = fscx32(a, b); a = tmp; }
@@ -4029,7 +4095,7 @@ static void bench_gf_pow_throughput(void)
     long long ops;
     double secs;
     int i;
-    printf("[29] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
+    printf("[30] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t base = rand32() | 1, exp = rand32() | 1, tmp;
       for (i = 0; i < 5; i++) { tmp = gf_pow_32(base, exp); base = tmp | 1; }
@@ -4074,7 +4140,7 @@ static void bench_hkex_gf_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[30] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
+    printf("[31] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, b = rand32()|1, C, C2, skA, skB;
       for (i = 0; i < 5; i++) {
@@ -4140,7 +4206,7 @@ static void bench_hske_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[31] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
+    printf("[32] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t pt, key, enc, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4207,7 +4273,7 @@ static void bench_hpke_el_gamal_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[32] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
+    printf("[33] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, r = rand32()|1, pt = rand32();
       uint32_t C = gf_pow_32(GF_GEN32, a), R, ek, E, dk;
@@ -4282,17 +4348,17 @@ static void bench_hpke_el_gamal_roundtrip(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [28]-[31]: PQC extension                    */
+/* Performance benchmarks [34]-[37]: PQC extension                    */
 /* ------------------------------------------------------------------ */
 
-/* [28] NL-FSCX v1 revolve (64/128/256-bit) + [28b] v2 enc+dec (64/128/256-bit) */
+/* [34] NL-FSCX v1 revolve (64/128/256-bit) + [34b] v2 enc+dec (64/128/256-bit) */
 static void bench_nl_fscx_revolve(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[33] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
+    printf("[34] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32();
       for (i = 0; i < 10; i++) a = nl_fscx_revolve_v1_32(a, b, NL_I32);
@@ -4328,7 +4394,7 @@ static void bench_nl_fscx_revolve(void)
       printf("    bits=256  v1 n/4 steps  "); print_rate(ops, secs); putchar('\n'); }
     putchar('\n');
 
-    printf("[33b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]\n");
+    printf("[34b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), E;
       for (i = 0; i < 5; i++) {
@@ -4386,7 +4452,7 @@ static void bench_hske_nl_a1_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[34] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
+    printf("[35] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K, P, ks, sink = 0;
       K = rand32(); P = rand32();
@@ -4465,14 +4531,14 @@ static void bench_hske_nl_a1_roundtrip(void)
     putchar('\n');
 }
 
-/* [28] HSKE-NL-A2 revolve-mode round-trip throughput (64/128/256-bit) */
+/* [36] HSKE-NL-A2 revolve-mode round-trip throughput (64/128/256-bit) */
 static void bench_hske_nl_a2_roundtrip(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[35] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
+    printf("[36] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K = rand32(), P = rand32(), E, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4534,7 +4600,7 @@ static void bench_hkex_rnl_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[36] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
+    printf("[37] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
     /* n=32 (rnl32 fast path) */
     { rnl32_poly_t m_base, a_rand, m_blind;
       int32_t s_A[RNL_N32], c_A[RNL_N32], s_B[RNL_N32], c_B[RNL_N32];
@@ -4658,7 +4724,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("=== Herradura KEx v1.9.14 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
+    printf("=== Herradura KEx v1.9.33 \xe2\x80\x94 Security & Performance Tests (C) ===\n");
     if (g_rounds > 0 || g_time_limit > 0.0) {
         if (g_rounds > 0 && g_time_limit > 0.0)
             printf("    Config: rounds=%d  time_limit=%.2fs\n", g_rounds, g_time_limit);
@@ -4712,6 +4778,7 @@ int main(int argc, char *argv[])
     puts("--- Security Tests: Masking / Ratchet (78.H/C) ---\n");
     test_masked_hske();
     test_ratchet_forward_secrecy();
+    test_hske_nl_aead();
 
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,6 @@
-/*  Herradura KEx — Security & Performance Tests (Go) v1.9.11
+/*  Herradura KEx — Security & Performance Tests (Go) v1.9.33
+    v1.9.33: HSKE-NL-AEAD test [28] — round-trip, tamper rejection, cross-language KAT (TODO #95);
+            benchmarks renumbered [29]–[40].
     v1.9.11: ZKP-RNL + ZKP-NL security tests [20][21] and benchmarks [32][33] (TODO #77 Batch 7);
             benchmarks renumbered [22]-[33].
     v1.8.7: 32-bit benchmark columns; benchHpksSternF loops over all sizes (TODO #61 extension).
@@ -724,7 +726,7 @@ func testHpksSternRingCorrectness() {
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[28] FSCX throughput  [CLASSICAL]")
+	fmt.Println("[29] FSCX throughput  [CLASSICAL]")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -738,7 +740,7 @@ func benchFscx() {
 }
 
 func benchHkexGFPow() {
-	fmt.Println("[29] HKEX-GF gf_pow throughput  [CLASSICAL]")
+	fmt.Println("[30] HKEX-GF gf_pow throughput  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -753,7 +755,7 @@ func benchHkexGFPow() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[30] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
+	fmt.Println("[31] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -772,7 +774,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[31] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+	fmt.Println("[32] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		rv   := rVal(size)
@@ -791,7 +793,7 @@ func benchHskeRoundTrip() {
 }
 
 func benchHpkeRoundTrip() {
-	fmt.Println("[32] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
+	fmt.Println("[33] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g    := big.NewInt(GfGen)
@@ -817,7 +819,7 @@ func benchHpkeRoundTrip() {
 }
 
 func benchNlFscxRevolve() {
-	fmt.Println("[33] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+	fmt.Println("[34] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
 		a  := randBA(size)
@@ -828,7 +830,7 @@ func benchNlFscxRevolve() {
 		fmt.Printf("    bits=%3d  v1 n/4 steps             : %s  (%d ops in %.2fs)\n",
 			size, fmtRate(ops, elapsed), ops, elapsed.Seconds())
 	}
-	fmt.Println("[33b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
+	fmt.Println("[34b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		rv := rVal(size)
 		a  := randBA(size)
@@ -844,7 +846,7 @@ func benchNlFscxRevolve() {
 }
 
 func benchHskeNlA1RoundTrip() {
-	fmt.Println("[34] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+	fmt.Println("[35] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		sink := randBA(size)
@@ -864,7 +866,7 @@ func benchHskeNlA1RoundTrip() {
 }
 
 func benchHskeNlA2RoundTrip() {
-	fmt.Println("[35] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+	fmt.Println("[36] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
 	for _, size := range sizes {
 		rv   := rVal(size)
 		sink := randBA(size)
@@ -881,7 +883,7 @@ func benchHskeNlA2RoundTrip() {
 }
 
 func benchHkexRnlHandshake() {
-	fmt.Println("[36] HKEX-RNL handshake throughput  [PQC-EXT]")
+	fmt.Println("[37] HKEX-RNL handshake throughput  [PQC-EXT]")
 	fmt.Printf("     (ring sizes %v; NTT O(n log n) per exchange)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := RnlMPoly(nRnl)
@@ -900,7 +902,7 @@ func benchHkexRnlHandshake() {
 }
 
 func benchHpksSternF() {
-	fmt.Printf("[37] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
+	fmt.Printf("[38] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
 	for _, size := range sizes {
 		seed, e, syn := SternFKeygen(size)
 		msg := randBA(size)
@@ -983,12 +985,12 @@ func testZkpNlCorrectness() {
 }
 
 // ---------------------------------------------------------------------------
-// Performance benchmarks [38]-[39]: ZKP
+// Performance benchmarks [39]-[40]: ZKP
 // ---------------------------------------------------------------------------
 
 func benchZkpRnl() {
 	const n = 256
-	fmt.Printf("[38] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
+	fmt.Printf("[39] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
 	mBase  := RnlMPoly(n)
 	aRand  := RnlRandPoly(n, RnlQ)
 	mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
@@ -1009,7 +1011,7 @@ func benchZkpNl() {
 		n      = 32
 		rounds = 16
 	)
-	fmt.Printf("[39] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
+	fmt.Printf("[40] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
 	A, B, y, _ := ZkpNlKeygen(n)
 	ops, elapsed := bench("", func() {
 		proof, err := ZkpNlProve(A, B, y, n, rounds, zkpMsg)
@@ -1184,6 +1186,67 @@ func testRatchetForwardSecrecy() {
 		uniqStr, divStr, status)
 }
 
+func testHskeNlAead() {
+	fmt.Println("[28] HSKE-NL-AEAD (TODO #95) — round-trip, tamper rejection, cross-language KAT  [NEW]")
+
+	// Cross-language known-answer test (must match C/Go/Python suite outputs)
+	kb := make([]byte, 32)
+	nb := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		kb[i] = byte(i)
+		nb[i] = byte(0xA0 ^ i)
+	}
+	katKey := NewBitArray(256, new(big.Int).SetBytes(kb))
+	katNonce := NewBitArray(256, new(big.Int).SetBytes(nb))
+	katPt := []byte("HSKE-NL-AEAD cross-language vector, 41 bytes!")
+	katCt, katTag := HskeNlAeadEncrypt(katKey, katNonce, []byte("hdr"), katPt)
+	okKat := fmt.Sprintf("%x", katCt) ==
+		"75fe38c5204d65381fc11f084181ee0cce44940c4b62b697ab85178f20022ce4cfbad25099f9e16d5ad7abf73d" &&
+		fmt.Sprintf("%x", katTag) ==
+			"b9bc7eb9cf31ec444a50ef670750d62a189f4518908a42d16ec6872eb710d022"
+
+	// Round-trip + tamper rejection over random inputs of irregular lengths
+	trials := testRounds(50)
+	if trials > 50 {
+		trials = 50
+	}
+	okRt, okTamper := 0, 0
+	for t := 0; t < trials; t++ {
+		key := NewRandBitArray(256)
+		nonce := NewRandBitArray(256)
+		pt := make([]byte, 1+(t*7)%97)
+		ad := make([]byte, t%17)
+		mrand.Read(pt)
+		mrand.Read(ad)
+		ct, tag := HskeNlAeadEncrypt(key, nonce, ad, pt)
+		if rec, ok := HskeNlAeadDecrypt(key, nonce, ad, ct, tag); ok && bytes.Equal(rec, pt) {
+			okRt++
+		}
+		badCt := append([]byte{ct[0] ^ 1}, ct[1:]...)
+		badTag := append([]byte{tag[0] ^ 1}, tag[1:]...)
+		badNonce := NewBitArray(256, new(big.Int).Xor(&nonce.Val, big.NewInt(1)))
+		badKey := NewBitArray(256, new(big.Int).Xor(&key.Val, big.NewInt(1)))
+		_, r1 := HskeNlAeadDecrypt(key, nonce, ad, badCt, tag)
+		_, r2 := HskeNlAeadDecrypt(key, nonce, ad, ct, badTag)
+		_, r3 := HskeNlAeadDecrypt(key, nonce, append(append([]byte{}, ad...), 'x'), ct, tag)
+		_, r4 := HskeNlAeadDecrypt(key, badNonce, ad, ct, tag)
+		_, r5 := HskeNlAeadDecrypt(badKey, nonce, ad, ct, tag)
+		if !r1 && !r2 && !r3 && !r4 && !r5 {
+			okTamper++
+		}
+	}
+	status := "PASS"
+	if !okKat || okRt != trials || okTamper != trials {
+		status = "FAIL"
+	}
+	katStr := "PASS"
+	if !okKat {
+		katStr = "FAIL"
+	}
+	fmt.Printf("    kat=%s  roundtrip=%d/%d  tamper_reject=%d/%d  [%s]\n\n",
+		katStr, okRt, trials, okTamper, trials, status)
+}
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -1225,7 +1288,7 @@ func main() {
 	}
 	if gBenchDur == 0 { gBenchDur = time.Second }
 
-	fmt.Println("=== Herradura KEx v1.9.31 — Security & Performance Tests (Go) ===")
+	fmt.Println("=== Herradura KEx v1.9.33 — Security & Performance Tests (Go) ===")
 	if gRounds > 0 || gTimeLimit > 0 {
 		switch {
 		case gRounds > 0 && gTimeLimit > 0:
@@ -1280,6 +1343,7 @@ func main() {
 	fmt.Println("--- Security Tests: Masking / Ratchet (78.H/C) ---\n")
 	testMaskedHske()
 	testRatchetForwardSecrecy()
+	testHskeNlAead()
 
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,7 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python) v1.9.32
+    Herradura KEx — Security & Performance Tests (Python) v1.9.33
+    v1.9.33: HSKE-NL-AEAD test [28] — round-trip, tamper rejection, cross-language KAT (TODO #95);
+            benchmarks renumbered [29]–[40].
     v1.9.32: ZKP-RNL test [21] structured cheats — wrong-key, tampered-w, perturbed-z rejection (TODO #94).
     v1.9.31: Unified test numbering [1]–[27] across C/Go/Python; benchmarks [28]–[39] (TODO #87).
             HPKS-Stern-Ring [27]→[20]; ZKP/FPE/TWK/Acc/Masked/Ratchet shifted +1; benchmarks shifted +3.
@@ -1907,6 +1909,79 @@ def test_ratchet_forward_secrecy():
     print()
 
 
+def test_hske_nl_aead():
+    print("[28] HSKE-NL-AEAD (TODO #95) — round-trip, tamper rejection, cross-language KAT  [NEW]")
+    n, blen, steps = 256, 32, 64
+    DS = b'HSKE-NL-AEAD-v1'
+
+    def aead_parts(key, nonce):
+        base    = BitArray(n, key.uint ^ nonce.uint)
+        seed    = BitArray(n, base.rotated(n // 8).uint ^ _RNL_KDF_DC_256)
+        mac_key = nl_fscx_revolve_v1(seed.rotated(n // 4), base, steps)
+        mac_iv  = BitArray(n, mac_key.uint ^ int.from_bytes(_HFSCX256_IV_BYTES, 'big'))
+        return base, seed, mac_iv
+
+    def xor_ks(seed, base, data):
+        out = bytearray()
+        for i in range((len(data) + blen - 1) // blen):
+            ks   = nl_fscx_revolve_v1(seed, BitArray(n, base.uint ^ i), steps)
+            out += bytes(d ^ k for d, k in zip(data[i*blen:(i+1)*blen],
+                                               ks.uint.to_bytes(blen, 'big')))
+        return bytes(out)
+
+    def aead_tag(mac_iv, nonce, ad, ct):
+        data = (DS + nonce.uint.to_bytes(blen, 'big')
+                + len(ad).to_bytes(8, 'big') + ad
+                + len(ct).to_bytes(8, 'big') + ct)
+        return hfscx_256(data, iv=mac_iv)
+
+    def aead_encrypt(key, nonce, ad, pt):
+        base, seed, mac_iv = aead_parts(key, nonce)
+        ct = xor_ks(seed, base, pt)
+        return ct, aead_tag(mac_iv, nonce, ad, ct)
+
+    def aead_decrypt(key, nonce, ad, ct, tag):
+        base, seed, mac_iv = aead_parts(key, nonce)
+        if aead_tag(mac_iv, nonce, ad, ct) != tag:
+            return None
+        return xor_ks(seed, base, ct)
+
+    # Cross-language known-answer test (must match C/Go/Python suite outputs)
+    kat_key   = BitArray(n, int.from_bytes(bytes(range(32)), 'big'))
+    kat_nonce = BitArray(n, int.from_bytes(bytes(0xA0 ^ i for i in range(32)), 'big'))
+    kat_pt    = b'HSKE-NL-AEAD cross-language vector, 41 bytes!'
+    kat_ct, kat_tag = aead_encrypt(kat_key, kat_nonce, b'hdr', kat_pt)
+    kat_ok = (kat_ct.hex() == '75fe38c5204d65381fc11f084181ee0cce44940c4b62b697'
+                              'ab85178f20022ce4cfbad25099f9e16d5ad7abf73d'
+              and kat_tag.hex() == 'b9bc7eb9cf31ec444a50ef670750d62a'
+                                   '189f4518908a42d16ec6872eb710d022')
+
+    # Round-trip + tamper rejection over random inputs of irregular lengths
+    trials = min(_iters(50), 50)
+    rt_ok = tamper_ok = 0
+    for t in range(trials):
+        key   = BitArray.random(n); nonce = BitArray.random(n)
+        pt    = os.urandom(1 + (t * 7) % 97)
+        ad    = os.urandom(t % 17)
+        ct, tag = aead_encrypt(key, nonce, ad, pt)
+        if aead_decrypt(key, nonce, ad, ct, tag) == pt:
+            rt_ok += 1
+        bad_ct  = bytes([ct[0] ^ 1]) + ct[1:]
+        bad_tag = bytes([tag[0] ^ 1]) + tag[1:]
+        bad_n   = BitArray(n, nonce.uint ^ 1)
+        bad_key = BitArray(n, key.uint ^ 1)
+        if (aead_decrypt(key, nonce, ad, bad_ct, tag) is None
+                and aead_decrypt(key, nonce, ad, ct, bad_tag) is None
+                and aead_decrypt(key, nonce, ad + b'x', ct, tag) is None
+                and aead_decrypt(key, bad_n, ad, ct, tag) is None
+                and aead_decrypt(bad_key, nonce, ad, ct, tag) is None):
+            tamper_ok += 1
+    status = "PASS" if kat_ok and rt_ok == trials and tamper_ok == trials else "FAIL"
+    print(f"    kat={'PASS' if kat_ok else 'FAIL'}  roundtrip={rt_ok}/{trials}  "
+          f"tamper_reject={tamper_ok}/{trials}  [{status}]")
+    print()
+
+
 # ---------------------------------------------------------------------------
 # Performance benchmarks
 # ---------------------------------------------------------------------------
@@ -1928,7 +2003,7 @@ def _bench(label: str, fn):
 
 
 def bench_fscx():
-    print("[28] FSCX throughput  [CLASSICAL]")
+    print("[29] FSCX throughput  [CLASSICAL]")
     for size in SIZES:
         a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -1938,7 +2013,7 @@ def bench_fscx():
 
 
 def bench_hkex_gf_pow():
-    print("[29] HKEX-GF gf_pow throughput  [CLASSICAL]")
+    print("[30] HKEX-GF gf_pow throughput  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); a = BitArray.random(size)
         def fn(a=a, poly=poly, size=size):
@@ -1948,7 +2023,7 @@ def bench_hkex_gf_pow():
 
 
 def bench_hkex_handshake():
-    print("[30] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
+    print("[31] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425)
         def fn():
@@ -1961,7 +2036,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[31] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+    print("[32] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
     for size in SIZES:
         iv = i_val(size); rv = r_val(size); sink = BitArray(size, 0)
         def fn():
@@ -1973,7 +2048,7 @@ def bench_hske_roundtrip():
 
 
 def bench_hpke_roundtrip():
-    print("[32] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
+    print("[33] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size)
         sink = BitArray(size, 0)
@@ -1990,13 +2065,13 @@ def bench_hpke_roundtrip():
 
 
 def bench_nl_fscx_revolve():
-    print("[33] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+    print("[34] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn():
             nonlocal a; a = nl_fscx_revolve_v1(a, b, iv)
         _bench(f"bits={size:3d}  v1 n/4 steps", fn)
-    print("[33b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
+    print("[34b] NL-FSCX v2 revolve+inv throughput (r_val steps)  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn(size=size, rv=rv, b=b):
@@ -2006,7 +2081,7 @@ def bench_nl_fscx_revolve():
 
 
 def bench_hske_nl_a1_roundtrip():
-    print("[34] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+    print("[35] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); sink = BitArray(size, 0)
         def fn(size=size, iv=iv):
@@ -2022,7 +2097,7 @@ def bench_hske_nl_a1_roundtrip():
 
 
 def bench_hske_nl_a2_roundtrip():
-    print("[35] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+    print("[36] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); sink = BitArray(size, 0)
         def fn(size=size, rv=rv):
@@ -2036,7 +2111,7 @@ def bench_hske_nl_a2_roundtrip():
 
 def bench_hkex_rnl_handshake():
     # Uses RNL_SIZES for speed; production uses n=256.
-    print("[36] HKEX-RNL handshake throughput  [PQC-EXT]")
+    print("[37] HKEX-RNL handshake throughput  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; n^2 poly-mul — O(n^2) per exchange)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
@@ -2052,7 +2127,7 @@ def bench_hkex_rnl_handshake():
 
 
 def bench_hpks_stern_f():
-    print("[37] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
+    print("[38] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
     rounds = 4; sink = [True]
     for size in SIZES:
         sf_seed, sf_e, sf_syn = stern_f_keygen(size)
@@ -2066,7 +2141,7 @@ def bench_hpks_stern_f():
 
 def bench_zkp_rnl():
     n = 256
-    print(f"[38] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
+    print(f"[39] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
     m_base  = _rnl_m_poly(n)
     a_rand  = _rnl_rand_poly(n, RNLQ)
     m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
@@ -2083,7 +2158,7 @@ def bench_zkp_rnl():
 
 def bench_zkp_nl():
     n = 32; rounds = 16
-    print(f"[39] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
+    print(f"[40] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
     A, B, y = _zkp_nl_keygen(n)
     def fn():
         proof = _zkp_nl_prove(A, B, y, n, rounds, ZKP_MSG)
@@ -2099,7 +2174,7 @@ def bench_zkp_nl():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.9.32 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.9.33 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -2127,7 +2202,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.9.32 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.9.33 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")
@@ -2177,6 +2252,7 @@ if __name__ == '__main__':
     print("--- Security Tests: Masking / Ratchet (78.H/C) ---\n")
     test_masked_hske()
     test_ratchet_forward_secrecy()
+    test_hske_nl_aead()
 
     print("--- Performance Benchmarks ---\n")
     bench_fscx()

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python) v1.9.31
+    Herradura KEx — Security & Performance Tests (Python) v1.9.32
+    v1.9.32: ZKP-RNL test [21] structured cheats — wrong-key, tampered-w, perturbed-z rejection (TODO #94).
     v1.9.31: Unified test numbering [1]–[27] across C/Go/Python; benchmarks [28]–[39] (TODO #87).
             HPKS-Stern-Ring [27]→[20]; ZKP/FPE/TWK/Acc/Masked/Ratchet shifted +1; benchmarks shifted +3.
     v1.9.11: ZKP-RNL + ZKP-NL security tests [20][21] and benchmarks [32][33] (TODO #77 Batch 7);
@@ -1709,6 +1710,7 @@ def test_zkp_rnl_correctness():
     for n in [32, 256]:
         N = _iters(5)
         ok_verify = 0; ok_tamper = 0; n_run = 0
+        ok_wrongkey = 0; ok_wtamper = 0; ok_ztamper = 0
         m_base = _rnl_m_poly(n)
         for _ in _trange(N):
             n_run += 1
@@ -1723,8 +1725,32 @@ def test_zkp_rnl_correctness():
                 ok_verify += 1
             if not _rnl_sigma_verify(m_blind, C, n, ZKP_MSG2, w, c, z):
                 ok_tamper += 1
-        status = "PASS" if (ok_verify == n_run and ok_tamper == n_run) else "FAIL"
+            # Structured cheats (TODO #94):
+            # (a) wrong-key witness: honest signer algorithm run with a fresh
+            #     s' != s against the original public key C — must not verify.
+            s2, _C2 = _rnl_keygen(m_blind, n, RNLQ, RNLP)
+            try:
+                w2, c2, z2 = _rnl_sigma_sign(s2, m_blind, C, n, ZKP_MSG)
+                if not _rnl_sigma_verify(m_blind, C, n, ZKP_MSG, w2, c2, z2):
+                    ok_wrongkey += 1
+            except RuntimeError:
+                ok_wrongkey += 1   # rejection-limit on a wrong key is also a reject
+            # (b) tampered commitment w — must fail Fiat-Shamir re-derivation.
+            w_t = list(w); w_t[0] += 1
+            if not _rnl_sigma_verify(m_blind, C, n, ZKP_MSG, w_t, c, z):
+                ok_wtamper += 1
+            # (c) perturbed response z (FS check still passes; the residual
+            #     norm check must catch it).
+            z_t = list(z); z_t[0] += 1
+            if not _rnl_sigma_verify(m_blind, C, n, ZKP_MSG, w, c, z_t):
+                ok_ztamper += 1
+        all_ok = (ok_verify == n_run and ok_tamper == n_run and
+                  ok_wrongkey == n_run and ok_wtamper == n_run and
+                  ok_ztamper == n_run)
+        status = "PASS" if all_ok else "FAIL"
         print(f"    n={n:3d}  verify={ok_verify}/{n_run}  tamper_reject={ok_tamper}/{n_run}"
+              f"  wrongkey_reject={ok_wrongkey}/{n_run}"
+              f"  w_tamper={ok_wtamper}/{n_run}  z_tamper={ok_ztamper}/{n_run}"
               f"  [{status}]")
     print()
 
@@ -2073,7 +2099,7 @@ def bench_zkp_nl():
 if __name__ == '__main__':
     # --- Arg parsing (CLI overrides env vars) ---
     parser = argparse.ArgumentParser(
-        description="Herradura KEx v1.9.16 — Security & Performance Tests (Python)",
+        description="Herradura KEx v1.9.32 — Security & Performance Tests (Python)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Env vars: HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env)")
     parser.add_argument('-r', '--rounds', type=int, default=0,
@@ -2101,7 +2127,7 @@ if __name__ == '__main__':
         g_bench_sec  = args.time_limit
         g_time_limit = args.time_limit
 
-    print("=== Herradura KEx v1.9.16 \u2014 Security & Performance Tests (Python) ===")
+    print("=== Herradura KEx v1.9.32 \u2014 Security & Performance Tests (Python) ===")
     if g_rounds > 0 or g_time_limit > 0:
         parts = []
         if g_rounds > 0:     parts.append(f"rounds={g_rounds}")

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -147,6 +147,7 @@
         nl_fscx_v1, nl_fscx_revolve_v1
         nl_fscx_v2, nl_fscx_v2_inv, nl_fscx_revolve_v2, nl_fscx_revolve_v2_inv
         hfscx_256
+        hske_nl_aead_encrypt, hske_nl_aead_decrypt  (HSKE-NL-AEAD, TODO #95)
         stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify
         hpke_stern_f_encap, hpke_stern_f_decap
         hkex_rnl_keygen, hkex_rnl_agree  (public aliases added in v1.7.4)
@@ -161,6 +162,7 @@
     See docs/TUTORIAL.md for complete per-protocol code examples.
 '''
 
+import hmac
 import itertools
 import math
 import os
@@ -1790,6 +1792,82 @@ def ratchet_advance(state: BitArray) -> tuple:
 
 
 # ---------------------------------------------------------------------------
+# 95 — HSKE-NL-AEAD: authenticated encryption with associated data (TODO #95)
+#
+# Encrypt-then-MAC over the HSKE-NL-A1 CTR keystream:
+#   base    = K XOR nonce
+#   seed    = ROL(base, n/8) XOR RNL_KDF_DC          (KDF degeneracy guard, #38)
+#   ks_i    = nl_fscx_revolve_v1(seed, base XOR i, n/4)
+#   ct      = pt XOR ks                              (keystream truncated to len(pt))
+#   mac_key = nl_fscx_revolve_v1(ROL(seed, n/4), base, n/4)   (domain-separated)
+#   tag     = HFSCX-256-MAC(mac_key XOR IV,
+#                 DS || nonce || len(ad)_be8 || ad || len(ct)_be8 || ct)
+#
+# Key-committing: the tag binds mac_key (hence K and nonce) through the
+# collision-resistant keyed HFSCX-256-DM, so a ciphertext cannot verify under
+# two different keys — a property AES-GCM lacks.  The DS prefix domain-separates
+# the tag from the encfile/decfile .hkx MAC, which shares the mac_key schedule.
+# Decryption is verify-then-decrypt with a constant-time tag comparison.
+# ---------------------------------------------------------------------------
+
+_AEAD_DS = b'HSKE-NL-AEAD-v1'
+
+
+def _hske_nl_aead_streams(key: BitArray, nonce: BitArray) -> tuple:
+    """Derive (base, seed, mac_iv) for one (key, nonce) pair."""
+    base    = BitArray(KEYBITS, key.uint ^ nonce.uint)
+    seed    = BitArray(KEYBITS, base.rotated(KEYBITS // 8).uint ^ _RNL_KDF_DC_256)
+    mac_key = nl_fscx_revolve_v1(seed.rotated(KEYBITS // 4), base, I_VALUE)
+    mac_iv  = BitArray(KEYBITS, mac_key.uint ^ int.from_bytes(_HFSCX256_IV_BYTES, 'big'))
+    return base, seed, mac_iv
+
+
+def _hske_nl_aead_xor_keystream(seed: BitArray, base: BitArray, data: bytes) -> bytes:
+    """XOR data with the HSKE-NL-A1 CTR keystream (truncated to len(data))."""
+    blen = KEYBITS // 8
+    out  = bytearray()
+    for i in range((len(data) + blen - 1) // blen):
+        chunk = data[i * blen:(i + 1) * blen]
+        ks    = nl_fscx_revolve_v1(seed, BitArray(KEYBITS, base.uint ^ i), I_VALUE)
+        out  += bytes(d ^ k for d, k in zip(chunk, ks.uint.to_bytes(blen, 'big')))
+    return bytes(out)
+
+
+def _hske_nl_aead_tag(mac_iv: BitArray, nonce: BitArray, ad: bytes, ct: bytes) -> bytes:
+    """Auth tag over DS || nonce || len(ad) || ad || len(ct) || ct."""
+    data = (_AEAD_DS + nonce.uint.to_bytes(KEYBITS // 8, 'big')
+            + len(ad).to_bytes(8, 'big') + ad
+            + len(ct).to_bytes(8, 'big') + ct)
+    return hfscx_256(data, iv=mac_iv)
+
+
+def hske_nl_aead_encrypt(key: BitArray, pt: bytes, ad: bytes = b'',
+                         nonce: 'BitArray | None' = None) -> tuple:
+    """AEAD-encrypt pt under key with associated data ad.
+
+    Returns (nonce, ct, tag): nonce is a fresh random 256-bit BitArray unless
+    supplied (never reuse a (key, nonce) pair), ct is len(pt) bytes, tag is
+    32 bytes."""
+    if nonce is None:
+        nonce = BitArray.random(KEYBITS)
+    base, seed, mac_iv = _hske_nl_aead_streams(key, nonce)
+    ct  = _hske_nl_aead_xor_keystream(seed, base, pt)
+    tag = _hske_nl_aead_tag(mac_iv, nonce, ad, ct)
+    return nonce, ct, tag
+
+
+def hske_nl_aead_decrypt(key: BitArray, nonce: BitArray, ct: bytes, tag: bytes,
+                         ad: bytes = b'') -> 'bytes | None':
+    """Verify-then-decrypt.  Returns the plaintext, or None if the tag does not
+    authenticate (ct, ad) under (key, nonce).  Tag comparison is constant-time."""
+    base, seed, mac_iv = _hske_nl_aead_streams(key, nonce)
+    expected = _hske_nl_aead_tag(mac_iv, nonce, ad, ct)
+    if not hmac.compare_digest(bytes(tag), expected):
+        return None
+    return _hske_nl_aead_xor_keystream(seed, base, ct)
+
+
+# ---------------------------------------------------------------------------
 # 80 — Oblivious PRF (OPRF) over GF(2^n)*  (TODO #80)
 #
 # F(k, x) = gf_pow(H(x), k)  where  H = HFSCX-256 hash-to-field.
@@ -2419,6 +2497,21 @@ def main():
         print("- Masked HSKE encrypt/decrypt correct")
     else:
         print("+ Masked HSKE encrypt/decrypt failed!")
+
+    # 95 — HSKE-NL-AEAD demo: round-trip + tamper rejection
+    aead_key = BitArray.random(KEYBITS)
+    aead_pt  = b"HSKE-NL-AEAD demo plaintext (arbitrary length, 47 B)"
+    aead_ad  = b"header-v1"
+    aead_nonce, aead_ct, aead_tag = hske_nl_aead_encrypt(aead_key, aead_pt, aead_ad)
+    aead_dec = hske_nl_aead_decrypt(aead_key, aead_nonce, aead_ct, aead_tag, aead_ad)
+    aead_bad = hske_nl_aead_decrypt(aead_key, aead_nonce,
+                                    bytes([aead_ct[0] ^ 1]) + aead_ct[1:],
+                                    aead_tag, aead_ad)
+    aead_bad_ad = hske_nl_aead_decrypt(aead_key, aead_nonce, aead_ct, aead_tag, b"header-v2")
+    if aead_dec == aead_pt and aead_bad is None and aead_bad_ad is None:
+        print("- HSKE-NL-AEAD round-trip + tamper/AD rejection correct")
+    else:
+        print("+ HSKE-NL-AEAD failed!")
 
     # 78.C — Ratchet demo (5 steps)
     ratchet_seed = b"demo-seed-78c"

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -46,6 +46,7 @@ from primitives import (
     BitArray, fscx_revolve, nl_fscx_revolve_v1, nl_fscx_revolve_v2,
     nl_fscx_revolve_v2_inv, gf_mul, gf_pow,
     hfscx_256, _HFSCX256_IV_BYTES, _RNL_KDF_DC_256,
+    hske_nl_aead_encrypt, hske_nl_aead_decrypt,
     _rnl_keygen, _rnl_agree, _rnl_m_poly, _rnl_rand_poly, _rnl_poly_add,
     _rnl_lift, _rnl_poly_mul,
     stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
@@ -314,9 +315,15 @@ def _decode_rnl_response(path):
 # Ciphertext serialization (symmetric)
 # ---------------------------------------------------------------------------
 
-def _encode_sym_ct(algo, E_int, nbits, nonce_int=None):
+def _encode_sym_ct(algo, E_int, nbits, nonce_int=None, tag_int=None):
     nbytes = nbits // 8
-    if algo == 'hske-nla1' and nonce_int is not None:
+    if algo == 'hske-nla1' and nonce_int is not None and tag_int is not None:
+        der = der_seq(der_int(2),               # format tag 2: NLA1 AEAD (TODO #95)
+                      der_int(nonce_int, nbytes),
+                      der_int(E_int, nbytes),
+                      der_int(tag_int, 32),
+                      der_int(nbits))
+    elif algo == 'hske-nla1' and nonce_int is not None:
         der = der_seq(der_int(1),               # format tag 1: NLA1 with nonce
                       der_int(nonce_int, nbytes),
                       der_int(E_int, nbytes),
@@ -329,17 +336,20 @@ def _encode_sym_ct(algo, E_int, nbits, nonce_int=None):
 
 
 def _decode_sym_ct(path):
-    """Return (E_int, nbits, nonce_int_or_None)."""
+    """Return (E_int, nbits, nonce_int_or_None, tag_int_or_None)."""
     label, ints = _read_pem_ints(path)
     if label != _LABEL_CT:
         raise ValueError(f"Expected CIPHERTEXT PEM, got {label!r}")
     fmt = ints[0]
-    if fmt == 1:
+    if fmt == 2:
+        _, nonce_int, E_int, tag_int, nbits = ints
+        return E_int, nbits, nonce_int, tag_int
+    elif fmt == 1:
         _, nonce_int, E_int, nbits = ints
-        return E_int, nbits, nonce_int
+        return E_int, nbits, nonce_int, None
     else:
         _, E_int, nbits = ints
-        return E_int, nbits, None
+        return E_int, nbits, None, None
 
 
 # ---------------------------------------------------------------------------
@@ -683,6 +693,18 @@ def cmd_enc(args):
 
         elif algo == 'hske-nla1':
             N_nonce = BitArray.random(nbits)
+            if getattr(args, 'aead', False):
+                # HSKE-NL-AEAD (TODO #95): format tag 2 with auth tag
+                if nbits != 256:
+                    sys.exit("enc: --aead requires a 256-bit key")
+                ad = (args.ad or '').encode()
+                _, ct, tag = hske_nl_aead_encrypt(K, in_padded, ad, nonce=N_nonce)
+                _write_file(out_path, _encode_sym_ct(
+                    'hske-nla1', int.from_bytes(ct, 'big'), nbits,
+                    nonce_int=N_nonce.uint, tag_int=int.from_bytes(tag, 'big')))
+                return
+            if args.ad:
+                sys.exit("enc: --ad requires --aead")
             base    = BitArray(nbits, K.uint ^ N_nonce.uint)
             seed    = BitArray(nbits, base.rotated(nbits // 8).uint ^ (_RNL_KDF_DC_256 >> (256 - nbits)))
             ks      = nl_fscx_revolve_v1(seed, BitArray(nbits, base.uint ^ 0), nbits // 4)
@@ -751,8 +773,20 @@ def cmd_dec(args):
         key_int, nbits = _load_key(key_path)
         K = BitArray(nbits, key_int)
 
-        E_int, _nbits, nonce_int = _decode_sym_ct(getattr(args, 'in'))
+        E_int, _nbits, nonce_int, tag_int = _decode_sym_ct(getattr(args, 'in'))
         E = BitArray(nbits, E_int)
+
+        if algo == 'hske-nla1' and tag_int is not None:
+            # HSKE-NL-AEAD (TODO #95): verify-then-decrypt
+            ad = (getattr(args, 'ad', None) or '').encode()
+            pt = hske_nl_aead_decrypt(K, BitArray(nbits, nonce_int),
+                                      E_int.to_bytes(nbits // 8, 'big'),
+                                      tag_int.to_bytes(32, 'big'), ad)
+            if pt is None:
+                sys.exit("dec: authentication tag mismatch — "
+                         "ciphertext corrupt, wrong key, or wrong --ad")
+            _write_file(out_path, pt)
+            return
 
         if algo == 'hske':
             D = fscx_revolve(E, K, 3 * nbits // 4)
@@ -1307,6 +1341,10 @@ def build_parser():
     en.add_argument('--pubkey', default=None)
     en.add_argument('--in',  required=True, dest='in')
     en.add_argument('--out', required=True)
+    en.add_argument('--aead', action='store_true',
+                    help='HSKE-NL-AEAD authenticated encryption (hske-nla1 only)')
+    en.add_argument('--ad', default=None,
+                    help='associated data bound into the AEAD tag (requires --aead)')
 
     # dec
     de = sub.add_parser('dec', help='Decrypt')
@@ -1315,6 +1353,8 @@ def build_parser():
     de.add_argument('--key',    default=None)
     de.add_argument('--in',  required=True, dest='in')
     de.add_argument('--out', required=True)
+    de.add_argument('--ad', default=None,
+                    help='associated data for AEAD ciphertexts (must match enc --ad)')
 
     # sign
     sg = sub.add_parser('sign', help='Sign a message or generate a ZKP')

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -981,11 +981,37 @@ static void cmd_enc(int argc, char **argv)
             seq_and_write(it, il, 3, PEM_CIPHERTEXT, out_path);
 
         } else if (strcmp(algo, "hske-nla1") == 0) {
+            int aead = has_flag(argc, argv, "--aead");
+            const char *ad = get_arg(argc, argv, "--ad");
             FILE *urnd = fopen("/dev/urandom", "rb");
             if (!urnd) die("cannot open /dev/urandom");
-            BitArray N_nonce, base, seed, ks, E;
+            BitArray N_nonce;
             ba_rand(&N_nonce, urnd);
             fclose(urnd);
+            if (ad && !aead) die("enc: --ad requires --aead");
+
+            if (aead) {
+                /* AEAD format tag 2: SEQ(2, nonce, E, tag, nbits) — TODO #95 */
+                uint8_t ct_buf[KEYBYTES], tag[32];
+                hske_nl_aead_encrypt(&K, &N_nonce,
+                                     (const uint8_t *)(ad ? ad : ""),
+                                     ad ? strlen(ad) : 0,
+                                     P.b, KEYBYTES, ct_buf, tag);
+                uint8_t it0[8], itn[DER_INT_LEN(KEYBYTES)], itE[DER_INT_LEN(KEYBYTES)];
+                uint8_t itt[DER_INT_LEN(KEYBYTES)], itnb[8];
+                size_t l0, ln, lE, lt, lnb;
+                der_i_byte(2, it0, &l0);
+                der_i32(N_nonce.b, itn, &ln);
+                der_i32(ct_buf, itE, &lE);
+                der_i32(tag, itt, &lt);
+                der_i_n256(itnb, &lnb);
+                const uint8_t *it[5] = {it0, itn, itE, itt, itnb};
+                size_t il[5] = {l0, ln, lE, lt, lnb};
+                seq_and_write(it, il, 5, PEM_CIPHERTEXT, out_path);
+                return;
+            }
+
+            BitArray base, seed, ks, E;
             ba_xor(&base, &K, &N_nonce);
             ba_rnl_kdf_seed(&seed, &base);
             nl_fscx_revolve_v1_ba(&ks, &seed, &base, I_VALUE);
@@ -1104,6 +1130,24 @@ static void cmd_dec(int argc, char **argv)
         BitArray E, D;
 
         if (strcmp(algo, "hske-nla1") == 0) {
+            if (fmt == 2) {
+                /* AEAD format tag 2: SEQ(2, nonce, E, tag, nbits) — TODO #95 */
+                const char *ad = get_arg(argc, argv, "--ad");
+                BitArray N_nonce, E_ba, tag_ba;
+                if (ct.n_items < 5) die("dec: bad hske-nla1 AEAD ciphertext");
+                ba_from_ra(&N_nonce, ct.vals[1], ct.vlens[1]);
+                ba_from_ra(&E_ba,    ct.vals[2], ct.vlens[2]);
+                ba_from_ra(&tag_ba,  ct.vals[3], ct.vlens[3]);
+                pem_key_free(&ct);
+                if (!hske_nl_aead_decrypt(&K, &N_nonce,
+                                          (const uint8_t *)(ad ? ad : ""),
+                                          ad ? strlen(ad) : 0,
+                                          E_ba.b, KEYBYTES, tag_ba.b, D.b))
+                    die("dec: authentication tag mismatch — "
+                        "ciphertext corrupt, wrong key, or wrong --ad");
+                write_binary_file(out_path, D.b, KEYBYTES);
+                return;
+            }
             if (fmt != 1 || ct.n_items < 4) die("dec: bad hske-nla1 ciphertext");
             BitArray N_nonce, base, seed, ks;
             ba_from_ra(&N_nonce, ct.vals[1], ct.vlens[1]);
@@ -1969,12 +2013,15 @@ static void usage(void)
 "    --kdf hfscx-256: post-hash the raw shared secret with HFSCX-256.\n"
 "    Both sides must use the same --kdf flag to derive the same final key.\n"
 "\n"
-"  enc --algo ALGO (--key SK | --pubkey PUB) --in FILE [--out FILE]\n"
+"  enc --algo ALGO (--key SK | --pubkey PUB) --in FILE [--out FILE] [--aead [--ad STR]]\n"
 "    Encrypt.  Symmetric (--key): hske hske-nla1 hske-nla2\n"
 "    Asymmetric (--pubkey): hpke hpke-nl hpke-stern\n"
+"    --aead (hske-nla1 only): HSKE-NL-AEAD authenticated encryption; --ad binds\n"
+"    optional associated data into the tag (must match at dec).\n"
 "\n"
-"  dec --algo ALGO --key KEY --in CT_FILE [--out FILE]\n"
+"  dec --algo ALGO --key KEY --in CT_FILE [--out FILE] [--ad STR]\n"
 "    Decrypt.  Symmetric: key=SESSION KEY PEM.  Asymmetric: key=PRIVATE KEY PEM.\n"
+"    AEAD ciphertexts (format tag 2) are verified before decryption.\n"
 "\n"
 "  encfile --algo hske-nla1 --key SK --in FILE --out FILE.hkx\n"
 "    Stream-encrypt an arbitrary-size file (HSKE-NL-A1 CTR-AEAD).\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -820,8 +820,27 @@ func loadKey(path string) (*big.Int, int, error) {
 // For HSKE-NL-A1 pass nonce != nil to include format tag 1 + nonce field;
 // all other algos use format tag 0 (no nonce).
 func encodeSymCT(algo string, E *big.Int, n int, nonce *big.Int) (string, error) {
+	return encodeSymCTTag(algo, E, n, nonce, nil)
+}
+
+// encodeSymCTTag: authTag != nil selects AEAD format tag 2 (TODO #95):
+// SEQ(2, nonce, E, tag, nbits).
+func encodeSymCTTag(algo string, E *big.Int, n int, nonce, authTag *big.Int) (string, error) {
 	nb := n / 8
 	var items [][]byte
+	if algo == "hske-nla1" && nonce != nil && authTag != nil {
+		tag, _ := derIntSmall(2)
+		nd, _  := derIntBig(nonce, nb)
+		ed, _  := derIntBig(E, nb)
+		td, _  := derIntBig(authTag, 32)
+		nn, _  := derIntSmall(n)
+		items = [][]byte{tag, nd, ed, td, nn}
+		seq, err := DerSeqEnc(items...)
+		if err != nil {
+			return "", err
+		}
+		return PemWrap(lblCT, seq), nil
+	}
 	if algo == "hske-nla1" && nonce != nil {
 		tag, _ := derIntSmall(1)
 		nd, _  := derIntBig(nonce, nb)
@@ -1210,6 +1229,8 @@ func cmdEnc(args []string) {
 	pubkey := fs.String("pubkey", "", "Recipient public key file (asymmetric algos)")
 	in     := fs.String("in", "-", "Plaintext input file")
 	out    := fs.String("out", "-", "Ciphertext output PEM file")
+	aead   := fs.Bool("aead", false, "HSKE-NL-AEAD authenticated encryption (hske-nla1 only)")
+	ad     := fs.String("ad", "", "Associated data bound into the AEAD tag (requires --aead)")
 	fs.Parse(args)
 
 	if *algo == "" {
@@ -1245,6 +1266,21 @@ func cmdEnc(args []string) {
 			pem, err = encodeSymCT("hske", &E.Val, n, nil)
 		case "hske-nla1":
 			nonce := NewRandBitArray(n)
+			if *aead {
+				// HSKE-NL-AEAD (TODO #95): format tag 2 with auth tag
+				if n != 256 {
+					fmt.Fprintln(os.Stderr, "enc: --aead requires a 256-bit key")
+					os.Exit(1)
+				}
+				ct, authTag := HskeNlAeadEncrypt(K, nonce, []byte(*ad), msgPad(inBytes, nb))
+				pem, err = encodeSymCTTag("hske-nla1", new(big.Int).SetBytes(ct), n,
+					&nonce.Val, new(big.Int).SetBytes(authTag))
+				break
+			}
+			if *ad != "" {
+				fmt.Fprintln(os.Stderr, "enc: --ad requires --aead")
+				os.Exit(1)
+			}
 			base  := NewBitArray(n, new(big.Int).Xor(&K.Val, &nonce.Val))
 			seed  := RnlKdfSeed(base)
 			ks    := NlFscxRevolveV1(seed, base, n/4)
@@ -1334,6 +1370,7 @@ func cmdDec(args []string) {
 	key  := fs.String("key", "", "Key or private key file")
 	in   := fs.String("in", "-", "Ciphertext PEM input file")
 	out  := fs.String("out", "-", "Plaintext output file")
+	ad   := fs.String("ad", "", "Associated data for AEAD ciphertexts (must match enc --ad)")
 	fs.Parse(args)
 
 	if *algo == "" {
@@ -1355,8 +1392,31 @@ func cmdDec(args []string) {
 		if err != nil {
 			die("dec", err)
 		}
-		// ctInts[0] = fmt tag; tag 1 → nonce present
+		// ctInts[0] = fmt tag; tag 1 → nonce present; tag 2 → AEAD (TODO #95)
 		fmtTag := bytesToInt(ctInts[0])
+		if fmtTag == 2 {
+			if *algo != "hske-nla1" {
+				fmt.Fprintln(os.Stderr, "dec: AEAD ciphertext requires --algo hske-nla1")
+				os.Exit(1)
+			}
+			n := bytesToInt(ctInts[4])
+			K := NewBitArray(n, keyInt)
+			nonce := NewBitArray(n, new(big.Int).SetBytes(ctInts[1]))
+			ct := make([]byte, n/8)
+			new(big.Int).SetBytes(ctInts[2]).FillBytes(ct)
+			authTag := make([]byte, 32)
+			new(big.Int).SetBytes(ctInts[3]).FillBytes(authTag)
+			pt, ok := HskeNlAeadDecrypt(K, nonce, []byte(*ad), ct, authTag)
+			if !ok {
+				fmt.Fprintln(os.Stderr, "dec: authentication tag mismatch — "+
+					"ciphertext corrupt, wrong key, or wrong --ad")
+				os.Exit(1)
+			}
+			if err := writeBytes(*out, pt); err != nil {
+				die("dec", err)
+			}
+			return
+		}
 		var EInt, nonceInt *big.Int
 		var n int
 		if fmtTag == 1 {

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -26,6 +26,8 @@ nl_fscx_revolve_v2_inv = _s.nl_fscx_revolve_v2_inv
 gf_mul                 = _s.gf_mul
 gf_pow                 = _s.gf_pow
 hfscx_256              = _s.hfscx_256
+hske_nl_aead_encrypt   = _s.hske_nl_aead_encrypt
+hske_nl_aead_decrypt   = _s.hske_nl_aead_decrypt
 _HFSCX256_IV_BYTES     = _s._HFSCX256_IV_BYTES
 _RNL_KDF_DC_256        = _s._RNL_KDF_DC_256
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.31)
+# Herradura Cryptographic Suite (v1.9.32)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.32)
+# Herradura Cryptographic Suite (v1.9.33)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofs-2.md
+++ b/SecurityProofs-2.md
@@ -833,6 +833,8 @@ Both follow from A1 + A2.  HMAC adds resistance against extension and key-recove
 
 **Recommendation.**  The current single-purpose AEAD use is well-served by raw keyed-IV.  For protocols intending to reuse the same long-term key across multiple algorithms or modes (e.g. derive both an encryption key and a MAC key from one master), HMAC-HFSCX-256-DM should be preferred.  This is captured as a future TODO item once such cross-protocol reuse is introduced.
 
+**HSKE-NL-AEAD (v1.9.33, TODO #95 option 1).**  The keyed-IV MAC mode is now also deployed as the tag of a general-purpose AEAD, `hske_nl_aead_encrypt` / `hske_nl_aead_decrypt` (C/Go/Python suites; CLI `enc`/`dec --aead`).  The construction is encrypt-then-MAC over the HSKE-NL-A1 CTR keystream with associated-data support: the tag is computed over the domain-separation prefix `HSKE-NL-AEAD-v1`, the nonce, and length-framed AD and ciphertext, with the MAC key derived from the same per-(key, nonce) schedule as the `.hkx` file format but separated from it by the DS prefix.  Because the tag binds the MAC key through the collision-resistant keyed chain, the scheme is *key-committing*: a ciphertext/tag pair cannot verify under two distinct keys without a keyed collision, ruled out by A2 — a property AES-GCM lacks.  Verification is constant-time and decrypt-after-verify.  A single-pass alternative — a MonkeyDuplex-style sponge AEAD using the bijective NL-FSCX v2 family as the duplex permutation (TODO #95 option 2) — remains open research; it requires the differential/linear characterisation of the v2 permutation tracked in TODO #99 before any deployment claim.
+
 ### 11.9.7 Domain separation across suite call sites
 
 | Site | Role | Effective domain marker |

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -47,7 +47,9 @@ Primary use case for §11.10.2: **anonymous credentials** — prove knowledge of
 
 **Completeness proof sketch.** $m \cdot z = m \cdot y + c \cdot (m \cdot s) = w + c \cdot \text{lift}(C) + c \cdot \varepsilon$, where $\varepsilon = m \cdot s - \text{lift}(C)$ satisfies $\|\varepsilon\|_\infty \leq q/(2p)$ by the definition of rounding.  Hence $\|m \cdot z - w - c \cdot \text{lift}(C)\|_\infty \leq t \cdot q/(2p)$.
 
-**Soundness.** Under the Fiat-Shamir ROM assumption, one round suffices for computational soundness.  Special soundness: given two accepting transcripts $(w, c, z)$ and $(w, c', z')$ with $c \neq c'$, the response difference $(z - z') \cdot (c - c')^{-1} \approx s$ in the ring, contradicting Ring-LWR hardness.
+**Soundness (relaxed special soundness, TODO #94).** Under the Fiat-Shamir ROM assumption, one round suffices for computational soundness.  An earlier version of this argument extracted $(z - z') \cdot (c - c')^{-1} \approx s$, implicitly assuming the challenge difference is invertible in $\mathcal{R}_q$.  That assumption is **not justified** for the suite parameters: $q = 65537$ gives $q - 1 = 2^{16}$, so $2n \mid q - 1$ for every power-of-two $n \leq 256$ and $x^n + 1$ splits into $n$ linear factors over $\mathbb{F}_q$.  The ring $\mathcal{R}_q \cong \mathbb{F}_q^n$ (CRT) therefore contains zero divisors, and a nonzero sparse ternary difference $c - c'$ is non-invertible whenever it vanishes at one of the $n$ roots of $x^n + 1$.  Empirically (`zkp_pqc_exploration.py` §2.6): 3 of 2000 random challenge pairs at $n = 32$ produced a nonzero non-invertible difference (heuristic expectation $n/q \approx 0.0005$, i.e. 0.05 %), so strict special soundness fails with small but nonzero probability.
+
+The argument is therefore restated in the standard *relaxed* form [Lyubashevsky 2012]: given two accepting transcripts $(w, c, z)$ and $(w, c', z')$ with $c \neq c'$, the extractor outputs the pair $(\bar{z}, \bar{c}) = (z - z', c - c')$ **without inverting** $\bar{c}$.  This pair satisfies $\bar{c} \neq 0$ with $\lVert \bar{c} \rVert_\infty \leq 2$ and at most $2t$ nonzero coefficients, $\lVert \bar{z} \rVert_\infty \leq 2(\gamma - t)$, and (subtracting the two verification equations) $\lVert m \cdot \bar{z} - \bar{c} \cdot \text{lift}(C) \rVert_\infty \leq 2t \lceil q/(2p) \rceil$ — a *relaxed witness* for the statement $(m, C)$.  Producing such a short relaxed witness without knowledge of $s$ would distinguish $C$ from rounding noise, contradicting Ring-LWR hardness; the honest witness $s$ itself yields one via $\bar{z} = \bar{c} \cdot s$.  The relaxation widens the extracted-witness norm by a factor of 2, which is accounted for in the security margin discussion (open direction 1, §11.10.6).
 
 **Zero-knowledge.** Rejection sampling ensures $z$ is statistically close to $\text{Unif}([-\gamma+t, \gamma-t]^n)$, independent of $s$.  The triple $(w, c, z)$ can be simulated without $s$ by choosing $z$ uniformly and setting $w = m \cdot z - c \cdot \text{lift}(C)$.
 
@@ -57,6 +59,15 @@ Primary use case for §11.10.2: **anonymous credentials** — prove knowledge of
 |---|---|---|
 | Completeness (honest prover) | 1 000 | 0 failures [PASS] |
 | Soundness (naive cheat: random $z$, no $s$) | 200 | 0 passes [PASS] |
+| Soundness (wrong-key witness $s' \neq s$, §2.4b) | 200 | 0 passes [PASS] |
+| Soundness (tampered $w$ — Fiat-Shamir check, §2.4b) | 200 | 0 passes [PASS] |
+| Soundness (perturbed $z$ — residual-norm check, §2.4b) | 200 | 0 passes [PASS] |
+| Soundness (challenge grinding, 64 attempts/trial, §2.4b) | 200 | 0 passes [PASS] |
+| Challenge-difference invertibility in $\mathcal{R}_q$ (§2.6) | 2 000 pairs | 3 nonzero non-invertible differences — strict special soundness fails; relaxed form required |
+
+The wrong-key, tampered- $w$, perturbed- $z$, and grinding cheats are also exercised in the
+language test suites (`CryptosuiteTests/Herradura_tests.py` test [21]) against the deployed
+`_rnl_sigma_sign` / `_rnl_sigma_verify` implementation at both $n = 32$ and $n = 256$.
 
 **Proof sizes:**
 

--- a/SecurityProofsCode/zkp_pqc_exploration.py
+++ b/SecurityProofsCode/zkp_pqc_exploration.py
@@ -18,7 +18,11 @@ This script covers the two NOT-yet-implemented pillars:
       §2.2  Protocol: commit / challenge / respond / verify
       §2.3  Completeness — 1 000 honest-prover trials (expect 0 failures)
       §2.4  Soundness   — 200 cheating-prover trials  (expect ≈0 passes)
+      §2.4b Structured cheats (TODO #94): wrong-key witness, tampered w,
+            perturbed z, bounded challenge grinding
       §2.5  Proof-size analysis
+      §2.6  Challenge-difference invertibility in R_q (relaxed soundness
+            motivation: x^n+1 splits over F_q since 2n | q-1)
   §3  NL-FSCX ZKP via MPC-in-the-head (ZKBoo, 3-party Boolean circuit)
       §3.1  NL-FSCX v1 bit-level circuit (n=8 toy)
       §3.2  ZKBoo 3-party evaluation with per-AND-gate commitments
@@ -315,6 +319,73 @@ def section2_soundness():
     print(f"  Time         : {elapsed:.2f} s")
 
 
+# ── §2.4b  Structured cheating provers (TODO #94 item 2) ─────────────────────
+
+def section2_structured_cheats():
+    print(SEP2)
+    print(f"§2.4b Ring-LWR Σ-protocol — Structured cheats ({SOUND} trials each, n={_N})")
+    t0 = time.time()
+
+    # Cheat B — wrong-key witness: run the honest prover algorithm with a
+    # freshly sampled s' != s against the original public key C.
+    wrong_key = 0
+    for _ in range(SOUND):
+        m, s, C = rnl_keygen()
+        s2 = _cbd_poly(_N, _Q)
+        try:
+            w, c, z = rnl_prove(m, s2, C)
+        except RuntimeError:
+            continue
+        if rnl_verify(m, C, w, c, z):
+            wrong_key += 1
+
+    # Cheat C — tampered commitment: take an honest transcript, perturb one
+    # coefficient of w, keep (c, z).  Must fail the Fiat-Shamir re-derivation.
+    tamper_w = 0
+    # Cheat D — perturbed response: keep (w, c), add 1 to one coefficient of z.
+    # FS check still passes (w unchanged); the residual-norm check must catch it.
+    tamper_z = 0
+    for _ in range(SOUND):
+        m, s, C = rnl_keygen()
+        try:
+            w, c, z = rnl_prove(m, s, C)
+        except RuntimeError:
+            continue
+        w2 = list(w); w2[0] += 1
+        if rnl_verify(m, C, w2, c, z):
+            tamper_w += 1
+        z2 = list(z); z2[0] += 1
+        if rnl_verify(m, C, w, c, z2):
+            tamper_z += 1
+
+    # Cheat E — bounded challenge grinding: the §2.4 cheat (choose z first,
+    # set w = m·z) repeated G times per trial, accepting if any attempt
+    # verifies.  Per-attempt success requires ||c·lift(C)||_inf <= slack,
+    # i.e. n coefficients simultaneously small: Pr ≈ ((2·slack+1)/q)^n ≈ 0.
+    GRIND = 64
+    grind = 0
+    for _ in range(SOUND):
+        m, s, C = rnl_keygen()
+        ok = False
+        for _ in range(GRIND):
+            w, c, z = _cheat_prove_rnl(m, C)
+            if rnl_verify(m, C, w, c, z):
+                ok = True
+                break
+        if ok:
+            grind += 1
+
+    elapsed = time.time() - t0
+    total_bad = wrong_key + tamper_w + tamper_z + grind
+    status = "PASS" if total_bad == 0 else "FAIL"
+    print(f"  Wrong-key witness s' passes      : {wrong_key}/{SOUND}")
+    print(f"  Tampered w passes (FS check)     : {tamper_w}/{SOUND}")
+    print(f"  Perturbed z passes (residual)    : {tamper_z}/{SOUND}")
+    print(f"  Grinding passes ({GRIND} att/trial)   : {grind}/{SOUND}")
+    print(f"  Overall: {total_bad} cheat acceptances  [{status}]")
+    print(f"  Time   : {elapsed:.2f} s")
+
+
 # ── §2.5  Proof size ──────────────────────────────────────────────────────────
 
 def section2_proofsize():
@@ -335,6 +406,56 @@ def section2_proofsize():
     print("  Compare: ML-DSA-44 sig = 2420 B; ML-DSA-65 = 3309 B; ML-DSA-87 = 4627 B.")
 
 
+# ── §2.6  Challenge-difference invertibility in R_q (TODO #94 item 1) ────────
+
+def section2_invertibility():
+    """
+    Special soundness extracts (z-z')·(c-c')^{-1}; this requires c-c' to be a
+    unit in R_q = Z_q[x]/(x^n+1).  For q = 65537 (q-1 = 2^16) and power-of-two
+    n, 2n | q-1, so x^n+1 splits into n LINEAR factors over F_q and R_q is
+    CRT-isomorphic to F_q^n.  A nonzero difference d = c-c' is invertible iff
+    d(r) != 0 at every root r of x^n+1.  This section measures the
+    non-invertible fraction empirically — any nonzero rate means strict
+    special soundness fails and the relaxed formulation (§11.10.2) is required.
+    """
+    print(SEP2)
+    PAIRS = 2000
+    print(f"§2.6  Challenge-difference invertibility in R_q ({PAIRS} pairs, n={_N})")
+    q, n = _Q, _N
+    assert (q - 1) % (2 * n) == 0, "x^n+1 does not split fully; adapt test"
+    # 3 generates F_65537^*; omega = 3^((q-1)/2n) is a primitive 2n-th root of
+    # unity; the roots of x^n+1 are the odd powers omega^(2i+1).
+    omega = pow(3, (q - 1) // (2 * n), q)
+    roots = [pow(omega, 2 * i + 1, q) for i in range(n)]
+
+    def _eval(poly, x):
+        acc = 0
+        for coef in reversed(poly):
+            acc = (acc * x + coef) % q
+        return acc
+
+    zero_diff = non_inv = 0
+    for _ in range(PAIRS):
+        c1 = _challenge(os.urandom(16), n, _T)
+        c2 = _challenge(os.urandom(16), n, _T)
+        d = [(a - b) % q for a, b in zip(c1, c2)]
+        if all(x == 0 for x in d):
+            zero_diff += 1
+            continue
+        if any(_eval(d, r) == 0 for r in roots):
+            non_inv += 1
+    frac = non_inv / PAIRS
+    # Heuristic expectation: each of n roots vanishes w.p. ~1/q for a "random"
+    # nonzero difference → union bound ≈ n/q.
+    print(f"  Identical challenge pairs        : {zero_diff}/{PAIRS}")
+    print(f"  Nonzero but NON-invertible diffs : {non_inv}/{PAIRS} ({frac:.4%})")
+    print(f"  Heuristic expectation n/q        : {n / q:.4%}")
+    print("  Conclusion: non-invertible differences exist (or cannot be excluded),")
+    print("  so the soundness argument uses RELAXED special soundness (§11.10.2):")
+    print("  the extractor outputs (z-z', c-c') as a relaxed witness; no inverse")
+    print("  of c-c' is taken.")
+
+
 def section2():
     print()
     print(SEP)
@@ -344,7 +465,9 @@ def section2():
           f"bound={_G - _MAX_CS}, slack={_T * (_Q // (2 * _P) + 1)}")
     section2_completeness()
     section2_soundness()
+    section2_structured_cheats()
     section2_proofsize()
+    section2_invertibility()
 
 
 # =============================================================================

--- a/TODO.md
+++ b/TODO.md
@@ -5816,3 +5816,198 @@ parameters.  Structured cheats implemented in `zkp_pqc_exploration.py` §2.4b
 in the Python suite test [21] at n=32/256 (wrong-key / w-tamper / z-tamper rejection).
 C/Go test-[21] extension deferred as a cross-language parity follow-up.  Items
 3(a)–(d) remain **OPEN**; 3(b) NTT acceleration is the recommended next step.
+
+---
+
+## Core Primitive Review — New Uses and Cryptographic Advantages — Identified 2026-06-12
+
+A focused review of the unique core algorithms (FSCX / FSCX_REVOLVE and the NL-FSCX
+family) identified five application directions that are **not** covered by the TODO #78
+catalogue.  Each item below records the primitive property exploited, the cryptographic
+advantage that makes the construction natural to this suite, and a concrete
+implementation plan.
+
+Properties recap driving these items:
+
+- **FSCX is GF(2)-linear and circulant** — `M = I XOR ROL XOR ROR` is a 3-tap circulant
+  matrix; rotation-only, branch-free, constant-time on every target including Arduino
+  and ARM Thumb-2.  Order of M is n/2, so `M^{-1} = M^{n/2-1}` is a precomputable
+  rotation table (`_m_inv`).
+- **NL-FSCX v2 is a keyed permutation family** — bijective in A for every B, with a
+  closed-form O(n)-rotation inverse.  Suitable wherever a tweakable PRP is needed.
+- **NL-FSCX v1 is a conjectured OWF** (Theorem 16, SecurityProofs-2 §11.8.3) — usable
+  for one-way state evolution (ratchets, hash chains, key erasure).
+- **HPKS Schnorr signing is linear in the secret exponent** — `s = (k − a·e) mod (2^n−1)`
+  is an affine function of both a and k, the property that enables threshold and
+  aggregate variants in classical Schnorr.
+
+---
+
+### 95. HSKE-NL-AEAD — authenticated encryption mode with key commitment (Feature, High)
+
+**Primitive exploited:** NL-FSCX v1 keystream (HSKE-NL-A1) + HFSCX-256-DM compression.
+
+**Gap:** The suite has no authenticated encryption.  HSKE, HSKE-NL-A1, and HSKE-NL-A2
+are malleable: an attacker can flip ciphertext bits (A1: bit-flips pass through to
+plaintext; A2: controlled corruption) without detection.  Every modern protocol use of
+the suite (CLI `enc`/`encfile`, PAKE session channel from #78.D, ratchet from #78.C)
+needs AEAD, and currently none exists.
+
+**Cryptographic advantage:** All components are native — no external MAC import needed.
+Two design options to evaluate:
+
+1. **Encrypt-then-MAC:** `C = HSKE-NL-A1(K_enc, nonce, P)`;
+   `tag = hfscx_256(K_mac || nonce || AD || C)` with `K_enc, K_mac` derived from a master
+   key via domain-separated HFSCX-256 calls.  This is also *key-committing* for free
+   (the tag binds K_mac through a collision-resistant hash), a property AES-GCM lacks.
+2. **Duplex/sponge mode over the NL-FSCX v2 permutation:** use `nl_fscx_revolve_v2`
+   as the sponge permutation (bijectivity gives the required permutation property),
+   absorbing AD and plaintext blocks and squeezing the tag — a MonkeyDuplex-style
+   single-pass AEAD.  Research-grade: requires analysis of v2's differential/linear
+   profile as a sponge permutation before deployment.
+
+**Plan:** implement option 1 (`hske_nl_aead_encrypt` / `hske_nl_aead_decrypt`) in
+C/Go/Python with constant-time tag comparison (reuse #83 helper); wire into CLI
+`enc`/`dec`/`encfile`/`decfile` behind an `--aead` flag; add tamper-rejection tests;
+document option 2 as a follow-up research note in SecurityProofs.
+
+Status: **Option 1 DONE v1.9.33** — `hske_nl_aead_encrypt`/`decrypt` in the Python suite,
+`herradura.h`, and `herradura/herradura.go` (byte-for-byte interoperable, shared KAT);
+CLI `enc`/`dec --aead [--ad]` with PEM format tag 2 in all three CLIs (`encfile`/`decfile`
+were already always-AEAD via the `.hkx` MAC — no flag needed there); security test [28]
+(KAT + roundtrip + ciphertext/tag/AD/nonce/key tamper rejection) in C/Go/Python;
+`CliTest/test_aead.sh` (9 interop pairs + rejection); SecurityProofs-2.md §11.9.6 note.
+Option 2 (NL-FSCX v2 sponge/duplex single-pass AEAD) remains **OPEN** as research,
+gated on the #99 diffusion characterisation.
+
+---
+
+### 96. Forward-secure DRBG — fast-key-erasure RNG from the NL-FSCX v1 ratchet (Feature, Medium)
+
+**Primitive exploited:** NL-FSCX v1 one-wayness (same assumption as #78.C ratchet).
+
+**Gap:** The suite consumes randomness from `os.urandom`/`/dev/urandom` everywhere but
+provides no deterministic expansion of its own.  Embedded targets (Arduino) have weak
+entropy sources; a seedable, forward-secure DRBG built from suite primitives would let
+all targets share one audited generator.
+
+**Construction (fast-key-erasure pattern, Bernstein 2017):**
+```
+state_{i+1} = nl_fscx_revolve_v1(state_i, DOMAIN_DRBG, n/4)
+output_i    = hfscx_256(state_i || counter || b'DRBG-OUT')
+```
+Erasing `state_i` after each advance makes prior outputs irrecoverable from a
+compromised state (backtracking resistance) under the same OWF conjecture as Theorem 16.
+
+**Cryptographic advantage:** identical security assumption set as the rest of the suite
+(no new hardness assumptions); rotation/XOR/add-only inner loop runs on AVR.
+
+**Prerequisite:** the same state-collision bound as #78.C — the v1 map is non-bijective,
+so expected cycle length of the state walk must be characterised
+(`SecurityProofsCode/nl_fscx_v1_ratchet_collision.py`, still unwritten) before
+production use.  NIST SP 800-90A health-test analogues (reseed counter, output-block
+limit) should be part of the design.
+
+**Plan:** add `drbg_seed` / `drbg_generate` / `drbg_reseed` to C/Go/Python suites;
+collision-distance analysis script; statistical tests (reuse test [4] machinery);
+document non-goals (not a NIST-validated DRBG).
+
+Status: **OPEN**
+
+---
+
+### 97. HPKS-XMSS-F — stateful many-time hash signature from WOTS-F chains + the #78.J Merkle tree (Feature, Medium)
+
+**Primitives exploited:** NL-FSCX v1 hash chain `h(x) = F^{n/4}(ROL(x, n/8), x)`
+(Theorem 16 / HPKS-WOTS-F, currently *proof-only* — no suite implementation exists) and
+the HFSCX-256 Merkle accumulator already implemented under #78.J.
+
+**Gap:** HPKS-WOTS-F is analysed in SecurityProofs-2 §11.8.3 and stress-tested in
+`nl_fscx_rot_analysis.py` (TODO #75), but never landed as code.  A one-time signature
+alone is operationally fragile; combining W-OTS chains with the existing Merkle tree
+gives an XMSS-style many-time signature — the only suite signature whose security rests
+purely on the OWF/collision assumptions (no DLP, no Ring-LWR, no syndrome decoding).
+
+**Cryptographic advantage:** hash-based signatures are the most conservative PQC class
+(SPHINCS+/XMSS are already NIST/RFC standards); this variant would be the suite's
+highest-assurance signature, with both building blocks already analysed.  The known
+two-sided rotational distinguisher on the WOTS chain (p ≈ 0.42/r power law, TODO #75)
+does not break the OWF-based proof but must be restated in the design rationale.
+
+**Plan:** implement `hpks_wots_keygen/sign/verify` (Winternitz parameter w=16),
+then `hpks_xmss_*` wrapping 2^h leaves (h=10 default) with the #78.J tree; state-file
+handling for leaf-index tracking in the CLI (`sign --algo hpks-xmss`); tests for
+one-time-reuse rejection and tamper rejection; SecurityProofs-2 §11.8.3 extension.
+
+Status: **OPEN**
+
+---
+
+### 98. Threshold and aggregate HPKS — exploiting Schnorr exponent linearity over GF(2^n)* (Research/Feature, Medium)
+
+**Primitive exploited:** linearity of HPKS signing in the secret:
+`s = (k − a·e) mod (2^n − 1)`.  If `a = a_1 + a_2 + ... + a_t mod (2^n − 1)` is
+additively shared, each party computes `s_j = (k_j − a_j·e) mod (2^n − 1)` with its own
+nonce share, and `s = Σ s_j`, `R = Π R_j` verify against the combined public key
+`C = Π C_j = g^{Σ a_j}` — the same algebra that powers FROST/MuSig2 in prime-order
+groups, transplanted to GF(2^n)*.
+
+**Cryptographic advantages:**
+- n-of-n distributed signing and key generation with zero new primitives — only
+  `gf_mul`/`gf_pow` and the existing HPKS challenge derivation.
+- Key-aggregation (MuSig-style) gives multi-party signatures the size of one HPKS
+  signature.
+- t-of-n follows with Shamir sharing over Z_{2^n−1}; note 2^n−1 is composite for the
+  suite sizes, so the sharing modulus and invertibility conditions need explicit
+  treatment (CRT over the factorisation, or restrict to n-of-n first).
+
+**Known hazards to address (research portion):** rogue-key attacks (require MuSig2-style
+nonce/key coefficient binding via HFSCX-256), nonce-reuse across signers, and the
+challenge function — HPKS uses `fscx_revolve(R, msg, i)` (linear) while HPKS-NL uses
+NL-FSCX v1; the threshold variant must use the NL challenge to avoid the known linear
+challenge weakness.
+
+**Plan:** analysis script `SecurityProofsCode/hpks_threshold_demo.py` first (n-of-n
+2-party demo, rogue-key counterexample, composite-modulus discussion); promote to suite
+functions only after the rogue-key binding design is fixed.
+
+Status: **OPEN**
+
+---
+
+### 99. FSCX as a standalone linear diffusion layer — branch-number characterisation and SPN construction study (Research, Medium)
+
+**Primitive exploited:** the circulant GF(2)-linear map `M = I XOR ROL XOR ROR` itself —
+the one core property no #78 item examines directly.
+
+**Observation:** modern lightweight ciphers (ASCON, Xoodoo, GIFT) are built as SPNs
+alternating a cheap non-linear layer with a rotation-based linear diffusion layer.
+FSCX's M is exactly such a layer: 3-tap circulant, XOR/rotate-only, constant-time,
+self-similar across word sizes, with known algebraic structure (order n/2, precomputable
+inverse).  The suite already pairs it with a non-linear step (integer-add carry chain in
+NL-FSCX v1/v2) — i.e. NL-FSCX is implicitly a 1-round ARX-style SPN, but its diffusion
+quality has never been quantified.
+
+**Work items:**
+1. Compute the differential and linear **branch number** of M (and of `M^k` for small k)
+   at n = 32, 64, 256; compare against ASCON's Σ functions (also 3-tap circulants —
+   `x XOR ROR(x,a) XOR ROR(x,b)`); FSCX's two-operand form `M(A) XOR M(B)` is a
+   structural sibling.
+2. Measure full-diffusion depth: minimum revolve steps until every output bit depends on
+   every input bit of A and B (avalanche matrix), at each suite size.
+3. From 1–2, derive a recommended round count for NL-FSCX-based keystreams independent
+   of the current heuristic `i = n/4`, and document whether `n/4` over- or
+   under-provisions diffusion.
+4. Sketch an explicit SPN ("FSCX-SPN") — alternate `nl_fscx_v1` non-linear step with an
+   independently-keyed round constant schedule — as the analysable successor to the
+   ad-hoc revolve constructions, feeding the sponge-permutation option of #95.
+
+**Cryptographic advantage:** turns the suite's signature primitive from a folklore
+construction into one with standard, comparable diffusion metrics, and creates the
+analysis foundation that #95 option 2 (sponge AEAD) and #96 (DRBG) depend on.
+
+**Plan:** `SecurityProofsCode/fscx_branch_number.py` (exhaustive at n=16/32, sampled at
+n=64/256); results into SecurityProofs-1 §3 (FSCX algebraic analysis); follow-up
+SecurityProofs note for the SPN sketch.
+
+Status: **OPEN**

--- a/TODO.md
+++ b/TODO.md
@@ -5602,3 +5602,217 @@ Update CLAUDE.md testing section to reflect actual counts.
 Update TODO #84 reference: Python test `[25]` → `[26]` (Masked HSKE renumbered).
 
 Status: **DONE v1.9.31**
+
+---
+
+## PQC Security Proofs Review — Identified 2026-06-12
+
+Review scope: SecurityProofs-2.md §11–§11.9 (NL-FSCX, HKEX-RNL, Stern-F, HFSCX-256-DM)
+and SecurityProofs-3.md §11.10 (ZKP extensions), cross-checked against the deployed
+Python suite implementation.
+
+### 88. Apply HFSCX-256-DM finalization to `_stern_matrix_row` — F_stern-v2 fix only partially deployed (Security, High)
+
+**Affected files:** all six language targets (suite + `herradura.h` + Go package +
+assembly/Arduino n=32 demos), `SecurityProofs-2.md` §11.8.4, test files.
+
+**Problem.** SecurityProofs-2.md §11.8.4 ("Fix (TODO #43)") specifies that the range
+compression of F_stern is eliminated by composing with HFSCX-256-DM, and states "One
+HFSCX-256-DM call is added **per row of H** and per hash step in the commitment scheme."
+TODO #43 (DONE v1.6.0) applied the finalization to `_stern_hash` only.  The public
+parity-matrix row generator still uses raw NL-FSCX v1:
+
+```python
+def _stern_matrix_row(seed_int, row, n):
+    seed = BitArray(n, seed_int)
+    A0   = BitArray(n, seed_int ^ row).rotated(n // 8)
+    return nl_fscx_revolve_v1(A0, seed, n // 4)   # no HFSCX finalization
+```
+
+Consequence: rows of H are drawn from a range-compressed distribution (~21–28% distinct
+at n=32 per TODO #42 measurements; predicted <10^-4 distinct fraction at n=256 per
+§11.8.4 §10 extrapolation).  H is therefore distinguishable from a uniformly random
+binary matrix by collision counting, and duplicate/correlated rows reduce rank(H),
+weakening the SD(N,t) instance below its nominal hardness.  This contradicts the PRF
+premise of Theorem 17 (ε_PRF term) for the matrix-generation use, which §11.8.4
+presents as fixed.
+
+**Fix:** route each row through HFSCX-256-DM before truncation to n bits, exactly as
+`_stern_hash` does, in all six targets.  Wire-format breaking: public keys, syndromes,
+signatures, and KEM ciphertexts all change (H changes).  Update §11.8.4 to record
+deployment, update interop tests, bump version.
+
+Status: **PENDING**
+
+---
+
+### 89. HKEX-RNL: unauthenticated unilateral blinding polynomial enables parameter-substitution downgrade (Security, High)
+
+**Affected files:** suite (all targets), `HerraduraCli` kex flows, `SecurityProofs-2.md`
+§11.4.2–§11.4.3.
+
+**Problem.** §11.4.2: "One party (e.g. Alice) draws a_rand ← R_q uniformly and transmits
+it in the clear."  The security argument (§11.4.3) requires m_blind = m + a_rand to be
+uniformly random in R_q, and notes blinding is **required** for the Ring-LWR reduction.
+Two gaps:
+
+1. **Active substitution.** A MITM (or a malicious peer) can replace a_rand with a chosen
+   value, e.g. a_rand = −m(x) + e for small e, making m_blind sparse/structured.  The
+   protocol then degenerates toward the unblinded case that §11.4.3 explicitly warns is
+   open to lattice-reduction leverage; in the extreme m_blind = 0 all public keys become
+   rounding of 0.  Nothing in the wire format or code validates a_rand.
+2. **Non-contributory randomness.** Even passively, the proof's "uniform m_blind" premise
+   rests entirely on one party's RNG; a backdoored or weak RNG on one side silently
+   weakens both.
+
+**Fix plan:**
+- Make the blinding contributory: both parties send nonces n_A, n_B and derive
+  a_rand = XOF(n_A ‖ n_B) by expanding HFSCX-256-DM in counter mode to n coefficients
+  mod q (rejection-sample to keep uniformity).  This fits the existing two-round
+  HKEX-RNL message flow without adding a round.
+- At minimum (non-breaking interim): receiver-side sanity validation of a_rand
+  (reject if m_blind has low Hamming weight / low coefficient entropy) plus a
+  documented caveat in §11.4.3 that the uniformity assumption is trust-on-first-use.
+- Update SecurityProofs-2.md §11.4.2/§11.4.3 with the active-adversary model.
+
+Status: **PENDING**
+
+---
+
+### 90. HKEX-RNL: define an upgraded parameter set reaching ≥128-bit Core-SVP (Security, Medium)
+
+**Affected files:** suite (all targets), `SecurityProofs-2.md` §11.4.3/§11.6/§11.7.
+
+**Problem.** The TODO #71 landscape review (§11.4.3) places the deployed parameters
+(n=256, q=65537, p=4096, η=1) at ~105–115 classical / ~95–105 quantum Core-SVP bits —
+below the 128-bit ML-KEM-768 target.  The documents state this but no remediation path
+is planned.
+
+**Fix plan (analysis first, then optional deployment):**
+1. Run the LWE estimator over candidate upgrades: (a) η=2 CBD secrets (Kyber-512
+   baseline), (b) module rank k=2 over n=256 (Module-LWR, doubles key material),
+   (c) smaller q (e.g. 3329) with retuned p and re-verified Peikert reconciliation
+   margin (max per-coeff error vs q/8).
+2. Verify m(x) invertibility and reconciliation failure rate = 0 at the chosen set
+   (extend `hkex_rnl_failure_rate.py`).
+3. Document the selected set as `HKEX-RNL-128`; keep the current set as the default
+   wire format until a major version, or version-tag the PEM header.
+
+Status: **PENDING**
+
+---
+
+### 91. Stern-F: plan production-security parameter path (N ≥ 17000 QC-MDPC) or enforce demo-only status (Security, Medium)
+
+**Affected files:** suite (C/Go/Python), `HerraduraCli`, `docs/TUTORIAL.md`,
+`SecurityProofs-2.md` §11.8.4.
+
+**Problem.** §11.7/§11.8.4 (TODO #71 review) put HPKS-Stern-F / HPKE-Stern-F at the
+deployed (N=256, k=128, t=16) at only ~2^56–2^60 classical and ~2^30–2^40 quantum ISD
+operations — "demo only".  Yet §11.10.5 lists HPKS-Stern-F as "Production-ready,
+v1.5.18", and the CLI signs/encrypts with it without any warning.  The 78 KB proof size
+quoted everywhere also corresponds to the demo parameters.
+
+**Fix plan:**
+1. Immediate (docs/UX): reconcile §11.10.5 wording with the §11.8.4 caveat; add a
+   CLI warning (or `--i-know-this-is-demo` style acknowledgement) when Stern-F is used
+   at N=256; state demo status in TUTORIAL.md.
+2. Research: evaluate a QC-MDPC instantiation (BIKE-style, N≈24646, t=134) using the
+   NL-FSCX v1 PRF for seed expansion as already sketched in §11.8.4; requires a
+   QC-MDPC bit-flipping decoder (currently absent — decap uses known-e′/brute force).
+   Estimate signature/key sizes and decide go/no-go for implementation.
+
+Status: **PENDING**
+
+---
+
+### 92. Reconcile assumption A2's classical preimage bound with §11.9.4/§11.9.11 claims (Documentation/Proof consistency, Medium)
+
+**Affected files:** `SecurityProofs-2.md` §11.9.2, §11.9.4, §11.9.8, §11.9.11.
+
+**Problem.** Assumption A2 (§11.9.2) states that inverting F_1^64 "requires
+Ω(2^{n/2}) = Ω(2^{128}) **classical** operations and Ω(2^{n/2}) quantum queries".  But
+§11.9.4 and the §11.9.11 summary claim **2^256 classical** preimage and second-preimage
+resistance "under A2" — a bound A2 as written cannot deliver.  Either A2 understates the
+conjectured classical hardness (it should be Ω(2^n) classical / Ω(2^{n/2}) quantum,
+consistent with Corollary 2's brute-force bound), or the §11.9.4/§11.9.11 rows overstate
+it.  Theorem 18 and §11.9.8 item 1 also cite Ω(2^{n/2}) from A2 and should be re-checked
+once A2 is restated.
+
+**Fix:** restate A2 with separate classical (2^n) and quantum (2^{n/2}, Grover) bounds,
+then audit every downstream citation (§11.9.3–§11.9.11) for consistency, and re-run the
+KaTeX validator per CLAUDE.md before pushing.
+
+**Related finding (added 2026-06-12 during TODO #94 work):** §11.4.3 states that
+$x^{256}+1$ "does not split into degree-1 factors over F_65537 since 512 ∤ q−1".
+This is arithmetically wrong: q−1 = 65536 = 2^16 and 512 = 2^9 divides it, so 2n | q−1
+for every power-of-two n ≤ 256 and the ring splits **completely** into linear factors
+(empirically confirmed in `zkp_pqc_exploration.py` §2.6 at n=32).  Fully-splitting
+rings are standard for lattice schemes (Dilithium uses one), so this does not by
+itself invalidate the Ring-LWR hardness claim, but the stated justification for
+ruling out subfield/NTRU-style attacks must be corrected and the attack-surface
+discussion re-checked when fixing this TODO.
+
+Status: **PENDING**
+
+---
+
+### 93. HFSCX-256-DM open hardenings: per-call-site domain tags, HMAC mode, assembly per-slot DS (Security, Low)
+
+**Affected files:** suite (all targets), `HerraduraCli`, `SecurityProofs-2.md`
+§11.9.6/§11.9.7/§11.9.9/§11.9.11.
+
+Consolidates the three "open hardenings" already noted in §11.9.11 plus the assembly
+gap in §11.9.9, none of which has a TODO entry:
+
+1. **1-byte domain-tag prefix** per call site (0x01 dgst, 0x02 sign-pre-hash,
+   0x03 AEAD-MAC), introduced as a versioned wire-format option `HFSCX-256-DS`
+   (§11.9.7).  Removes the reliance on collision-resistance reasoning for
+   domain separation between `dgst` and sign pre-hash (which currently share IV).
+2. **HMAC-HFSCX-256-DM** construction available in the library, and required whenever
+   one long-term key is reused across modes (§11.9.6); current raw keyed-IV MAC stays
+   the AEAD default.
+3. **Assembly/Arduino n=32:** add per-slot DS tags to `stern_hash1_32`/`stern_hash2_32`
+   (currently only structural distinctness; §11.9.9 calls this "a future hardening
+   item").
+
+Status: **PENDING**
+
+---
+
+### 94. ZKP-RNL Σ-protocol: formal soundness gaps — challenge-difference invertibility, stronger cheat tests, and §11.10.6 follow-ups (Research, Medium)
+
+**Affected files:** `SecurityProofs-3.md` §11.10, `SecurityProofsCode/zkp_pqc_exploration.py`,
+suite ZKP-RNL implementations.
+
+**Problems identified in review of §11.10.2:**
+
+1. **Special soundness uses (c − c′)^{-1} without an invertibility argument.**  For
+   sparse ternary challenges in Z_q[x]/(x^n+1) the difference of two challenges is not
+   guaranteed invertible; standard Lyubashevsky-style proofs choose the challenge space
+   specifically so that differences are invertible (or work with relaxed soundness
+   extracting 2s-type witnesses).  §11.10.2's soundness sketch glosses over this.
+2. **Soundness testing is weak:** the only cheat tested is "random z, no s"
+   (200 trials).  Add structured cheats: z forged from a different key s′, replayed
+   transcripts with modified w, boundary-norm z, and challenge-grinding within
+   rejection-sampling limits.
+3. **§11.10.6 open directions** have no TODO tracking: (a) formal Ring-LWR reduction
+   quantifying the rounding-slack term, (b) NTT-accelerated Σ-protocol (prover/verifier
+   currently O(n²) schoolbook), (c) ZKB++ decomposition to cut ZKP-NL proofs from
+   920 KB to ~180 KB, (d) hybrid Ring-LWR + Stern-F credential.
+
+**Fix plan:** address item 1 in the proof text (restate as relaxed special soundness or
+restrict the challenge space and prove difference invertibility); implement item 2 in
+`zkp_pqc_exploration.py` and the suite test files; items 3(a)–(d) prioritized
+afterwards, with 3(b) (NTT) the cheapest concrete win.
+
+Status: **Items 1–2 DONE v1.9.32** — §11.10.2 restated as relaxed special soundness
+(extractor outputs (z−z', c−c') without inversion; norm bounds stated).  Empirical
+confirmation added (`zkp_pqc_exploration.py` §2.6): x^n+1 splits into n linear factors
+over F_65537 (since 2n | q−1), and 3/2000 random challenge pairs at n=32 have nonzero
+non-invertible differences — strict special soundness is genuinely false at these
+parameters.  Structured cheats implemented in `zkp_pqc_exploration.py` §2.4b
+(wrong-key witness, tampered-w, perturbed-z, 64-attempt grinding; 0 cheat passes) and
+in the Python suite test [21] at n=32/256 (wrong-key / w-tamper / z-tamper rejection).
+C/Go test-[21] extension deferred as a cross-language parity follow-up.  Items
+3(a)–(d) remain **OPEN**; 3(b) NTT acceleration is the recommended next step.

--- a/herradura.h
+++ b/herradura.h
@@ -672,6 +672,98 @@ static void hske_nla1_mac_key(const BitArray *seed, const BitArray *base,
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+ * HSKE-NL-AEAD: authenticated encryption with associated data (TODO #95)
+ *
+ * Encrypt-then-MAC over the HSKE-NL-A1 CTR keystream:
+ *   base = K XOR nonce; seed = ba_rnl_kdf_seed(base);
+ *   ct   = pt XOR ks   (hske_nla1_ks_block, truncated to pt_len);
+ *   tag  = HFSCX-256-MAC(mac_key XOR IV,
+ *              DS || nonce || ad_len_be8 || ad || ct_len_be8 || ct)
+ * Key-committing: the tag binds mac_key (hence K and nonce) through the keyed
+ * HFSCX-256-DM.  The DS prefix domain-separates the tag from the .hkx file MAC,
+ * which shares the mac_key schedule.  Decryption is verify-then-decrypt with a
+ * constant-time tag comparison.  Never reuse a (key, nonce) pair.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+#define _AEAD_DS     "HSKE-NL-AEAD-v1"
+#define _AEAD_DS_LEN 15
+
+static void _hske_nl_aead_be64(uint8_t *dst, uint64_t v)
+{
+    int j;
+    for (j = 0; j < 8; j++) dst[j] = (uint8_t)((v >> (56 - 8 * j)) & 0xFF);
+}
+
+static void _hske_nl_aead_tag(const BitArray *mac_key, const BitArray *nonce,
+                              const uint8_t *ad, size_t ad_len,
+                              const uint8_t *ct, size_t ct_len,
+                              uint8_t tag_out[32])
+{
+    uint8_t mac_iv[32];
+    size_t len = _AEAD_DS_LEN + KEYBYTES + 8 + ad_len + 8 + ct_len, off;
+    uint8_t *buf = (uint8_t *)malloc(len);
+    int j;
+    if (!buf) { fprintf(stderr, "hske_nl_aead: out of memory\n"); exit(1); }
+    for (j = 0; j < 32; j++) mac_iv[j] = mac_key->b[j] ^ _HFSCX256_IV[j];
+    memcpy(buf, _AEAD_DS, _AEAD_DS_LEN);
+    off = _AEAD_DS_LEN;
+    memcpy(buf + off, nonce->b, KEYBYTES);          off += KEYBYTES;
+    _hske_nl_aead_be64(buf + off, (uint64_t)ad_len); off += 8;
+    if (ad_len) memcpy(buf + off, ad, ad_len);
+    off += ad_len;
+    _hske_nl_aead_be64(buf + off, (uint64_t)ct_len); off += 8;
+    if (ct_len) memcpy(buf + off, ct, ct_len);
+    hfscx_256(buf, len, mac_iv, tag_out);
+    free(buf);
+}
+
+static void _hske_nl_aead_xor_ks(const BitArray *seed, const BitArray *base,
+                                 const uint8_t *in, size_t len, uint8_t *out)
+{
+    BitArray ks;
+    size_t off, blk, j;
+    uint32_t i = 0;
+    for (off = 0; off < len; off += KEYBYTES, i++) {
+        blk = (len - off < KEYBYTES) ? len - off : KEYBYTES;
+        hske_nla1_ks_block(seed, base, i, &ks);
+        for (j = 0; j < blk; j++) out[off + j] = in[off + j] ^ ks.b[j];
+    }
+}
+
+/* AEAD-encrypt pt_len bytes into ct_out (same length) and tag_out (32 bytes).
+ * Caller supplies a fresh random 256-bit nonce (e.g. via ba_rand). */
+static void hske_nl_aead_encrypt(const BitArray *key, const BitArray *nonce,
+                                 const uint8_t *ad, size_t ad_len,
+                                 const uint8_t *pt, size_t pt_len,
+                                 uint8_t *ct_out, uint8_t tag_out[32])
+{
+    BitArray base, seed, mac_key;
+    ba_xor(&base, key, nonce);
+    ba_rnl_kdf_seed(&seed, &base);
+    _hske_nl_aead_xor_ks(&seed, &base, pt, pt_len, ct_out);
+    hske_nla1_mac_key(&seed, &base, &mac_key);
+    _hske_nl_aead_tag(&mac_key, nonce, ad, ad_len, ct_out, pt_len, tag_out);
+}
+
+/* Verify-then-decrypt.  Returns 1 and writes ct_len bytes to pt_out on
+ * success; returns 0 (pt_out untouched) if the tag does not authenticate. */
+static int hske_nl_aead_decrypt(const BitArray *key, const BitArray *nonce,
+                                const uint8_t *ad, size_t ad_len,
+                                const uint8_t *ct, size_t ct_len,
+                                const uint8_t tag[32], uint8_t *pt_out)
+{
+    BitArray base, seed, mac_key;
+    uint8_t expected[32];
+    ba_xor(&base, key, nonce);
+    ba_rnl_kdf_seed(&seed, &base);
+    hske_nla1_mac_key(&seed, &base, &mac_key);
+    _hske_nl_aead_tag(&mac_key, nonce, ad, ad_len, ct, ct_len, expected);
+    if (!ct_eq32(tag, expected)) return 0;
+    _hske_nl_aead_xor_ks(&seed, &base, ct, ct_len, pt_out);
+    return 1;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
  * HKEX-RNL: Ring-LWR key exchange helpers (n=256, negacyclic Z_q[x]/(x^n+1))
  * ───────────────────────────────────────────────────────────────────────────── */
 

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -19,6 +19,7 @@ package herradura
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/binary"
 	"fmt"
 	"log"
@@ -446,6 +447,76 @@ func HskeNla1KsBlock(seed, base *BitArray, i uint32) *BitArray {
 func HskeNla1MacKey(seed, base *BitArray) *BitArray {
 	seed2 := seed.RotateLeft(64) // ROL(seed, n/4)
 	return NlFscxRevolveV1(seed2, base, 64)
+}
+
+// ---------------------------------------------------------------------------
+// HSKE-NL-AEAD: authenticated encryption with associated data (TODO #95)
+//
+// Encrypt-then-MAC over the HSKE-NL-A1 CTR keystream:
+//   base = K XOR nonce; seed = RnlKdfSeed(base)
+//   ct   = pt XOR ks   (HskeNla1KsBlock, truncated to len(pt))
+//   tag  = HFSCX-256-MAC(mac_key XOR IV,
+//              DS || nonce || ad_len_be8 || ad || ct_len_be8 || ct)
+// Key-committing: the tag binds mac_key (hence K and nonce) through the keyed
+// HFSCX-256-DM.  The DS prefix domain-separates the tag from the .hkx file
+// MAC, which shares the mac_key schedule.  Decryption is verify-then-decrypt
+// with a constant-time tag comparison.  Never reuse a (key, nonce) pair.
+// ---------------------------------------------------------------------------
+
+const hskeNlAeadDS = "HSKE-NL-AEAD-v1"
+
+func hskeNlAeadXorKs(seed, base *BitArray, in []byte) []byte {
+	out := make([]byte, len(in))
+	for off, i := 0, uint32(0); off < len(in); off, i = off+32, i+1 {
+		ks := HskeNla1KsBlock(seed, base, i).Bytes()
+		end := off + 32
+		if end > len(in) {
+			end = len(in)
+		}
+		for j := off; j < end; j++ {
+			out[j] = in[j] ^ ks[j-off]
+		}
+	}
+	return out
+}
+
+func hskeNlAeadTag(macKey, nonce *BitArray, ad, ct []byte) []byte {
+	macIV := macKey.Bytes()
+	for i := range macIV {
+		macIV[i] ^= Hfscx256IV[i]
+	}
+	buf := make([]byte, 0, len(hskeNlAeadDS)+32+8+len(ad)+8+len(ct))
+	buf = append(buf, hskeNlAeadDS...)
+	buf = append(buf, nonce.Bytes()...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(len(ad)))
+	buf = append(buf, ad...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(len(ct)))
+	buf = append(buf, ct...)
+	return Hfscx256(buf, macIV)
+}
+
+// HskeNlAeadEncrypt AEAD-encrypts pt under (key, nonce) with associated data
+// ad.  Returns (ct, tag): ct is len(pt) bytes, tag is 32 bytes.  The caller
+// supplies a fresh random 256-bit nonce (e.g. NewRandBitArray(256)).
+func HskeNlAeadEncrypt(key, nonce *BitArray, ad, pt []byte) ([]byte, []byte) {
+	base := NewBitArray(key.Size(), new(big.Int).Xor(&key.Val, &nonce.Val))
+	seed := RnlKdfSeed(base)
+	ct := hskeNlAeadXorKs(seed, base, pt)
+	tag := hskeNlAeadTag(HskeNla1MacKey(seed, base), nonce, ad, ct)
+	return ct, tag
+}
+
+// HskeNlAeadDecrypt verifies then decrypts.  Returns (pt, true) on success or
+// (nil, false) if the tag does not authenticate (ct, ad) under (key, nonce).
+// The tag comparison is constant-time.
+func HskeNlAeadDecrypt(key, nonce *BitArray, ad, ct, tag []byte) ([]byte, bool) {
+	base := NewBitArray(key.Size(), new(big.Int).Xor(&key.Val, &nonce.Val))
+	seed := RnlKdfSeed(base)
+	expected := hskeNlAeadTag(HskeNla1MacKey(seed, base), nonce, ad, ct)
+	if subtle.ConstantTimeCompare(tag, expected) != 1 {
+		return nil, false
+	}
+	return hskeNlAeadXorKs(seed, base, ct), true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements TODO #95 option 1 — a general-purpose AEAD for the suite — plus the new core-primitive-review TODO catalogue (#95–#99).

- **Suite libraries** (`Herradura cryptographic suite.py`, `herradura.h`, `herradura/herradura.go`): `hske_nl_aead_encrypt` / `hske_nl_aead_decrypt` — encrypt-then-MAC over the HSKE-NL-A1 CTR keystream with associated-data support. Tag = keyed HFSCX-256-DM over `HSKE-NL-AEAD-v1` DS prefix ‖ nonce ‖ length-framed AD ‖ length-framed ciphertext. Key-committing (a property AES-GCM lacks); verify-then-decrypt with constant-time tag comparison. All three implementations are byte-for-byte interoperable (shared KAT).
- **CLI** (Python/C/Go): `enc --algo hske-nla1 --aead [--ad STR]`, new ciphertext PEM format tag 2 `SEQ(2, nonce, E, tag, nbits)`; `dec` auto-detects and fails closed on tag mismatch. `encfile`/`decfile` were already always-AEAD via the `.hkx` MAC.
- **Tests**: new security test [28] in C/Go/Python (cross-language KAT, round-trip over irregular lengths, ciphertext/tag/AD/nonce/key tamper rejection); benchmarks renumbered [29]–[40]; new `CliTest/test_aead.sh` (9 cross-CLI interop pairs + rejection checks).
- **Docs**: CHANGELOG v1.9.33, SecurityProofs-2.md §11.9.6 AEAD note (option 2 — NL-FSCX v2 sponge AEAD — recorded as open research gated on #99), TODO #95 status, CLAUDE.md test numbering.

## Test plan

- [x] Suite self-tests: Python suite AEAD demo passes
- [x] Test [28] PASS in C, Go, Python (KAT + roundtrip + tamper rejection); only the by-design [4] FAILs
- [x] `CliTest/test_aead.sh`: 19/19 PASS (all 9 enc/dec pairs, wrong-AD, wrong-key)
- [x] Regression: `test_encrypt.sh`, `test_encfile.sh`, `test_c_interop.sh`, `test_go_interop.sh` all PASS
- [x] `build_c.sh` / `build_go.sh` clean; `go vet ./herradura` clean
- [x] KaTeX pipeline validator on SecurityProofs-2.md: 873 OK, 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)