### PR TITLE
HPKS-WOTS-F / HPKS-XMSS-F ported to C and Go — v1.9.42 (TODO #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.42] - 2026-06-14
+
+### Consistency — HPKS-WOTS-F / HPKS-XMSS-F ported to C and Go (TODO #102)
+
+Ports the HPKS-WOTS-F / HPKS-XMSS-F hash-based signature scheme from the Python suite
+(added in TODO #97, v1.9.39) to C (`herradura.h`), Go (`herradura/herradura.go`), the
+C and Go suite demo files, and all three C/Go/Python test files.  Security test [30] is
+added across all targets; performance benchmarks shift from [30]–[41] to [31]–[42].
+
+- **`herradura.h`**: adds `WOTS_W/L/L1/L2` constants, `_wots_h_ba`, `_wots_chain_ba`,
+  `_wots_leaf_seed`, `_wots_msg_to_digits`, `hpks_wots_keygen`, `hpks_wots_sign`,
+  `hpks_wots_recover_pk`, `hpks_wots_verify`, `_wots_pk_bytes`, `HpksXmssSig` struct,
+  `hpks_xmss_keygen`, `hpks_xmss_sign`, `hpks_xmss_sig_free`, `hpks_xmss_verify`.
+  Chain step: `h(x) = nl_fscx_revolve_v1(ROL(x, n/8), x, n/4)`, w=16, ℓ=67 chains.
+- **`herradura/herradura.go`**: adds `HpksWotsKeygen`, `HpksWotsSign`, `HpksWotsRecoverPk`,
+  `HpksWotsVerify`, `HpksXmssKeypair`, `HpksXmssKeygen`, `HpksXmssSig`,
+  `HpksXmssSign`, `HpksXmssVerify`.
+- **`Herradura cryptographic suite.c`**: adds HPKS-XMSS-F demo block (h=3, 2 leaves,
+  tamper + OTS-reuse rejection).
+- **`Herradura cryptographic suite.go`**: adds matching demo block; adds `crypto/rand` import.
+- **`CryptosuiteTests/Herradura_tests.c`**: adds `test_wots_xmss()` → security test [30]
+  (3 random seeds × 8-leaf tree × sign/tamper/reuse checks); benchmarks renumbered [31]–[42].
+- **`CryptosuiteTests/Herradura_tests.go`**: adds `testWotsXmss()` → security test [30];
+  benchmarks renumbered [31]–[42].
+- **`CryptosuiteTests/Herradura_tests.py`**: adds self-contained WOTS/XMSS helpers and
+  `test_wots_xmss()` → security test [30]; benchmarks renumbered [31]–[42].
+
+Assembly and Arduino targets are out of scope (WOTS chain length too large for 32-bit targets).
+
+---
+
 ## [1.9.41] - 2026-06-14
 
 ### Consistency — FPE (78.A), Tweakable cipher (78.B), Accumulator (78.J) ported to ARM and NASM (TODO #104)

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,7 +4,8 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.35
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.42
+    v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
             benchmarks renumbered [30]–[41].
@@ -83,22 +84,23 @@
       [27] Ratchet (78.C) forward secrecy & key uniqueness  [NEW].
       [28] HSKE-NL-AEAD (TODO #95) round-trip, tamper rejection, cross-language KAT  [NEW].
       [29] HDRBG (TODO #96) KAT, determinism, reseed separation, block limit  [NEW].
+      [30] HPKS-WOTS-F / HPKS-XMSS-F sign+verify (h=3, 2 leaves, tamper/reuse rejection)  [PQC].
       C-only (unlabeled): F_stern(K,·) range compression at n=32 (HyperLogLog, TODO #42).
 
-    Performance benchmarks [30]–[41] (unified with Go and Python):
-      [30] FSCX throughput (256-bit).
-      [31] HKEX-GF gf_pow throughput (32-bit).
-      [32] HKEX-GF full handshake (32-bit).
-      [33] HSKE round-trip (256-bit).
-      [34] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
-      [35] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
-      [35b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
-      [36] HSKE-NL-A1 counter-mode throughput (32-bit).
-      [37] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
-      [38] HKEX-RNL full handshake throughput (n=32).
-      [39] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
-      [40] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
-      [41] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
+    Performance benchmarks [31]–[42] (unified with Go and Python):
+      [31] FSCX throughput (256-bit).
+      [32] HKEX-GF gf_pow throughput (32-bit).
+      [33] HKEX-GF full handshake (32-bit).
+      [34] HSKE round-trip (256-bit).
+      [35] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
+      [36] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
+      [36b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
+      [37] HSKE-NL-A1 counter-mode throughput (32-bit).
+      [38] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
+      [39] HKEX-RNL full handshake throughput (n=32).
+      [40] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
+      [41] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
+      [42] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -3530,7 +3532,7 @@ static void bench_hpks_stern_f(void)
     long long ops;
     double secs;
     int i;
-    printf("[39] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
+    printf("[40] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
     /* N=32 */
     { static SternSig32T bsig32;
       uint32_t seed32 = stern32_rand_seed(), e32 = stern32_rand_error(), msg32;
@@ -3621,7 +3623,7 @@ static void bench_zkp_rnl(void)
     int32_t s[256], C[256];
     int32_t w[256], c_poly[256], z[256];
     int i;
-    printf("[40] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
+    printf("[41] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
     rnl_m_poly_n(m_base, n);
     rnl_rand_poly_n(a_rand, n);
     rnl_poly_add_n(m_blind, m_base, a_rand, n);
@@ -3659,7 +3661,7 @@ static void bench_zkp_nl(void)
     uint64_t A, B, y;
     ZkpNlRound *proof;
     int i;
-    printf("[41] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
+    printf("[42] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
            n, rounds);
     zkp_nl_keygen(n, urnd_fp, &A, &B, &y);
     /* warm-up */
@@ -4120,17 +4122,61 @@ static void test_hdrbg(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [30]-[41]                                    */
+/* Security Test [30]: HPKS-WOTS-F / HPKS-XMSS-F                     */
 /* ------------------------------------------------------------------ */
 
-/* [30] FSCX throughput (64/128/256-bit) */
+static void test_wots_xmss(void)
+{
+    static const int xmss_h = 3;  /* 8 leaves; fast for tests */
+    int N = TEST_ROUNDS(3), i, ok_sign = 0, ok_tamper = 0, ok_reuse = 0;
+    struct timespec t0;
+    printf("[30] HPKS-WOTS-F / HPKS-XMSS-F sign+verify (h=%d)  [PQC]\n", xmss_h);
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
+        uint8_t seed[KEYBYTES];
+        if (fread(seed, 1, KEYBYTES, urnd_fp) != KEYBYTES) break;
+        uint8_t root[KEYBYTES];
+        uint8_t *leaves; size_t num_leaves;
+        hpks_xmss_keygen(root, &leaves, &num_leaves, seed, xmss_h);
+
+        const uint8_t msg[]  = "HPKS-XMSS-F security test";
+        const uint8_t bad[]  = "tampered message";
+        const uint8_t diff[] = "different message";
+        HpksXmssSig sig0, sig1;
+        hpks_xmss_sign(&sig0, msg, sizeof(msg)-1, seed, leaves, num_leaves, 0);
+        hpks_xmss_sign(&sig1, msg, sizeof(msg)-1, seed, leaves, num_leaves, 1);
+
+        if (hpks_xmss_verify(msg,  sizeof(msg)-1,  &sig0, root) &&
+            hpks_xmss_verify(msg,  sizeof(msg)-1,  &sig1, root))
+            ok_sign++;
+        if (!hpks_xmss_verify(bad,  sizeof(bad)-1,  &sig0, root))
+            ok_tamper++;
+        if (!hpks_xmss_verify(diff, sizeof(diff)-1, &sig0, root))
+            ok_reuse++;
+
+        hpks_xmss_sig_free(&sig0);
+        hpks_xmss_sig_free(&sig1);
+        free(leaves);
+        if (time_exceeded(&t0)) { N = i + 1; break; }
+    }
+    printf("    sign_ok=%d/%d  tamper_reject=%d/%d  reuse_reject=%d/%d  [%s]\n",
+           ok_sign, N, ok_tamper, N, ok_reuse, N,
+           (ok_sign == N && ok_tamper == N && ok_reuse == N) ? "PASS" : "FAIL");
+    putchar('\n');
+}
+
+/* ------------------------------------------------------------------ */
+/* Performance benchmarks [31]-[42]                                    */
+/* ------------------------------------------------------------------ */
+
+/* [31] FSCX throughput (64/128/256-bit) */
 static void bench_fscx_throughput(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[30] FSCX throughput  [CLASSICAL]\n");
+    printf("[31] FSCX throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), tmp;
       for (i = 0; i < 10; i++) { tmp = fscx32(a, b); a = tmp; }
@@ -4174,7 +4220,7 @@ static void bench_gf_pow_throughput(void)
     long long ops;
     double secs;
     int i;
-    printf("[31] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
+    printf("[32] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t base = rand32() | 1, exp = rand32() | 1, tmp;
       for (i = 0; i < 5; i++) { tmp = gf_pow_32(base, exp); base = tmp | 1; }
@@ -4219,7 +4265,7 @@ static void bench_hkex_gf_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[32] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
+    printf("[33] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, b = rand32()|1, C, C2, skA, skB;
       for (i = 0; i < 5; i++) {
@@ -4285,7 +4331,7 @@ static void bench_hske_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[33] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
+    printf("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t pt, key, enc, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4352,7 +4398,7 @@ static void bench_hpke_el_gamal_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[34] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
+    printf("[35] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, r = rand32()|1, pt = rand32();
       uint32_t C = gf_pow_32(GF_GEN32, a), R, ek, E, dk;
@@ -4437,7 +4483,7 @@ static void bench_nl_fscx_revolve(void)
     long long ops;
     double secs;
     int i;
-    printf("[35] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
+    printf("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32();
       for (i = 0; i < 10; i++) a = nl_fscx_revolve_v1_32(a, b, NL_I32);
@@ -4531,7 +4577,7 @@ static void bench_hske_nl_a1_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[36] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
+    printf("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K, P, ks, sink = 0;
       K = rand32(); P = rand32();
@@ -4617,7 +4663,7 @@ static void bench_hske_nl_a2_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[37] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
+    printf("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K = rand32(), P = rand32(), E, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4679,7 +4725,7 @@ static void bench_hkex_rnl_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[38] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
+    printf("[39] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
     /* n=32 (rnl32 fast path) */
     { rnl32_poly_t m_base, a_rand, m_blind;
       int32_t s_A[RNL_N32], c_A[RNL_N32], s_B[RNL_N32], c_B[RNL_N32];
@@ -4859,6 +4905,7 @@ int main(int argc, char *argv[])
     test_ratchet_forward_secrecy();
     test_hske_nl_aead();
     test_hdrbg();
+    test_wots_xmss();
 
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
-/*  Herradura KEx — Security & Performance Tests (Go) v1.9.35
+/*  Herradura KEx — Security & Performance Tests (Go) v1.9.42
+    v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
             benchmarks renumbered [30]–[41].
@@ -730,7 +731,7 @@ func testHpksSternRingCorrectness() {
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[30] FSCX throughput  [CLASSICAL]")
+	fmt.Println("[31] FSCX throughput  [CLASSICAL]")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -744,7 +745,7 @@ func benchFscx() {
 }
 
 func benchHkexGFPow() {
-	fmt.Println("[31] HKEX-GF gf_pow throughput  [CLASSICAL]")
+	fmt.Println("[32] HKEX-GF gf_pow throughput  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -759,7 +760,7 @@ func benchHkexGFPow() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[32] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
+	fmt.Println("[33] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -778,7 +779,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[33] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+	fmt.Println("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		rv   := rVal(size)
@@ -797,7 +798,7 @@ func benchHskeRoundTrip() {
 }
 
 func benchHpkeRoundTrip() {
-	fmt.Println("[34] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
+	fmt.Println("[35] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g    := big.NewInt(GfGen)
@@ -823,7 +824,7 @@ func benchHpkeRoundTrip() {
 }
 
 func benchNlFscxRevolve() {
-	fmt.Println("[35] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+	fmt.Println("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
 		a  := randBA(size)
@@ -850,7 +851,7 @@ func benchNlFscxRevolve() {
 }
 
 func benchHskeNlA1RoundTrip() {
-	fmt.Println("[36] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+	fmt.Println("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		sink := randBA(size)
@@ -870,7 +871,7 @@ func benchHskeNlA1RoundTrip() {
 }
 
 func benchHskeNlA2RoundTrip() {
-	fmt.Println("[37] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+	fmt.Println("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
 	for _, size := range sizes {
 		rv   := rVal(size)
 		sink := randBA(size)
@@ -887,7 +888,7 @@ func benchHskeNlA2RoundTrip() {
 }
 
 func benchHkexRnlHandshake() {
-	fmt.Println("[38] HKEX-RNL handshake throughput  [PQC-EXT]")
+	fmt.Println("[39] HKEX-RNL handshake throughput  [PQC-EXT]")
 	fmt.Printf("     (ring sizes %v; NTT O(n log n) per exchange)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := RnlMPoly(nRnl)
@@ -906,7 +907,7 @@ func benchHkexRnlHandshake() {
 }
 
 func benchHpksSternF() {
-	fmt.Printf("[39] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
+	fmt.Printf("[40] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
 	for _, size := range sizes {
 		seed, e, syn := SternFKeygen(size)
 		msg := randBA(size)
@@ -994,7 +995,7 @@ func testZkpNlCorrectness() {
 
 func benchZkpRnl() {
 	const n = 256
-	fmt.Printf("[40] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
+	fmt.Printf("[41] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
 	mBase  := RnlMPoly(n)
 	aRand  := RnlRandPoly(n, RnlQ)
 	mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
@@ -1015,7 +1016,7 @@ func benchZkpNl() {
 		n      = 32
 		rounds = 16
 	)
-	fmt.Printf("[41] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
+	fmt.Printf("[42] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
 	A, B, y, _ := ZkpNlKeygen(n)
 	ops, elapsed := bench("", func() {
 		proof, err := ZkpNlProve(A, B, y, n, rounds, zkpMsg)
@@ -1318,6 +1319,36 @@ func testHdrbg() {
 		p(okKat), p(okDet), p(okLimit), frac*100, status)
 }
 
+func testWotsXmss() {
+	const xmssH = 3 // 8 leaves; production uses h=10
+	N := testRounds(3)
+	okSign, okTamper, okReuse := 0, 0, 0
+	fmt.Printf("[30] HPKS-WOTS-F / HPKS-XMSS-F sign+verify (h=%d)  [PQC]\n", xmssH)
+	t0 := time.Now()
+	for i := 0; i < N; i++ {
+		seed := make([]byte, 32)
+		for j := range seed { seed[j] = byte(mrand.Intn(256)) }
+		kp   := HpksXmssKeygen(seed, xmssH)
+		msg  := []byte("HPKS-XMSS-F security test")
+		sig0 := HpksXmssSign(msg, kp, 0)
+		sig1 := HpksXmssSign(msg, kp, 1)
+		if HpksXmssVerify(msg, sig0, kp.Root) && HpksXmssVerify(msg, sig1, kp.Root) {
+			okSign++
+		}
+		if !HpksXmssVerify([]byte("tampered"), sig0, kp.Root) {
+			okTamper++
+		}
+		if !HpksXmssVerify([]byte("different message"), sig0, kp.Root) {
+			okReuse++
+		}
+		if timeExceeded(t0) { N = i + 1; break }
+	}
+	status := "PASS"
+	if okSign != N || okTamper != N || okReuse != N { status = "FAIL" }
+	fmt.Printf("    sign_ok=%d/%d  tamper_reject=%d/%d  reuse_reject=%d/%d  [%s]\n\n",
+		okSign, N, okTamper, N, okReuse, N, status)
+}
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -1416,6 +1447,7 @@ func main() {
 	testRatchetForwardSecrecy()
 	testHskeNlAead()
 	testHdrbg()
+	testWotsXmss()
 
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python) v1.9.35
+    Herradura KEx — Security & Performance Tests (Python) v1.9.42
+    v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
             benchmarks renumbered [30]–[41].
@@ -2075,8 +2076,104 @@ def _bench(label: str, fn):
     print(f"    {label:<44s}: {rate_str}  ({ops} ops in {elapsed:.2f}s)")
 
 
+# ---------------------------------------------------------------------------
+# HPKS-WOTS-F / HPKS-XMSS-F helpers (self-contained, mirrors suite logic)
+# ---------------------------------------------------------------------------
+
+_WOTS_W     = 16
+_WOTS_LOG2W = 4
+_WOTS_L1    = _KEYBITS // _WOTS_LOG2W   # 64
+_WOTS_L2    = 3
+_WOTS_L     = _WOTS_L1 + _WOTS_L2      # 67
+
+def _wots_h_t(x: BitArray) -> BitArray:
+    n = x._size
+    return nl_fscx_revolve_v1(x.rotated(n // 8), x, n // 4)
+
+def _wots_chain_t(x: BitArray, steps: int) -> BitArray:
+    for _ in range(steps):
+        x = _wots_h_t(x)
+    return x
+
+def _wots_leaf_seed_t(master_seed: bytes, leaf_idx: int, chain_idx: int) -> BitArray:
+    raw = hfscx_256(master_seed + leaf_idx.to_bytes(4, 'big') + chain_idx.to_bytes(2, 'big'))
+    return BitArray(_KEYBITS, int.from_bytes(raw, 'big'))
+
+def _wots_msg_digits_t(msg: bytes) -> list:
+    msg_hash = hfscx_256(msg)
+    val      = int.from_bytes(msg_hash, 'big')
+    digits   = [(val >> (4 * (_WOTS_L1 - 1 - i))) & 0xF for i in range(_WOTS_L1)]
+    cs       = sum(_WOTS_W - 1 - d for d in digits)
+    cs_d     = [(cs >> (4 * (_WOTS_L2 - 1 - i))) & 0xF for i in range(_WOTS_L2)]
+    return digits + cs_d
+
+def _wots_keygen_t(master_seed: bytes, leaf_idx: int):
+    sk = [_wots_leaf_seed_t(master_seed, leaf_idx, i) for i in range(_WOTS_L)]
+    pk = [_wots_chain_t(sk[i], _WOTS_W - 1) for i in range(_WOTS_L)]
+    return sk, pk
+
+def _wots_sign_t(msg: bytes, master_seed: bytes, leaf_idx: int):
+    digits  = _wots_msg_digits_t(msg)
+    sk, _pk = _wots_keygen_t(master_seed, leaf_idx)
+    return [_wots_chain_t(sk[i], _WOTS_W - 1 - digits[i]) for i in range(_WOTS_L)]
+
+def _wots_recover_pk_t(msg: bytes, sig: list) -> list:
+    digits = _wots_msg_digits_t(msg)
+    return [_wots_chain_t(sig[i], digits[i]) for i in range(_WOTS_L)]
+
+def _wots_pk_bytes_t(pk: list) -> bytes:
+    return b''.join(v.uint.to_bytes(_KEYBITS // 8, 'big') for v in pk)
+
+def _xmss_keygen_t(master_seed: bytes, h: int):
+    num = 1 << h
+    leaf_hashes = []
+    for idx in range(num):
+        _, pk = _wots_keygen_t(master_seed, idx)
+        leaf_hashes.append(haccum_leaf_test(_wots_pk_bytes_t(pk)))
+    return haccum_root_test(leaf_hashes), leaf_hashes
+
+def _xmss_sign_t(msg: bytes, master_seed: bytes, leaf_hashes: list, leaf_idx: int) -> dict:
+    return {
+        'leaf_idx': leaf_idx,
+        'wots_sig': _wots_sign_t(msg, master_seed, leaf_idx),
+        'auth_path': haccum_prove_test(leaf_hashes, leaf_idx),
+    }
+
+def _xmss_verify_t(msg: bytes, sig: dict, root: bytes) -> bool:
+    recovered = _wots_recover_pk_t(msg, sig['wots_sig'])
+    lh = haccum_leaf_test(_wots_pk_bytes_t(recovered))
+    return haccum_verify_test(root, lh, sig['auth_path'], sig['leaf_idx'])
+
+
+def test_wots_xmss():
+    XMSS_H = 2  # 4 leaves; h=3 is too slow for default Python runs
+    N = g_rounds if g_rounds > 0 else 1
+    ok_sign = ok_tamper = ok_reuse = done = 0
+    print(f"[30] HPKS-WOTS-F / HPKS-XMSS-F sign+verify (h={XMSS_H})  [PQC]")
+    t0 = time.perf_counter()
+    for _ in range(N):
+        if g_time_limit > 0 and time.perf_counter() - t0 >= g_time_limit:
+            break
+        seed = random.randbytes(32)
+        root, leaves = _xmss_keygen_t(seed, XMSS_H)
+        msg   = b"HPKS-XMSS-F security test"
+        sig0  = _xmss_sign_t(msg, seed, leaves, 0)
+        sig1  = _xmss_sign_t(msg, seed, leaves, 1)
+        if _xmss_verify_t(msg, sig0, root) and _xmss_verify_t(msg, sig1, root):
+            ok_sign += 1
+        if not _xmss_verify_t(b"tampered", sig0, root):
+            ok_tamper += 1
+        if not _xmss_verify_t(b"different message", sig0, root):
+            ok_reuse += 1
+        done += 1
+    N = done
+    status = "PASS" if N > 0 and ok_sign == N and ok_tamper == N and ok_reuse == N else (
+             "SKIP" if N == 0 else "FAIL")
+    print(f"    sign_ok={ok_sign}/{N}  tamper_reject={ok_tamper}/{N}  reuse_reject={ok_reuse}/{N}  [{status}]\n")
+
+
 def bench_fscx():
-    print("[30] FSCX throughput  [CLASSICAL]")
+    print("[31] FSCX throughput  [CLASSICAL]")
     for size in SIZES:
         a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -2086,7 +2183,7 @@ def bench_fscx():
 
 
 def bench_hkex_gf_pow():
-    print("[31] HKEX-GF gf_pow throughput  [CLASSICAL]")
+    print("[32] HKEX-GF gf_pow throughput  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); a = BitArray.random(size)
         def fn(a=a, poly=poly, size=size):
@@ -2096,7 +2193,7 @@ def bench_hkex_gf_pow():
 
 
 def bench_hkex_handshake():
-    print("[32] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
+    print("[33] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425)
         def fn():
@@ -2109,7 +2206,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[33] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+    print("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
     for size in SIZES:
         iv = i_val(size); rv = r_val(size); sink = BitArray(size, 0)
         def fn():
@@ -2121,7 +2218,7 @@ def bench_hske_roundtrip():
 
 
 def bench_hpke_roundtrip():
-    print("[34] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
+    print("[35] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size)
         sink = BitArray(size, 0)
@@ -2138,7 +2235,7 @@ def bench_hpke_roundtrip():
 
 
 def bench_nl_fscx_revolve():
-    print("[35] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+    print("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -2154,7 +2251,7 @@ def bench_nl_fscx_revolve():
 
 
 def bench_hske_nl_a1_roundtrip():
-    print("[36] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+    print("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); sink = BitArray(size, 0)
         def fn(size=size, iv=iv):
@@ -2170,7 +2267,7 @@ def bench_hske_nl_a1_roundtrip():
 
 
 def bench_hske_nl_a2_roundtrip():
-    print("[37] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+    print("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); sink = BitArray(size, 0)
         def fn(size=size, rv=rv):
@@ -2184,7 +2281,7 @@ def bench_hske_nl_a2_roundtrip():
 
 def bench_hkex_rnl_handshake():
     # Uses RNL_SIZES for speed; production uses n=256.
-    print("[38] HKEX-RNL handshake throughput  [PQC-EXT]")
+    print("[39] HKEX-RNL handshake throughput  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; n^2 poly-mul — O(n^2) per exchange)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
@@ -2200,7 +2297,7 @@ def bench_hkex_rnl_handshake():
 
 
 def bench_hpks_stern_f():
-    print("[39] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
+    print("[40] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
     rounds = 4; sink = [True]
     for size in SIZES:
         sf_seed, sf_e, sf_syn = stern_f_keygen(size)
@@ -2214,7 +2311,7 @@ def bench_hpks_stern_f():
 
 def bench_zkp_rnl():
     n = 256
-    print(f"[40] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
+    print(f"[41] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
     m_base  = _rnl_m_poly(n)
     a_rand  = _rnl_rand_poly(n, RNLQ)
     m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
@@ -2231,7 +2328,7 @@ def bench_zkp_rnl():
 
 def bench_zkp_nl():
     n = 32; rounds = 16
-    print(f"[41] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
+    print(f"[42] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
     A, B, y = _zkp_nl_keygen(n)
     def fn():
         proof = _zkp_nl_prove(A, B, y, n, rounds, ZKP_MSG)
@@ -2327,6 +2424,7 @@ if __name__ == '__main__':
     test_ratchet_forward_secrecy()
     test_hske_nl_aead()
     test_hdrbg()
+    test_wots_xmss()
 
     print("--- Performance Benchmarks ---\n")
     bench_fscx()

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -580,6 +580,42 @@ int main(void)
         puts(ok ? "+ ZKP-NL proof verified" : "- ZKP-NL verification FAILED");
     }
 
+    puts("\n*** HPKS-WOTS-F / HPKS-XMSS-F \xe2\x80\x94 hash-based many-time signatures");
+    {
+        uint8_t xmss_seed[KEYBYTES];
+        if (fread(xmss_seed, 1, KEYBYTES, urnd) != KEYBYTES) exit(1);
+        int xmss_h = 3;  /* 8 leaves; production uses h=10 */
+        uint8_t xmss_root[KEYBYTES];
+        uint8_t *xmss_leaves;
+        size_t   xmss_num;
+        hpks_xmss_keygen(xmss_root, &xmss_leaves, &xmss_num, xmss_seed, xmss_h);
+
+        const uint8_t xmss_msg[] = "HPKS-XMSS-F test message";
+        HpksXmssSig sig0, sig1;
+        hpks_xmss_sign(&sig0, xmss_msg, sizeof(xmss_msg)-1,
+                        xmss_seed, xmss_leaves, xmss_num, 0);
+        hpks_xmss_sign(&sig1, xmss_msg, sizeof(xmss_msg)-1,
+                        xmss_seed, xmss_leaves, xmss_num, 1);
+
+        int ok0   = hpks_xmss_verify(xmss_msg, sizeof(xmss_msg)-1, &sig0, xmss_root);
+        int ok1   = hpks_xmss_verify(xmss_msg, sizeof(xmss_msg)-1, &sig1, xmss_root);
+        const uint8_t bad_msg[] = "tampered";
+        int bad   = hpks_xmss_verify(bad_msg, sizeof(bad_msg)-1, &sig0, xmss_root);
+        const uint8_t diff_msg[] = "different message";
+        int reuse = hpks_xmss_verify(diff_msg, sizeof(diff_msg)-1, &sig0, xmss_root);
+
+        if (ok0 && ok1 && !bad && !reuse)
+            printf("- HPKS-XMSS-F sign/verify correct (h=%d, 2 leaves, tamper/reuse rejected)\n",
+                   xmss_h);
+        else
+            printf("+ HPKS-XMSS-F FAILED: ok0=%d ok1=%d bad=%d reuse=%d\n",
+                   ok0, ok1, bad, reuse);
+
+        hpks_xmss_sig_free(&sig0);
+        hpks_xmss_sig_free(&sig1);
+        free(xmss_leaves);
+    }
+
     /* *** EVE bypass TESTS *** */
     printf("\n\n*** EVE bypass TESTS\n");
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -43,6 +43,7 @@ package main
 import (
 	. "herradurakex/herradura"
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"math/big"
 )
@@ -340,6 +341,30 @@ func main() {
 				} else {
 					fmt.Println("- ZKP-NL verify FAILED")
 				}
+			}
+		}
+	}
+
+	// ── HPKS-WOTS-F / HPKS-XMSS-F ───────────────────────────────────────────────
+	fmt.Println("\n--- HPKS-XMSS-F [PQC — hash-based many-time sig; WOTS-F chains + Merkle tree]")
+	{
+		xmssSeed := make([]byte, 32)
+		if _, err := rand.Read(xmssSeed); err != nil {
+			fmt.Println("+ HPKS-XMSS-F: rand.Read failed:", err)
+		} else {
+			xmssH  := 3 // 8 leaves; production uses h=10
+			xmssKp := HpksXmssKeygen(xmssSeed, xmssH)
+			xmssMsg := []byte("HPKS-XMSS-F test message")
+			sig0 := HpksXmssSign(xmssMsg, xmssKp, 0)
+			sig1 := HpksXmssSign(xmssMsg, xmssKp, 1)
+			ok0   := HpksXmssVerify(xmssMsg, sig0, xmssKp.Root)
+			ok1   := HpksXmssVerify(xmssMsg, sig1, xmssKp.Root)
+			bad   := HpksXmssVerify([]byte("tampered"), sig0, xmssKp.Root)
+			reuse := HpksXmssVerify([]byte("different message"), sig0, xmssKp.Root)
+			if ok0 && ok1 && !bad && !reuse {
+				fmt.Printf("- HPKS-XMSS-F sign/verify correct (h=%d, 2 leaves, tamper/reuse rejected)\n", xmssH)
+			} else {
+				fmt.Printf("+ HPKS-XMSS-F FAILED: ok0=%v ok1=%v bad=%v reuse=%v\n", ok0, ok1, bad, reuse)
 			}
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.41)
+# Herradura Cryptographic Suite (v1.9.42)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6102,7 +6102,9 @@ Status: **DONE v1.9.40**
 
 **Assembly/Arduino scope:** out of scope — the WOTS chain length and Merkle tree are too large for the 32-bit demo targets.
 
-Status: **OPEN**
+**Note on Python:** The Python suite already had HPKS-WOTS-F / HPKS-XMSS-F from TODO #97 (v1.9.39). This TODO adds the missing C, Go, and test-file coverage.
+
+Status: **DONE v1.9.42**
 
 ---
 

--- a/herradura.h
+++ b/herradura.h
@@ -3064,4 +3064,194 @@ static int hpake_login_demo(uint8_t session_key[KEYBYTES],
     return 1;
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 97 — HPKS-WOTS-F / HPKS-XMSS-F — Hash-based signatures (TODO #97/#102)
+ *
+ * Hash chain step: h(x) = nl_fscx_revolve_v1(ROL(x, n/8), x, n/4)
+ * Winternitz w=16: ℓ_msg=64 nibbles, ℓ_cs=3, ℓ=67 total chains.
+ * XMSS: 2^H Merkle leaves; leaf = haccum_leaf(pk_0 || … || pk_{ℓ-1}).
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+#define WOTS_W     16
+#define WOTS_LOG2W  4
+#define WOTS_L1    64   /* KEYBITS / log2(W) = 256/4 */
+#define WOTS_L2     3   /* checksum digits in base-16 */
+#define WOTS_L     67   /* total chain count */
+
+/* Single hash-chain step: h(x) = nl_fscx_revolve_v1(ROL(x, n/8), x, n/4). */
+static inline void _wots_h_ba(BitArray *out, const BitArray *x)
+{
+    BitArray rotx;
+    ba_rol_k(&rotx, x, KEYBITS / 8);
+    nl_fscx_revolve_v1_ba(out, &rotx, x, KEYBITS / 4);
+}
+
+/* Apply _wots_h_ba `steps` times in-place. */
+static inline void _wots_chain_ba(BitArray *x, int steps)
+{
+    BitArray tmp;
+    for (int i = 0; i < steps; i++) { _wots_h_ba(&tmp, x); *x = tmp; }
+}
+
+/* Derive WOTS SK chain seed from master_seed (32 bytes), leaf_idx, chain_idx. */
+static inline void _wots_leaf_seed(BitArray *out,
+                                   const uint8_t master_seed[KEYBYTES],
+                                   uint32_t leaf_idx, uint16_t chain_idx)
+{
+    uint8_t buf[KEYBYTES + 6], h[KEYBYTES];
+    memcpy(buf, master_seed, KEYBYTES);
+    buf[KEYBYTES+0] = (leaf_idx >> 24) & 0xFF;
+    buf[KEYBYTES+1] = (leaf_idx >> 16) & 0xFF;
+    buf[KEYBYTES+2] = (leaf_idx >>  8) & 0xFF;
+    buf[KEYBYTES+3] =  leaf_idx        & 0xFF;
+    buf[KEYBYTES+4] = (chain_idx >> 8) & 0xFF;
+    buf[KEYBYTES+5] =  chain_idx       & 0xFF;
+    hfscx_256(buf, sizeof buf, NULL, h);
+    memcpy(out->b, h, KEYBYTES);
+}
+
+/* WOTS-F keygen: fills sk[WOTS_L] and pk[WOTS_L]. */
+static inline void hpks_wots_keygen(BitArray sk[WOTS_L], BitArray pk[WOTS_L],
+                                    const uint8_t master_seed[KEYBYTES],
+                                    uint32_t leaf_idx)
+{
+    for (int i = 0; i < WOTS_L; i++) {
+        _wots_leaf_seed(&sk[i], master_seed, leaf_idx, (uint16_t)i);
+        pk[i] = sk[i];
+        _wots_chain_ba(&pk[i], WOTS_W - 1);
+    }
+}
+
+/* Encode 32-byte msg_hash as WOTS_L base-16 digits with checksum. */
+static inline void _wots_msg_to_digits(int digits[WOTS_L],
+                                        const uint8_t msg_hash[KEYBYTES])
+{
+    for (int i = 0; i < WOTS_L1; i++)
+        digits[i] = (msg_hash[i/2] >> (4 * (1 - (i%2)))) & 0xF;
+    int cs = 0;
+    for (int i = 0; i < WOTS_L1; i++) cs += (WOTS_W - 1 - digits[i]);
+    for (int i = 0; i < WOTS_L2; i++)
+        digits[WOTS_L1 + i] = (cs >> (4 * (WOTS_L2 - 1 - i))) & 0xF;
+}
+
+/* WOTS-F sign: sig[i] = h^(w-1-d_i)(sk[i]). */
+static inline void hpks_wots_sign(BitArray sig[WOTS_L],
+                                   const uint8_t msg[/* any */], size_t mlen,
+                                   const uint8_t master_seed[KEYBYTES],
+                                   uint32_t leaf_idx)
+{
+    uint8_t msg_hash[KEYBYTES];
+    hfscx_256(msg, mlen, NULL, msg_hash);
+    int digits[WOTS_L];
+    _wots_msg_to_digits(digits, msg_hash);
+    BitArray sk[WOTS_L], pk_unused[WOTS_L];
+    hpks_wots_keygen(sk, pk_unused, master_seed, leaf_idx);
+    for (int i = 0; i < WOTS_L; i++) {
+        sig[i] = sk[i];
+        _wots_chain_ba(&sig[i], WOTS_W - 1 - digits[i]);
+    }
+}
+
+/* Recover WOTS pk from (msg, sig): pk_i = h^{d_i}(sig_i). */
+static inline void hpks_wots_recover_pk(BitArray recovered[WOTS_L],
+                                         const uint8_t msg[], size_t mlen,
+                                         const BitArray sig[WOTS_L])
+{
+    uint8_t msg_hash[KEYBYTES];
+    hfscx_256(msg, mlen, NULL, msg_hash);
+    int digits[WOTS_L];
+    _wots_msg_to_digits(digits, msg_hash);
+    for (int i = 0; i < WOTS_L; i++) {
+        recovered[i] = sig[i];
+        _wots_chain_ba(&recovered[i], digits[i]);
+    }
+}
+
+/* WOTS-F verify: 1 if h^{d_i}(sig_i) == pk_i for all i. */
+static inline int hpks_wots_verify(const uint8_t msg[], size_t mlen,
+                                    const BitArray sig[WOTS_L],
+                                    const BitArray pk[WOTS_L])
+{
+    BitArray recovered[WOTS_L];
+    hpks_wots_recover_pk(recovered, msg, mlen, sig);
+    for (int i = 0; i < WOTS_L; i++)
+        if (!ba_equal(&recovered[i], &pk[i])) return 0;
+    return 1;
+}
+
+/* Serialise WOTS pk to byte array (WOTS_L * KEYBYTES bytes). */
+static inline void _wots_pk_bytes(uint8_t *out, const BitArray pk[WOTS_L])
+{
+    for (int i = 0; i < WOTS_L; i++)
+        memcpy(out + i * KEYBYTES, pk[i].b, KEYBYTES);
+}
+
+/* HPKS-XMSS-F signature. auth_path is a flat malloc'd buffer: depth*KEYBYTES. */
+typedef struct {
+    uint32_t  leaf_idx;
+    BitArray  wots_sig[WOTS_L];
+    uint8_t  *auth_path;   /* depth * KEYBYTES contiguous sibling hashes */
+    int       depth;
+} HpksXmssSig;
+
+/* XMSS-F keygen: builds 2^h leaf hashes from master_seed.
+ * Outputs: root[KEYBYTES], flat_leaves (2^h * KEYBYTES, caller frees), num_leaves.
+ * flat_leaves is used as the contiguous array required by haccum_prove/verify. */
+static void hpks_xmss_keygen(uint8_t root[KEYBYTES],
+                              uint8_t **flat_leaves_out, size_t *num_leaves_out,
+                              const uint8_t master_seed[KEYBYTES], int h)
+{
+    size_t num = (size_t)1 << h;
+    uint8_t (*flat)[KEYBYTES] = (uint8_t (*)[KEYBYTES])malloc(num * KEYBYTES);
+    if (!flat) { fprintf(stderr, "hpks_xmss_keygen: oom\n"); exit(1); }
+    for (size_t idx = 0; idx < num; idx++) {
+        BitArray sk[WOTS_L], pk[WOTS_L];
+        hpks_wots_keygen(sk, pk, master_seed, (uint32_t)idx);
+        uint8_t pk_bytes[WOTS_L * KEYBYTES];
+        _wots_pk_bytes(pk_bytes, pk);
+        haccum_leaf(pk_bytes, WOTS_L * KEYBYTES, flat[idx]);
+    }
+    haccum_root(flat, num, root);
+    *flat_leaves_out = (uint8_t *)flat;
+    *num_leaves_out  = num;
+}
+
+/* XMSS-F sign: fills sig. sig->auth_path is malloc'd inside (caller frees via
+ * hpks_xmss_sig_free). flat_leaves is the array returned by hpks_xmss_keygen. */
+static void hpks_xmss_sign(HpksXmssSig *sig,
+                             const uint8_t msg[], size_t mlen,
+                             const uint8_t master_seed[KEYBYTES],
+                             const uint8_t *flat_leaves, size_t num_leaves,
+                             uint32_t leaf_idx)
+{
+    sig->leaf_idx  = leaf_idx;
+    hpks_wots_sign(sig->wots_sig, msg, mlen, master_seed, leaf_idx);
+    int depth;
+    sig->auth_path = haccum_prove((const uint8_t (*)[KEYBYTES])flat_leaves,
+                                   num_leaves, (size_t)leaf_idx, &depth);
+    sig->depth     = depth;
+}
+
+/* Free auth_path inside an HpksXmssSig. */
+static inline void hpks_xmss_sig_free(HpksXmssSig *sig)
+{
+    free(sig->auth_path);
+    sig->auth_path = NULL;
+}
+
+/* XMSS-F verify: 1 if valid. */
+static int hpks_xmss_verify(const uint8_t msg[], size_t mlen,
+                              const HpksXmssSig *sig,
+                              const uint8_t root[KEYBYTES])
+{
+    BitArray recovered[WOTS_L];
+    hpks_wots_recover_pk(recovered, msg, mlen, sig->wots_sig);
+    uint8_t pk_bytes[WOTS_L * KEYBYTES];
+    _wots_pk_bytes(pk_bytes, recovered);
+    uint8_t leaf_hash[KEYBYTES];
+    haccum_leaf(pk_bytes, WOTS_L * KEYBYTES, leaf_hash);
+    return haccum_verify(root, leaf_hash, sig->auth_path, sig->depth,
+                         (size_t)sig->leaf_idx);
+}
+
 #endif /* HERRADURA_H */

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -2165,6 +2165,164 @@ func TwkDecrypt(ct *BitArray, key []byte, sector uint64, bidx uint32) *BitArray 
 }
 
 // ---------------------------------------------------------------------------
+// 97 — HPKS-WOTS-F / HPKS-XMSS-F — Hash-based signatures (TODO #97/#102)
+//
+// Hash chain step: h(x) = NlFscxRevolveV1(ROL(x, n/8), x, n/4)
+// Winternitz w=16: ℓ_msg=64 nibbles, ℓ_cs=3, ℓ=67 total chains.
+// ---------------------------------------------------------------------------
+
+const (
+	WotsW    = 16
+	WotsLog2W = 4
+	WotsL1   = 64 // 256 / log2(16)
+	WotsL2   = 3  // checksum digits base-16
+	WotsL    = 67
+)
+
+// wotsH applies one hash-chain step: h(x) = NlFscxRevolveV1(ROL(x,n/8), x, n/4).
+func wotsH(x *BitArray) *BitArray {
+	n := x.Size()
+	return NlFscxRevolveV1(x.RotateLeft(n/8), x, n/4)
+}
+
+// wotsChain applies wotsH exactly steps times.
+func wotsChain(x *BitArray, steps int) *BitArray {
+	for i := 0; i < steps; i++ {
+		x = wotsH(x)
+	}
+	return x
+}
+
+// wotsMsgToDigits encodes a 32-byte hash as WotsL base-16 digits with checksum.
+func wotsMsgToDigits(msgHash []byte) []int {
+	digits := make([]int, WotsL)
+	for i := 0; i < WotsL1; i++ {
+		digits[i] = int((msgHash[i/2] >> (4 * uint(1-(i%2)))) & 0xF)
+	}
+	cs := 0
+	for i := 0; i < WotsL1; i++ {
+		cs += WotsW - 1 - digits[i]
+	}
+	for i := 0; i < WotsL2; i++ {
+		digits[WotsL1+i] = (cs >> (4 * uint(WotsL2-1-i))) & 0xF
+	}
+	return digits
+}
+
+// wotsLeafSeed derives the WOTS SK for (leafIdx, chainIdx) from masterSeed.
+func wotsLeafSeed(masterSeed []byte, leafIdx uint32, chainIdx uint16) *BitArray {
+	buf := make([]byte, len(masterSeed)+6)
+	copy(buf, masterSeed)
+	buf[len(masterSeed)+0] = byte(leafIdx >> 24)
+	buf[len(masterSeed)+1] = byte(leafIdx >> 16)
+	buf[len(masterSeed)+2] = byte(leafIdx >> 8)
+	buf[len(masterSeed)+3] = byte(leafIdx)
+	buf[len(masterSeed)+4] = byte(chainIdx >> 8)
+	buf[len(masterSeed)+5] = byte(chainIdx)
+	h := Hfscx256(buf, nil)
+	return NewBitArray(256, new(big.Int).SetBytes(h))
+}
+
+// HpksWotsKeygen generates (sk, pk) for one WOTS leaf — each WotsL BitArrays.
+func HpksWotsKeygen(masterSeed []byte, leafIdx uint32) ([WotsL]*BitArray, [WotsL]*BitArray) {
+	var sk, pk [WotsL]*BitArray
+	for i := 0; i < WotsL; i++ {
+		sk[i] = wotsLeafSeed(masterSeed, leafIdx, uint16(i))
+		pk[i] = wotsChain(sk[i], WotsW-1)
+	}
+	return sk, pk
+}
+
+// HpksWotsSign returns sig[i] = h^(w-1-d_i)(sk[i]).
+func HpksWotsSign(msg, masterSeed []byte, leafIdx uint32) [WotsL]*BitArray {
+	msgHash := Hfscx256(msg, nil)
+	digits  := wotsMsgToDigits(msgHash)
+	sk, _   := HpksWotsKeygen(masterSeed, leafIdx)
+	var sig [WotsL]*BitArray
+	for i := 0; i < WotsL; i++ {
+		sig[i] = wotsChain(sk[i], WotsW-1-digits[i])
+	}
+	return sig
+}
+
+// HpksWotsRecoverPk recovers the WOTS public key from (msg, sig).
+func HpksWotsRecoverPk(msg []byte, sig [WotsL]*BitArray) [WotsL]*BitArray {
+	msgHash := Hfscx256(msg, nil)
+	digits  := wotsMsgToDigits(msgHash)
+	var recovered [WotsL]*BitArray
+	for i := 0; i < WotsL; i++ {
+		recovered[i] = wotsChain(sig[i], digits[i])
+	}
+	return recovered
+}
+
+// HpksWotsVerify returns true iff h^{d_i}(sig[i]) == pk[i] for all i.
+func HpksWotsVerify(msg []byte, sig, pk [WotsL]*BitArray) bool {
+	recovered := HpksWotsRecoverPk(msg, sig)
+	for i := 0; i < WotsL; i++ {
+		if recovered[i].Val.Cmp(&pk[i].Val) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// wotsPkBytes serialises a WOTS pk to a byte slice (WotsL * 32 bytes).
+func wotsPkBytes(pk [WotsL]*BitArray) []byte {
+	out := make([]byte, WotsL*32)
+	for i := 0; i < WotsL; i++ {
+		b := pk[i].Bytes()
+		copy(out[i*32:], b)
+	}
+	return out
+}
+
+// HpksXmssKeypair holds the public root and the leaf-hash tree.
+type HpksXmssKeypair struct {
+	MasterSeed []byte
+	Root       []byte   // 32-byte XMSS public key (Merkle root)
+	LeafHashes [][]byte // 2^H leaf hashes for proof generation
+}
+
+// HpksXmssKeygen builds a 2^h-leaf Merkle tree from masterSeed.
+func HpksXmssKeygen(masterSeed []byte, h int) *HpksXmssKeypair {
+	num := 1 << h
+	leafHashes := make([][]byte, num)
+	for idx := 0; idx < num; idx++ {
+		_, pk := HpksWotsKeygen(masterSeed, uint32(idx))
+		leafHashes[idx] = HaccumLeaf(wotsPkBytes(pk))
+	}
+	return &HpksXmssKeypair{
+		MasterSeed: masterSeed,
+		Root:       HaccumRoot(leafHashes),
+		LeafHashes: leafHashes,
+	}
+}
+
+// HpksXmssSig holds an XMSS-F signature.
+type HpksXmssSig struct {
+	LeafIdx  int
+	WotsSig  [WotsL]*BitArray
+	AuthPath [][]byte
+}
+
+// HpksXmssSign signs msg at leafIdx using the pre-built keypair.
+func HpksXmssSign(msg []byte, kp *HpksXmssKeypair, leafIdx int) *HpksXmssSig {
+	return &HpksXmssSig{
+		LeafIdx:  leafIdx,
+		WotsSig:  HpksWotsSign(msg, kp.MasterSeed, uint32(leafIdx)),
+		AuthPath: HaccumProve(kp.LeafHashes, leafIdx),
+	}
+}
+
+// HpksXmssVerify verifies an XMSS-F signature against root.
+func HpksXmssVerify(msg []byte, sig *HpksXmssSig, root []byte) bool {
+	recovered := HpksWotsRecoverPk(msg, sig.WotsSig)
+	leafHash  := HaccumLeaf(wotsPkBytes(recovered))
+	return HaccumVerify(root, leafHash, sig.AuthPath, sig.LeafIdx)
+}
+
+// ---------------------------------------------------------------------------
 // 78.H — Masking-Friendly FSCX (Boolean masking via GF(2) linearity)
 //
 // FSCX(A⊕r, B, steps) ⊕ FSCX(r, 0, steps) = FSCX(A, B, steps)


### PR DESCRIPTION
## Summary

- **`herradura.h`** — adds full HPKS-WOTS-F and HPKS-XMSS-F implementation: `hpks_wots_keygen`, `hpks_wots_sign`, `hpks_wots_recover_pk`, `hpks_wots_verify`, `HpksXmssSig` struct, `hpks_xmss_keygen`, `hpks_xmss_sign`, `hpks_xmss_sig_free`, `hpks_xmss_verify`. Chain step: `h(x) = nl_fscx_revolve_v1(ROL(x, n/8), x, n/4)`, w=16, ℓ=67 chains.
- **`herradura/herradura.go`** — `HpksWotsKeygen/Sign/RecoverPk/Verify`, `HpksXmssKeypair`, `HpksXmssKeygen/Sign/Verify`.
- **`Herradura cryptographic suite.c` / `.go`** — HPKS-XMSS-F demo block (h=3, 2 leaves, tamper + OTS-reuse rejection).
- **`CryptosuiteTests/Herradura_tests.c/go/py`** — security test `[30] HPKS-WOTS-F / HPKS-XMSS-F`; benchmarks renumbered `[31]–[42]` across all three targets.

Python was already covered by TODO #97 (v1.9.39). This PR adds C and Go parity.

## Test plan

- [ ] `./CryptosuiteTests/Herradura_tests_c -r 1` → `[30] … [PASS]`
- [ ] `cd CryptosuiteTests && go run Herradura_tests.go -r 1` → `[30] … [PASS]`
- [ ] `python3 CryptosuiteTests/Herradura_tests.py -r 1` → `[30] … [PASS]` (h=2, ~10s)
- [ ] `./Herradura\ cryptographic\ suite_c` → `HPKS-XMSS-F sign/verify correct`
- [ ] `go run Herradura\ cryptographic\ suite.go` → `HPKS-XMSS-F sign/verify correct`

🤖 Generated with [Claude Code](https://claude.com/claude-code)