### PR TITLE
HPKS-Stern-F cross-language CLI interop fix — v1.9.36 (TODO #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.36] - 2026-06-13
+
+### Bug fix — HPKS-Stern-F CLI cross-language sign/verify interop (TODO #100)
+
+Two bugs prevented Python, C, and Go CLI implementations from verifying each other's HPKS-Stern-F signatures:
+
+1. **Python challenge derivation (`Herradura cryptographic suite.py`)** — `hpks_stern_f_sign`, `hpks_stern_f_verify`, `stern_ring_sign`, and `stern_ring_verify` used `ch_st.uint % 3` (full 256-bit integer mod 3) to extract each Fiat-Shamir challenge from the NL-FSCX v1 chain state. C and Go extract the low 32 bits of the state first (`uint32(state) % 3`). Fixed by changing to `(ch_st.uint & 0xFFFFFFFF) % 3`, matching C's `((uint32_t)ch_st.b[KEYBYTES-4..KEYBYTES-1]) % 3` and Go's `uint32(chSt.Val.Uint64()) % 3`.
+
+2. **C syndrome-to-BitArray byte ordering (`herradura.h`, `HerraduraCli/herradura_cli.c`)** — `syndr_to_ba` stored syndrome byte `k` at `out->b[KEYBYTES/2 + k]`, putting syndrome bit `i` at integer bit `(15 - i/8)*8 + i%8` (reversed within each 8-bit group). Python and Go store syndrome bit `i` at integer bit `i` (big.Int / Python int convention). Fixed by changing `syndr_to_ba` to store `syndr[k]` at `out->b[KEYBYTES - 1 - k]`, so that syndrome bit `i` lands at integer bit `i`. The public key serialization in `herradura_cli.c` (pkey `--pubout`) and deserialization (verify) were updated to apply the same byte-reversal, so C-generated public keys are now wire-compatible with Python and Go.
+
+- **New interop test** — `CliTest/test_stern_interop.sh` covers all 9 sign→verify combinations (Python→Python, Python→C, Python→Go, C→Python, C→C, C→Go, Go→Python, Go→C, Go→Go) and verifies all pass.
+- **Wire-format breaking**: HPKS-Stern-F signatures generated with v1.9.35 and earlier are not verifiable with v1.9.36+ across language boundaries (Python→C/Go or C/Go→Python would have always failed; within a single language boundary no new breakage was introduced for self-tests).
+
+---
+
 ## [1.9.35] - 2026-06-12
 
 ### Security — HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88)

--- a/CliTest/test_stern_interop.sh
+++ b/CliTest/test_stern_interop.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# test_stern_interop.sh — 6-direction HPKS-Stern-F cross-language sign/verify matrix
+# Tests all combinations: Python→Python, Python→C, Python→Go,
+#                          C→C, C→Python, C→Go,
+#                          Go→Go, Go→Python, Go→C
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+PY="$REPO/HerraduraCli/herradura.py"
+C_CLI="$REPO/HerraduraCli/herradura_cli"
+GO_CLI="$REPO/HerraduraCli/herradura_cli_go"
+SUITE="$REPO/Herradura cryptographic suite.py"
+
+pass=0; fail=0
+PASS() { echo "PASS $*"; pass=$((pass+1)); }
+FAIL() { echo "FAIL $*"; fail=$((fail+1)); }
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "hello stern" > "$tmpdir/msg.txt"
+
+# --------------------------------------------------------------------------
+# Generate one key per implementation
+# --------------------------------------------------------------------------
+python3 "$PY" genpkey --algo hpks-stern --out "$tmpdir/py_priv.pem" 2>/dev/null
+python3 "$PY" pkey    --in "$tmpdir/py_priv.pem" --pubout --out "$tmpdir/py_pub.pem" 2>/dev/null
+
+"$C_CLI" genpkey --algo hpks-stern --out "$tmpdir/c_priv.pem"
+"$C_CLI" pkey    --algo hpks-stern --in "$tmpdir/c_priv.pem" --pubout --out "$tmpdir/c_pub.pem"
+
+"$GO_CLI" genpkey --algo hpks-stern --out "$tmpdir/go_priv.pem" 2>/dev/null
+"$GO_CLI" pkey    -in "$tmpdir/go_priv.pem" -pubout -out "$tmpdir/go_pub.pem"
+
+# --------------------------------------------------------------------------
+# Sign with each implementation
+# --------------------------------------------------------------------------
+python3 "$PY" sign  --algo hpks-stern --key "$tmpdir/py_priv.pem" \
+    --in "$tmpdir/msg.txt" --out "$tmpdir/sig_py.pem" 2>/dev/null
+
+"$C_CLI" sign --algo hpks-stern --key "$tmpdir/c_priv.pem" \
+    --in "$tmpdir/msg.txt" --out "$tmpdir/sig_c.pem"
+
+"$GO_CLI" sign --algo hpks-stern --key "$tmpdir/go_priv.pem" \
+    --in "$tmpdir/msg.txt" --out "$tmpdir/sig_go.pem" 2>/dev/null
+
+# --------------------------------------------------------------------------
+# Verify: all 9 combinations (signer → verifier)
+# --------------------------------------------------------------------------
+verify_py()  { python3 "$PY" verify --algo hpks-stern --pubkey "$1" --in "$tmpdir/msg.txt" --sig "$2" 2>/dev/null | grep -q "Signature OK"; }
+verify_c()   { "$C_CLI"   verify --algo hpks-stern --pubkey "$1" --in "$tmpdir/msg.txt" --sig "$2" | grep -q "Signature OK"; }
+verify_go()  { "$GO_CLI"  verify --algo hpks-stern --pubkey "$1" --in "$tmpdir/msg.txt" --sig "$2" 2>/dev/null | grep -q "Signature OK"; }
+
+for signer in py c go; do
+    pub="$tmpdir/${signer}_pub.pem"
+    sig="$tmpdir/sig_${signer}.pem"
+    for verifier in py c go; do
+        label="${signer}→${verifier} hpks-stern"
+        case "$verifier" in
+            py) verify_py "$pub" "$sig" && PASS "$label" || FAIL "$label" ;;
+            c)  verify_c  "$pub" "$sig" && PASS "$label" || FAIL "$label" ;;
+            go) verify_go "$pub" "$sig" && PASS "$label" || FAIL "$label" ;;
+        esac
+    done
+done
+
+echo ""
+echo "Results: $pass PASS / $fail FAIL"
+[ "$fail" -eq 0 ]

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -994,7 +994,7 @@ def hpks_stern_f_sign(msg: 'BitArray', e_int: int, seed: 'BitArray',
     challenges = []
     for i in range(rounds):
         ch_st = nl_fscx_v1(ch_st, BitArray(n, i))
-        challenges.append(ch_st.uint % 3)
+        challenges.append((ch_st.uint & 0xFFFFFFFF) % 3)
 
     responses = []
     for i, (r_int, y_int, pi_seed, _Hr, sr, sy) in enumerate(round_data):
@@ -1020,7 +1020,7 @@ def hpks_stern_f_verify(msg: 'BitArray', sig, seed: 'BitArray',
     ch_st = _stern_hash(n, *flat)
     for i, b in enumerate(challenges):
         ch_st = nl_fscx_v1(ch_st, BitArray(n, i))
-        if ch_st.uint % 3 != b:
+        if (ch_st.uint & 0xFFFFFFFF) % 3 != b:
             return False
 
     # Build H once: only needed for b ∈ {1, 2} branches but the seed is fixed.
@@ -1188,7 +1188,7 @@ def hpks_stern_ring_sign(msg: 'BitArray', e_int: int, j: int,
     # Step 4 — assign real signer's per-round challenge via challenge splitting
     for r in range(rounds):
         ch_st   = nl_fscx_v1(ch_st, BitArray(n, r))
-        joint_b = ch_st.uint % 3
+        joint_b = (ch_st.uint & 0xFFFFFFFF) % 3
         sim_sum = sum(all_challenges[i][r] for i in range(k) if i != j) % 3
         all_challenges[j][r] = (joint_b - sim_sum) % 3
 
@@ -1226,7 +1226,7 @@ def hpks_stern_ring_verify(msg: 'BitArray', sig, ring_keys: list,
     # Check challenge consistency: sum_i b_ir ≡ joint_b_r (mod 3) for all r
     for r in range(rounds):
         ch_st   = nl_fscx_v1(ch_st, BitArray(n, r))
-        joint_b = ch_st.uint % 3
+        joint_b = (ch_st.uint & 0xFFFFFFFF) % 3
         if sum(all_challenges[i][r] for i in range(k)) % 3 != joint_b:
             return False
 

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -559,10 +559,13 @@ static void cmd_pkey(int argc, char **argv)
             stern_syndrome(syndr, &seed, &e);
 
             /* Syndrome is SDF_SYNBYTES (16) bytes; encode as 32-byte DER INTEGER
-             * matching Python: der_int(syn_int, nbytes) where nbytes=n//8=32. */
-            uint8_t syn32[KEYBYTES];
+             * where syndrome bit i (= row i parity) occupies integer bit i.
+             * syndr[k] holds rows k*8..k*8+7 as bits 0-7, so syndr[k] goes to
+             * byte KEYBYTES-1-k (integer bits k*8..k*8+7) — matching Python/Go. */
+            uint8_t syn32[KEYBYTES]; int _sk;
             memset(syn32, 0, KEYBYTES);
-            memcpy(syn32 + KEYBYTES - SDF_SYNBYTES, syndr, SDF_SYNBYTES);
+            for (_sk = 0; _sk < SDF_SYNBYTES; _sk++)
+                syn32[KEYBYTES - 1 - _sk] = syndr[_sk];
 
             uint8_t isyn[DER_INT_LEN(KEYBYTES)], is[DER_INT_LEN(KEYBYTES)], in[8];
             size_t lsyn, ls, ln;
@@ -1457,12 +1460,15 @@ static void cmd_verify(int argc, char **argv)
     } else if (strcmp(algo, "hpks-stern") == 0) {
         if (pub_k.n_items < 2) die("verify: malformed Stern public key");
 
-        /* Extract syndr (16 bytes) from syn32 (32 bytes, right-aligned). */
-        uint8_t syn32[KEYBYTES], syndr[SDF_SYNBYTES];
+        /* Extract syndr (16 bytes) from syn32 (32 bytes, right-aligned).
+         * The public key stores syndr[k] at byte KEYBYTES-1-k so that syndrome
+         * bit i occupies integer bit i (matching Python/Go convention). */
+        uint8_t syn32[KEYBYTES], syndr[SDF_SYNBYTES]; int _sk;
         memset(syn32, 0, KEYBYTES);
         { size_t cl = pub_k.vlens[0] < KEYBYTES ? pub_k.vlens[0] : KEYBYTES;
           memcpy(syn32 + KEYBYTES - cl, pub_k.vals[0], cl); }
-        memcpy(syndr, syn32 + KEYBYTES - SDF_SYNBYTES, SDF_SYNBYTES);
+        for (_sk = 0; _sk < SDF_SYNBYTES; _sk++)
+            syndr[_sk] = syn32[KEYBYTES - 1 - _sk];
 
         BitArray seed_ba;
         ba_from_ra(&seed_ba, pub_k.vals[1], pub_k.vlens[1]);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.35)
+# Herradura Cryptographic Suite (v1.9.36)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6062,4 +6062,4 @@ suggests at least two distinct bugs.
 and test_go_interop.sh cover classical/RNL algorithms only), which is how this went
 unnoticed.  Fix should add a `test_stern_interop.sh` with the 6-direction matrix.
 
-Status: **PENDING**
+Status: **DONE v1.9.36**

--- a/herradura.h
+++ b/herradura.h
@@ -1224,8 +1224,12 @@ static void stern_syndrome(uint8_t *syndr, const BitArray *seed,
 /* Pack syndrome into lower half of a BitArray (upper bytes = 0). */
 static void syndr_to_ba(BitArray *out, const uint8_t *syndr)
 {
+    int k;
     memset(out->b, 0, KEYBYTES);
-    memcpy(out->b + KEYBYTES / 2, syndr, SDF_SYNBYTES);
+    /* Store syndr[k] (rows k*8..k*8+7) at byte KEYBYTES-1-k so that syndrome
+     * bit i lands at integer bit i, matching Python/Go's big.Int convention. */
+    for (k = 0; k < SDF_SYNBYTES; k++)
+        out->b[KEYBYTES - 1 - k] = syndr[k];
 }
 
 /* Fisher-Yates shuffle [0..N-1] driven by NL-FSCX v1 PRNG.


### PR DESCRIPTION
## Summary

- **Bug fix (Python):** Challenge derivation in `hpks_stern_f_sign/verify` and `stern_ring_sign/verify` used `ch_st.uint % 3` (full 256-bit integer mod 3) instead of `(ch_st.uint & 0xFFFFFFFF) % 3` (low 32 bits mod 3), diverging from the C/Go implementations that operate on 32-bit words.
- **Bug fix (C `herradura.h`):** `syndr_to_ba` used `memcpy` to place the 16-byte syndrome at bytes `[16..31]` of the 256-bit big-endian `BitArray`, incorrectly mapping syndrome bit $i$ to integer bit $120+i$ instead of bit $i$. Fixed with a byte-reversal loop so bit $i$ lands at integer bit $i$, matching Python/Go's `big.Int` convention.
- **Bug fix (C CLI):** `herradura_cli.c` `pkey --pubout` and `cmd_verify` syndrome serialization/deserialization had the same byte-order error as `syndr_to_ba`. Fixed with matching reversal loops.
- **New test:** `CliTest/test_stern_interop.sh` — covers all 9 sign→verify combinations across Python, C, and Go CLIs (previously untested cross-language path). All 9/9 pass.

## Test plan

- [x] `bash CliTest/test_stern_interop.sh` — 9/9 PASS
- [x] `./CryptosuiteTests/Herradura_tests_c` — all tests pass (C self-tests unaffected)
- [x] `cd CryptosuiteTests && go run Herradura_tests.go` — all tests pass
- [x] `python3 CryptosuiteTests/Herradura_tests.py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)