### PR TITLE
HKEX-RNL m_blind substitution-attack mitigation — v1.9.37 (TODO #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.37] - 2026-06-13
+
+### Security — HKEX-RNL m_blind substitution-attack mitigation (TODO #89)
+
+A MITM or malicious peer could replace `a_rand` in Alice's public PEM with a chosen
+value (e.g., `a_rand = -m(x)`, forcing `m_blind = 0`), degrading the Ring-LWR hardness
+guarantee or leaking the shared key directly.
+
+- **`herradura.h`**: added `rnl_validate_m_blind(poly, n)` — rejects a peer-supplied
+  blinding polynomial if it has fewer than `n/4` non-zero coefficients or a coefficient
+  range smaller than `q/4`. A legitimately uniform polynomial over Z_65537 passes both
+  checks with overwhelming probability.
+- **`herradura/herradura.go`**: added `RnlValidateMBlind(poly []int, q int) bool` with
+  the same two checks.
+- **`HerraduraCli/herradura_cli.c`**: Bob (step 1) calls `rnl_validate_m_blind` after
+  unpacking `m_A`; exits with an error on failure.
+- **`HerraduraCli/herradura.py`**: added `_rnl_validate_m_blind`; Bob (step 1) calls it
+  and exits with a descriptive error on failure.
+- **`HerraduraCli/herradura_cli.go`**: Bob (step 1) calls `RnlValidateMBlind`; exits
+  with an error on failure.
+- **`SecurityProofs-2.md` §11.4.3**: added "Active-adversary caveat" paragraph
+  documenting the substitution attack, the v1.9.37 mitigation, and the remaining gap
+  (non-contributory blinding — full fix deferred to a future protocol revision).
+- **No wire-format change**: validation is receiver-side only; all existing keys and
+  PEM files remain compatible.
+
+---
+
 ## [1.9.36] - 2026-06-13
 
 ### Bug fix — HPKS-Stern-F CLI cross-language sign/verify interop (TODO #100)

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -199,6 +199,19 @@ def _rnl_derive_C(m_poly, s_poly, n):
     return _suite_mod._rnl_round(ms, RNLQ, RNLP)
 
 
+def _rnl_validate_m_blind(poly, q=RNLQ):
+    """Return True if poly looks like a uniform-random element of Z_q^n.
+    Rejects sparse polys (nz < n/4) and clustered polys (range < q/4)."""
+    n = len(poly)
+    nz = sum(1 for c in poly if c != 0)
+    if nz < n // 4:
+        return False
+    span = max(poly) - min(poly)
+    if span < q // 4:
+        return False
+    return True
+
+
 def _encode_stern_privkey(e_int, seed, n, algo):
     nbytes = n // 8
     der = der_seq(der_int(e_int, nbytes), der_int(seed.uint, nbytes), der_int(n))
@@ -640,6 +653,8 @@ def cmd_kex(args):
             C_A, m_A, n_their = _decode_rnl_pubkey(their_ints)
             if n != n_their:
                 sys.exit(f"Ring size mismatch: ours n={n}, theirs n={n_their}")
+            if not _rnl_validate_m_blind(m_A):
+                sys.exit("kex hkex-rnl: peer m_blind failed entropy check — possible substitution attack")
             C_B    = _rnl_derive_C(m_A, s_B, n)
             K_B, hint = _rnl_agree(s_B, C_A, RNLQ, RNLP, RNLPP, n, n)
             K_B_int = _apply_kdf(K_B.uint, n)

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -649,6 +649,9 @@ static void cmd_kex(int argc, char **argv)
             poly_unpack(m_A, their.vals[1], their.vlens[1], 4);
             pem_key_free(&our); pem_key_free(&their);
 
+            if (!rnl_validate_m_blind(m_A, RNL_N))
+                die("kex hkex-rnl: peer m_blind failed entropy check — possible substitution attack");
+
             /* Derive C_B = round_p(m_A * s_B) */
             rnl_poly_mul(ms, m_A, s_B);
             rnl_round(C_B, ms, RNL_Q, RNL_P);

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -670,6 +670,11 @@ func cmdKex(args []string) {
 			C_A := unpackPolyRaw(theirInts[0], n, 2)
 			m_A := unpackPolyRaw(theirInts[1], n, 4)
 
+			if !RnlValidateMBlind(m_A, RnlQ) {
+				fmt.Fprintln(os.Stderr, "kex hkex-rnl: peer m_blind failed entropy check — possible substitution attack")
+				os.Exit(1)
+			}
+
 			// Derive C_B = round_p(m_A * s_B)
 			ms  := RnlPolyMul(m_A, s_B, RnlQ, n)
 			C_B := RnlRound(ms, RnlQ, RnlP)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.36)
+# Herradura Cryptographic Suite (v1.9.37)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofs-2.md
+++ b/SecurityProofs-2.md
@@ -230,6 +230,28 @@ uniformly random in $\mathcal{R}_q$.  The key-exchange problem then reduces to t
 Ring-LWE/LWR instance over a power-of-two cyclotomic ring — the same structure as Kyber.
 This is believed post-quantum hard; no polynomial-time quantum algorithm is known.
 
+**Active-adversary caveat (TODO #89).** The security argument above assumes $m_\text{blind}$
+arrives unmodified.  A MITM or malicious peer can substitute $a_\text{rand}$ with a chosen
+value (e.g., $a_\text{rand} = -m(x)$, forcing $m_\text{blind} = 0$), steering the
+protocol toward the unblinded case where the sparse fixed structure of $m(x)$ enables
+lattice-reduction leverage.  In the extreme case $m_\text{blind} = 0$, both public keys
+$C_A$ and $C_B$ become rounding of the zero polynomial, leaking the shared key immediately.
+
+**Mitigation (v1.9.37).** The receiver (Bob, step 1) validates the incoming $m_\text{blind}$
+before use via two heuristic checks: (1) at least $n/4$ non-zero coefficients (a truly
+random polynomial over $\mathbb{Z}_{65537}$ has $\approx n$ non-zero coefficients); and
+(2) coefficient range $\max - \min \geq q/4$ (a clustered or constant polynomial has a
+small range).  These checks catch zero-polynomial and sparse-polynomial attacks while
+accepting any legitimate uniformly random blinding.  The check is implemented in
+`rnl_validate_m_blind` (C/`herradura.h`), `_rnl_validate_m_blind` (Python CLI), and
+`RnlValidateMBlind` (Go package); all three CLIs reject on failure with an explicit error.
+
+**Remaining gap.** The blinding is still non-contributory: the uniformity of $m_\text{blind}$
+rests entirely on Alice's RNG.  A backdoored or weak RNG on Alice's side silently weakens
+both parties even if the receiver-side validation passes.  The full fix — making $a_\text{rand}$
+a function of nonces from both parties ($a_\text{rand} = \text{XOF}(n_A \| n_B)$) — requires
+a protocol change and is tracked as the open portion of TODO #89.
+
 **Security estimate (2026 landscape review, TODO #71).** For the deployed parameters
 $(n=256, q=65537, p=4096, \eta=1)$, BKZ-based lattice reduction (the best known classical
 attack via the Ring-LWR-to-Ring-LWE reduction) is estimated at approximately **105–115

--- a/TODO.md
+++ b/TODO.md
@@ -5684,7 +5684,12 @@ Two gaps:
   documented caveat in §11.4.3 that the uniformity assumption is trust-on-first-use.
 - Update SecurityProofs-2.md §11.4.2/§11.4.3 with the active-adversary model.
 
-Status: **PENDING**
+Status: **DONE v1.9.37** — Interim non-breaking fix: `rnl_validate_m_blind` added to
+`herradura.h` (C) and `RnlValidateMBlind` to `herradura/herradura.go`; both check
+non-zero coefficient count ≥ n/4 and coefficient range ≥ q/4; called in C, Python, and
+Go CLIs at Bob step 1 before `m_blind` is used for keygen.  SecurityProofs-2.md §11.4.3
+updated with active-adversary model, the substitution attack, and the remaining gap (non-
+contributory blinding).  Full contributory fix (XOF(n_A‖n_B) blinding) remains open.
 
 ---
 

--- a/herradura.h
+++ b/herradura.h
@@ -1070,6 +1070,26 @@ static void rnl_bits_to_ba(BitArray *out, const int32_t *bits_poly)
     }
 }
 
+/* Validate that m_blind plausibly came from a uniform-random draw over Z_q^n.
+ * Returns 1 if valid, 0 if the polynomial looks attacker-substituted.
+ * Two checks (either failing → reject):
+ *   (1) non-zero coefficient count >= n/4  — catches sparse/zero-polynomial attacks
+ *   (2) coefficient range (max-min) >= q/4 — catches clustered/small-value attacks
+ * A truly random poly over Z_65537 has ~n nonzero coefficients and range ~q. */
+static int rnl_validate_m_blind(const rnl_poly_t poly, int n)
+{
+    int i, nz = 0;
+    int32_t mn = poly[0], mx = poly[0];
+    for (i = 0; i < n; i++) {
+        if (poly[i] != 0) nz++;
+        if (poly[i] < mn) mn = poly[i];
+        if (poly[i] > mx) mx = poly[i];
+    }
+    if (nz < n / 4) return 0;
+    if (mx - mn < (int32_t)(RNL_Q / 4)) return 0;
+    return 1;
+}
+
 /* keygen: s=CBD(eta=1) private, C=round_p(m_blind * s) */
 static void rnl_keygen(int32_t s_out[RNL_N], int32_t c_out[RNL_N],
                        const rnl_poly_t m_blind, FILE *urnd)

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -763,6 +763,27 @@ func RnlMPoly(n int) []int {
 	return p
 }
 
+// RnlValidateMBlind returns true if poly looks like a uniform-random element of Z_q^n.
+// Rejects sparse polys (non-zero count < n/4) and clustered polys (range < q/4).
+// Call this before using a peer-supplied m_blind to detect substitution attacks.
+func RnlValidateMBlind(poly []int, q int) bool {
+	n := len(poly)
+	nz := 0
+	mn, mx := poly[0], poly[0]
+	for _, c := range poly {
+		if c != 0 {
+			nz++
+		}
+		if c < mn {
+			mn = c
+		}
+		if c > mx {
+			mx = c
+		}
+	}
+	return nz >= n/4 && mx-mn >= q/4
+}
+
 // RnlRandPoly samples n uniform coefficients from Z_q using rejection sampling.
 func RnlRandPoly(n, q int) []int {
 	p := make([]int, n)


### PR DESCRIPTION
## Summary

- Adds receiver-side validation of the peer-supplied `m_blind` polynomial in HKEX-RNL key exchange (Bob step 1) across all three CLIs and the Go package
- A MITM could previously substitute a crafted `m_blind` (e.g. the zero polynomial, forcing `m_blind = 0`) to degrade Ring-LWR hardness or leak the shared key outright
- Validation rejects polynomials with < n/4 non-zero coefficients or coefficient range < q/4 — catching zero-polynomial and sparse-polynomial attacks while accepting any legitimately uniform draw
- `SecurityProofs-2.md §11.4.3` updated with the active-adversary model, the mitigation, and the remaining gap (non-contributory blinding)
- No wire-format change; all existing keys and PEM files remain compatible

## Test plan

- [x] `bash CliTest/test_vectors.sh` — HKEX-RNL key agreement passes (3/3)
- [x] `bash CliTest/test_c_interop.sh` — C ↔ Python interop passes (4/4)
- [x] `bash CliTest/test_go_interop.sh` — Go ↔ Python ↔ C interop passes (10/10)
- [x] `bash CliTest/test_aead.sh` — AEAD interop passes (19/19)
- [x] Python smoke test: zero poly and m_base rejected, random poly accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)