### PR TITLE
HPKS-T n-of-n threshold aggregate Schnorr — v1.9.43 (TODO #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.43] - 2026-06-14
+
+### Feature — HPKS-T: n-of-n Threshold Aggregate Schnorr over GF(2^n)* (TODO #98)
+
+Implements HPKS-T (MuSig2-style threshold Schnorr) in Python, C, and Go, adds security
+test [31] across all three targets, renumbers benchmarks to [32]–[43], and adds TODO #106
+tracking the CLI multi-party signing capability.
+
+**Protocol:** μ_j = HFSCX-256(L ∥ C_j) mod ord (rogue-key binding);
+C_agg = Π C_j^{μ_j}; R = Π g^{k_j};
+e = nl_fscx_revolve_v1(R, msg, n/4); s_j = (k_j − a_j·μ_j·e) mod ord;
+s = Σ s_j mod ord. Verify: g^s · C_agg^e == R (identical to single-party HPKS-NL).
+
+- **`herradura.h`**: adds `ba_add_mod_ord`, `GF_GEN_BA` macro, `_ba_mod_{add,sub,mul}_ord`
+  aliases; adds `_hpkst_mu_coeff`, `_hpkst_aggregate`, `_hpkst_build_L`, `hpkst_sign`,
+  `hpkst_verify`.
+- **`herradura/herradura.go`**: adds `HpkstAggregatePublickeys`, `HpkstSign`, `HpkstVerify`
+  (all using `*big.Int` GF arithmetic consistent with the existing package API).
+- **`Herradura cryptographic suite.py`**: adds module-level `hpkst_aggregate_pubkeys`,
+  `hpkst_sign`, `hpkst_verify`; demo block (3-of-3, tamper rejection).
+- **`Herradura cryptographic suite.c`**: adds HPKS-T demo block (3-of-3, tamper rejection).
+- **`Herradura cryptographic suite.go`**: adds HPKS-T demo block.
+- **`CryptosuiteTests/Herradura_tests.c`**: adds `test_hpkst()` → security test [31];
+  benchmarks renumbered [32]–[43].
+- **`CryptosuiteTests/Herradura_tests.go`**: adds `testHpkst()` → security test [31];
+  benchmarks renumbered [32]–[43].
+- **`CryptosuiteTests/Herradura_tests.py`**: adds `test_hpkst()` → security test [31];
+  benchmarks renumbered [32]–[43].
+- **`SecurityProofsCode/hpks_threshold_demo.py`**: standalone analysis script (n=32,
+  rogue-key attack demo, coefficient-binding fix, 2-of-2 and 3-of-3 correctness).
+- **`TODO.md`**: TODO #98 marked DONE v1.9.43; TODO #106 added for CLI multi-party
+  threshold signing capability (commit/aggregate/respond/combine 4-phase protocol).
+
+---
+
 ## [1.9.42] - 2026-06-14
 
 ### Consistency — HPKS-WOTS-F / HPKS-XMSS-F ported to C and Go (TODO #102)

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,7 +4,8 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.42
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.43
+    v1.9.43: HPKS-T threshold Schnorr test [31] (TODO #98); benchmarks renumbered [32]–[43].
     v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
@@ -85,22 +86,23 @@
       [28] HSKE-NL-AEAD (TODO #95) round-trip, tamper rejection, cross-language KAT  [NEW].
       [29] HDRBG (TODO #96) KAT, determinism, reseed separation, block limit  [NEW].
       [30] HPKS-WOTS-F / HPKS-XMSS-F sign+verify (h=3, 2 leaves, tamper/reuse rejection)  [PQC].
+      [31] HPKS-T n-of-n threshold Schnorr over GF(2^n)* (3-of-3, sign/verify/tamper)  [CLASSICAL].
       C-only (unlabeled): F_stern(K,·) range compression at n=32 (HyperLogLog, TODO #42).
 
-    Performance benchmarks [31]–[42] (unified with Go and Python):
-      [31] FSCX throughput (256-bit).
-      [32] HKEX-GF gf_pow throughput (32-bit).
-      [33] HKEX-GF full handshake (32-bit).
-      [34] HSKE round-trip (256-bit).
-      [35] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
-      [36] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
+    Performance benchmarks [32]–[43] (unified with Go and Python):
+      [32] FSCX throughput (256-bit).
+      [33] HKEX-GF gf_pow throughput (32-bit).
+      [34] HKEX-GF full handshake (32-bit).
+      [35] HSKE round-trip (256-bit).
+      [36] HPKE El Gamal encrypt+decrypt round-trip (32-bit).
+      [37] NL-FSCX v1 revolve throughput (32-bit, n/4 steps).
       [36b] NL-FSCX v2 revolve+inv throughput (32-bit, r_val steps).
-      [37] HSKE-NL-A1 counter-mode throughput (32-bit).
-      [38] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
-      [39] HKEX-RNL full handshake throughput (n=32).
-      [40] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
-      [41] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
-      [42] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
+      [38] HSKE-NL-A1 counter-mode throughput (32-bit).
+      [39] HSKE-NL-A2 revolve-mode round-trip throughput (32-bit).
+      [40] HKEX-RNL full handshake throughput (n=32).
+      [41] HPKS-Stern-F sign+verify throughput  [CODE-BASED PQC].
+      [42] ZKP-RNL sign+verify throughput (n=256)  [PQC-EXT].
+      [43] ZKP-NL prove+verify throughput (n=32, rounds=16)  [PQC-EXT].
 
     Copyright (C) 2024-2026 Omar Alejandro Herrera Reyna
 
@@ -3532,7 +3534,7 @@ static void bench_hpks_stern_f(void)
     long long ops;
     double secs;
     int i;
-    printf("[40] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
+    printf("[41] HPKS-Stern-F sign+verify  (N=n, rounds=8)  [CODE-BASED PQC]\n");
     /* N=32 */
     { static SternSig32T bsig32;
       uint32_t seed32 = stern32_rand_seed(), e32 = stern32_rand_error(), msg32;
@@ -3623,7 +3625,7 @@ static void bench_zkp_rnl(void)
     int32_t s[256], C[256];
     int32_t w[256], c_poly[256], z[256];
     int i;
-    printf("[41] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
+    printf("[42] ZKP-RNL sign+verify throughput  (n=256)  [PQC-EXT]\n");
     rnl_m_poly_n(m_base, n);
     rnl_rand_poly_n(a_rand, n);
     rnl_poly_add_n(m_blind, m_base, a_rand, n);
@@ -3661,7 +3663,7 @@ static void bench_zkp_nl(void)
     uint64_t A, B, y;
     ZkpNlRound *proof;
     int i;
-    printf("[42] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
+    printf("[43] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n",
            n, rounds);
     zkp_nl_keygen(n, urnd_fp, &A, &B, &y);
     /* warm-up */
@@ -4165,18 +4167,48 @@ static void test_wots_xmss(void)
     putchar('\n');
 }
 
+static void test_hpkst(void)
+{
+    enum { T_N = 3 };
+    int N = TEST_ROUNDS(3), i, ok_sign = 0, ok_tamper = 0;
+    struct timespec t0;
+    static const uint8_t t_msg[32] = "HPKS-T threshold security test!";
+    BitArray msg_ba; memcpy(msg_ba.b, t_msg, 32);
+    printf("[31] HPKS-T  n-of-n threshold Schnorr over GF(2^n)*  [CLASSICAL]\n");
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (i = 0; i < N; i++) {
+        BitArray secrets[T_N], pubkeys[T_N];
+        for (int j = 0; j < T_N; j++) {
+            ba_rand(&secrets[j], urnd_fp);
+            gf_pow_ba(&pubkeys[j], &GF_GEN, &secrets[j]);
+        }
+        BitArray cagg, R, s;
+        hpkst_sign(secrets, pubkeys, T_N, &msg_ba, NULL, &cagg, &R, &s, urnd_fp);
+        if (hpkst_verify(&cagg, &R, &s, &msg_ba))
+            ok_sign++;
+        BitArray s_bad = s; s_bad.b[KEYBYTES-1] ^= 1;
+        if (!hpkst_verify(&cagg, &R, &s_bad, &msg_ba))
+            ok_tamper++;
+        if (time_exceeded(&t0)) { N = i + 1; break; }
+    }
+    printf("    sign_ok=%d/%d  tamper_reject=%d/%d  [%s]\n",
+           ok_sign, N, ok_tamper, N,
+           (ok_sign == N && ok_tamper == N) ? "PASS" : "FAIL");
+    putchar('\n');
+}
+
 /* ------------------------------------------------------------------ */
-/* Performance benchmarks [31]-[42]                                    */
+/* Performance benchmarks [32]-[43]                                    */
 /* ------------------------------------------------------------------ */
 
-/* [31] FSCX throughput (64/128/256-bit) */
+/* [32] FSCX throughput (64/128/256-bit) */
 static void bench_fscx_throughput(void)
 {
     struct timespec t0, t1;
     long long ops;
     double secs;
     int i;
-    printf("[31] FSCX throughput  [CLASSICAL]\n");
+    printf("[32] FSCX throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32(), tmp;
       for (i = 0; i < 10; i++) { tmp = fscx32(a, b); a = tmp; }
@@ -4220,7 +4252,7 @@ static void bench_gf_pow_throughput(void)
     long long ops;
     double secs;
     int i;
-    printf("[32] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
+    printf("[33] HKEX-GF gf_pow throughput  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t base = rand32() | 1, exp = rand32() | 1, tmp;
       for (i = 0; i < 5; i++) { tmp = gf_pow_32(base, exp); base = tmp | 1; }
@@ -4265,7 +4297,7 @@ static void bench_hkex_gf_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[33] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
+    printf("[34] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, b = rand32()|1, C, C2, skA, skB;
       for (i = 0; i < 5; i++) {
@@ -4331,7 +4363,7 @@ static void bench_hske_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
+    printf("[35] HSKE round-trip: encrypt+decrypt  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t pt, key, enc, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4398,7 +4430,7 @@ static void bench_hpke_el_gamal_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[35] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
+    printf("[36] HPKE El Gamal encrypt+decrypt round-trip  [CLASSICAL]\n");
     /* 32-bit */
     { uint32_t a = rand32()|1, r = rand32()|1, pt = rand32();
       uint32_t C = gf_pow_32(GF_GEN32, a), R, ek, E, dk;
@@ -4483,7 +4515,7 @@ static void bench_nl_fscx_revolve(void)
     long long ops;
     double secs;
     int i;
-    printf("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
+    printf("[37] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t a = rand32(), b = rand32();
       for (i = 0; i < 10; i++) a = nl_fscx_revolve_v1_32(a, b, NL_I32);
@@ -4577,7 +4609,7 @@ static void bench_hske_nl_a1_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
+    printf("[38] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K, P, ks, sink = 0;
       K = rand32(); P = rand32();
@@ -4663,7 +4695,7 @@ static void bench_hske_nl_a2_roundtrip(void)
     long long ops;
     double secs;
     int i;
-    printf("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
+    printf("[39] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]\n");
     /* 32-bit */
     { uint32_t K = rand32(), P = rand32(), E, sink = 0;
       for (i = 0; i < 5; i++) {
@@ -4725,7 +4757,7 @@ static void bench_hkex_rnl_handshake(void)
     long long ops;
     double secs;
     int i;
-    printf("[39] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
+    printf("[40] HKEX-RNL handshake throughput  (NTT O(n log n))  [PQC-EXT]\n");
     /* n=32 (rnl32 fast path) */
     { rnl32_poly_t m_base, a_rand, m_blind;
       int32_t s_A[RNL_N32], c_A[RNL_N32], s_B[RNL_N32], c_B[RNL_N32];
@@ -4906,6 +4938,7 @@ int main(int argc, char *argv[])
     test_hske_nl_aead();
     test_hdrbg();
     test_wots_xmss();
+    test_hpkst();
 
     puts("--- Performance Benchmarks ---\n");
     bench_fscx_throughput();

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,5 @@
-/*  Herradura KEx — Security & Performance Tests (Go) v1.9.42
+/*  Herradura KEx — Security & Performance Tests (Go) v1.9.43
+    v1.9.43: HPKS-T threshold Schnorr test [31] (TODO #98); benchmarks renumbered [32]–[43].
     v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
@@ -731,7 +732,7 @@ func testHpksSternRingCorrectness() {
 // ---------------------------------------------------------------------------
 
 func benchFscx() {
-	fmt.Println("[31] FSCX throughput  [CLASSICAL]")
+	fmt.Println("[32] FSCX throughput  [CLASSICAL]")
 	for _, size := range sizes {
 		a := randBA(size)
 		b := randBA(size)
@@ -745,7 +746,7 @@ func benchFscx() {
 }
 
 func benchHkexGFPow() {
-	fmt.Println("[32] HKEX-GF gf_pow throughput  [CLASSICAL]")
+	fmt.Println("[33] HKEX-GF gf_pow throughput  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -760,7 +761,7 @@ func benchHkexGFPow() {
 }
 
 func benchHkexHandshake() {
-	fmt.Println("[33] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
+	fmt.Println("[34] HKEX-GF full handshake (4 GfPow calls)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g := big.NewInt(GfGen)
@@ -779,7 +780,7 @@ func benchHkexHandshake() {
 }
 
 func benchHskeRoundTrip() {
-	fmt.Println("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+	fmt.Println("[35] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		rv   := rVal(size)
@@ -798,7 +799,7 @@ func benchHskeRoundTrip() {
 }
 
 func benchHpkeRoundTrip() {
-	fmt.Println("[35] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
+	fmt.Println("[36] HPKE encrypt+decrypt round-trip (El Gamal + FscxRevolve)  [CLASSICAL]")
 	for _, size := range gfSizes {
 		poly := GfPoly[size]
 		g    := big.NewInt(GfGen)
@@ -824,7 +825,7 @@ func benchHpkeRoundTrip() {
 }
 
 func benchNlFscxRevolve() {
-	fmt.Println("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+	fmt.Println("[37] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
 	for _, size := range sizes {
 		iv := iVal(size)
 		a  := randBA(size)
@@ -851,7 +852,7 @@ func benchNlFscxRevolve() {
 }
 
 func benchHskeNlA1RoundTrip() {
-	fmt.Println("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+	fmt.Println("[38] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
 	for _, size := range sizes {
 		iv   := iVal(size)
 		sink := randBA(size)
@@ -871,7 +872,7 @@ func benchHskeNlA1RoundTrip() {
 }
 
 func benchHskeNlA2RoundTrip() {
-	fmt.Println("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+	fmt.Println("[39] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
 	for _, size := range sizes {
 		rv   := rVal(size)
 		sink := randBA(size)
@@ -888,7 +889,7 @@ func benchHskeNlA2RoundTrip() {
 }
 
 func benchHkexRnlHandshake() {
-	fmt.Println("[39] HKEX-RNL handshake throughput  [PQC-EXT]")
+	fmt.Println("[40] HKEX-RNL handshake throughput  [PQC-EXT]")
 	fmt.Printf("     (ring sizes %v; NTT O(n log n) per exchange)\n", rnlSizes)
 	for _, nRnl := range rnlSizes {
 		mBase := RnlMPoly(nRnl)
@@ -907,7 +908,7 @@ func benchHkexRnlHandshake() {
 }
 
 func benchHpksSternF() {
-	fmt.Printf("[40] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
+	fmt.Printf("[41] HPKS-Stern-F sign+verify throughput  (N=n, rounds=%d)  [CODE-BASED PQC]\n", sdfTestRounds)
 	for _, size := range sizes {
 		seed, e, syn := SternFKeygen(size)
 		msg := randBA(size)
@@ -995,7 +996,7 @@ func testZkpNlCorrectness() {
 
 func benchZkpRnl() {
 	const n = 256
-	fmt.Printf("[41] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
+	fmt.Printf("[42] ZKP-RNL sign+verify throughput  (n=%d)  [PQC-EXT]\n", n)
 	mBase  := RnlMPoly(n)
 	aRand  := RnlRandPoly(n, RnlQ)
 	mBlind := RnlPolyAdd(mBase, aRand, RnlQ)
@@ -1016,7 +1017,7 @@ func benchZkpNl() {
 		n      = 32
 		rounds = 16
 	)
-	fmt.Printf("[42] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
+	fmt.Printf("[43] ZKP-NL prove+verify throughput  (n=%d, rounds=%d)  [PQC-EXT]\n", n, rounds)
 	A, B, y, _ := ZkpNlKeygen(n)
 	ops, elapsed := bench("", func() {
 		proof, err := ZkpNlProve(A, B, y, n, rounds, zkpMsg)
@@ -1349,6 +1350,40 @@ func testWotsXmss() {
 		okSign, N, okTamper, N, okReuse, N, status)
 }
 
+func testHpkst() {
+	const tN = 3
+	N := testRounds(3)
+	okSign, okTamper := 0, 0
+	fmt.Printf("[31] HPKS-T  %d-of-%d threshold Schnorr over GF(2^n)*  [CLASSICAL]\n", tN, tN)
+	t0 := time.Now()
+	msg := []byte("HPKS-T threshold security test!")
+	for i := 0; i < N; i++ {
+		secrets := make([]*big.Int, tN)
+		pubkeys := make([]*big.Int, tN)
+		gGen    := big.NewInt(3)
+		poly    := GfPoly[256]
+		for j := 0; j < tN; j++ {
+			kb := make([]byte, 32)
+			for k := range kb { kb[k] = byte(mrand.Intn(256)) }
+			secrets[j] = new(big.Int).SetBytes(kb)
+			pubkeys[j] = GfPow(gGen, secrets[j], poly, 256)
+		}
+		cAgg, R, s := HpkstSign(secrets, pubkeys, msg)
+		if HpkstVerify(cAgg, R, s, msg) {
+			okSign++
+		}
+		sBad := new(big.Int).Xor(s, big.NewInt(1))
+		if !HpkstVerify(cAgg, R, sBad, msg) {
+			okTamper++
+		}
+		if timeExceeded(t0) { N = i + 1; break }
+	}
+	status := "PASS"
+	if okSign != N || okTamper != N { status = "FAIL" }
+	fmt.Printf("    sign_ok=%d/%d  tamper_reject=%d/%d  [%s]\n\n",
+		okSign, N, okTamper, N, status)
+}
+
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -1448,6 +1483,7 @@ func main() {
 	testHskeNlAead()
 	testHdrbg()
 	testWotsXmss()
+	testHpkst()
 
 	fmt.Println("--- Performance Benchmarks ---\n")
 	benchFscx()

--- a/CryptosuiteTests/Herradura_tests.py
+++ b/CryptosuiteTests/Herradura_tests.py
@@ -1,5 +1,6 @@
 '''
-    Herradura KEx — Security & Performance Tests (Python) v1.9.42
+    Herradura KEx — Security & Performance Tests (Python) v1.9.43
+    v1.9.43: HPKS-T threshold Schnorr test [31] (TODO #98); benchmarks renumbered [32]–[43].
     v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
     v1.9.34: HDRBG test [29] — KAT, determinism, reseed separation, block limit (TODO #96);
@@ -2172,8 +2173,74 @@ def test_wots_xmss():
     print(f"    sign_ok={ok_sign}/{N}  tamper_reject={ok_tamper}/{N}  reuse_reject={ok_reuse}/{N}  [{status}]\n")
 
 
+def _hpkst_mu_t(L_bytes: bytes, C_j_val: int) -> int:
+    cjb = C_j_val.to_bytes(_KEYBITS // 8, 'big')
+    h   = hfscx_256(L_bytes + cjb)
+    mu  = int.from_bytes(h, 'big') % (2**_KEYBITS - 1)
+    return mu or 1
+
+def _hpkst_aggregate_t(pubkeys: list[int]) -> tuple[int, list[int]]:
+    _poly = GF_POLY[_KEYBITS]
+    bkeys = sorted(pk.to_bytes(_KEYBITS // 8, 'big') for pk in pubkeys)
+    L_bytes = b''.join(bkeys)
+    coeffs  = [_hpkst_mu_t(L_bytes, pk) for pk in pubkeys]
+    agg = 1
+    for pk, mu in zip(pubkeys, coeffs):
+        agg = gf_mul(agg, gf_pow(pk, mu, _poly, _KEYBITS), _poly, _KEYBITS)
+    return agg, coeffs
+
+def _hpkst_sign_t(secrets: list[int], pubkeys: list[int], msg: bytes) -> tuple[int, int, int]:
+    _poly = GF_POLY[_KEYBITS]; _ord = 2**_KEYBITS - 1
+    cagg, coeffs = _hpkst_aggregate_t(pubkeys)
+    nonces = [random.randrange(1, _ord) for _ in secrets]
+    R = 1
+    for k in nonces:
+        R = gf_mul(R, gf_pow(GF_GEN, k, _poly, _KEYBITS), _poly, _KEYBITS)
+    msg_ba = BitArray(_KEYBITS, int.from_bytes(msg[:_KEYBITS//8].ljust(_KEYBITS//8, b'\x00'), 'big'))
+    e = nl_fscx_revolve_v1(BitArray(_KEYBITS, R), msg_ba, _KEYBITS // 4)
+    e_val = e._val
+    s = 0
+    for a_j, k_j, mu_j in zip(secrets, nonces, coeffs):
+        s_j = (k_j - a_j * mu_j * e_val) % _ord
+        s = (s + s_j) % _ord
+    return cagg, R, s
+
+def _hpkst_verify_t(cagg: int, R: int, s: int, msg: bytes) -> bool:
+    _poly = GF_POLY[_KEYBITS]
+    msg_ba = BitArray(_KEYBITS, int.from_bytes(msg[:_KEYBITS//8].ljust(_KEYBITS//8, b'\x00'), 'big'))
+    e = nl_fscx_revolve_v1(BitArray(_KEYBITS, R), msg_ba, _KEYBITS // 4)
+    e_val = e._val
+    lhs = gf_mul(gf_pow(GF_GEN, s, _poly, _KEYBITS),
+                 gf_pow(cagg, e_val, _poly, _KEYBITS), _poly, _KEYBITS)
+    return lhs == R
+
+def test_hpkst():
+    T_N = 3
+    N = g_rounds if g_rounds > 0 else 3
+    ok_sign = ok_tamper = done = 0
+    print(f"[31] HPKS-T  {T_N}-of-{T_N} threshold Schnorr over GF(2^n)*  [CLASSICAL]")
+    t0 = time.perf_counter()
+    _poly = GF_POLY[_KEYBITS]; _ord = 2**_KEYBITS - 1
+    for _ in range(N):
+        if g_time_limit > 0 and time.perf_counter() - t0 >= g_time_limit:
+            break
+        secrets = [random.randrange(1, _ord) for _ in range(T_N)]
+        pubkeys = [gf_pow(GF_GEN, a, _poly, _KEYBITS) for a in secrets]
+        msg = b"HPKS-T threshold security test!"
+        cagg, R, s = _hpkst_sign_t(secrets, pubkeys, msg)
+        if _hpkst_verify_t(cagg, R, s, msg):
+            ok_sign += 1
+        if not _hpkst_verify_t(cagg, R, s ^ 1, msg):
+            ok_tamper += 1
+        done += 1
+    N = done
+    status = "PASS" if N > 0 and ok_sign == N and ok_tamper == N else (
+             "SKIP" if N == 0 else "FAIL")
+    print(f"    sign_ok={ok_sign}/{N}  tamper_reject={ok_tamper}/{N}  [{status}]\n")
+
+
 def bench_fscx():
-    print("[31] FSCX throughput  [CLASSICAL]")
+    print("[32] FSCX throughput  [CLASSICAL]")
     for size in SIZES:
         a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -2183,7 +2250,7 @@ def bench_fscx():
 
 
 def bench_hkex_gf_pow():
-    print("[32] HKEX-GF gf_pow throughput  [CLASSICAL]")
+    print("[33] HKEX-GF gf_pow throughput  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); a = BitArray.random(size)
         def fn(a=a, poly=poly, size=size):
@@ -2193,7 +2260,7 @@ def bench_hkex_gf_pow():
 
 
 def bench_hkex_handshake():
-    print("[33] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
+    print("[34] HKEX-GF full handshake (4 gf_pow calls)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425)
         def fn():
@@ -2206,7 +2273,7 @@ def bench_hkex_handshake():
 
 
 def bench_hske_roundtrip():
-    print("[34] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
+    print("[35] HSKE round-trip: encrypt+decrypt  [CLASSICAL]")
     for size in SIZES:
         iv = i_val(size); rv = r_val(size); sink = BitArray(size, 0)
         def fn():
@@ -2218,7 +2285,7 @@ def bench_hske_roundtrip():
 
 
 def bench_hpke_roundtrip():
-    print("[35] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
+    print("[36] HPKE encrypt+decrypt round-trip (El Gamal + fscx_revolve)  [CLASSICAL]")
     for size in GF_SIZES:
         poly = GF_POLY.get(size, 0x00000425); iv = i_val(size); rv = r_val(size)
         sink = BitArray(size, 0)
@@ -2235,7 +2302,7 @@ def bench_hpke_roundtrip():
 
 
 def bench_nl_fscx_revolve():
-    print("[36] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
+    print("[37] NL-FSCX v1 revolve throughput (n/4 steps)  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); a = BitArray.random(size); b = BitArray.random(size)
         def fn():
@@ -2251,7 +2318,7 @@ def bench_nl_fscx_revolve():
 
 
 def bench_hske_nl_a1_roundtrip():
-    print("[37] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
+    print("[38] HSKE-NL-A1 counter-mode throughput  [PQC-EXT]")
     for size in SIZES:
         iv = i_val(size); sink = BitArray(size, 0)
         def fn(size=size, iv=iv):
@@ -2267,7 +2334,7 @@ def bench_hske_nl_a1_roundtrip():
 
 
 def bench_hske_nl_a2_roundtrip():
-    print("[38] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
+    print("[39] HSKE-NL-A2 revolve-mode round-trip  [PQC-EXT]")
     for size in SIZES:
         rv = r_val(size); sink = BitArray(size, 0)
         def fn(size=size, rv=rv):
@@ -2281,7 +2348,7 @@ def bench_hske_nl_a2_roundtrip():
 
 def bench_hkex_rnl_handshake():
     # Uses RNL_SIZES for speed; production uses n=256.
-    print("[39] HKEX-RNL handshake throughput  [PQC-EXT]")
+    print("[40] HKEX-RNL handshake throughput  [PQC-EXT]")
     print(f"     (ring sizes {RNL_SIZES}; n^2 poly-mul — O(n^2) per exchange)")
     for n_rnl in RNL_SIZES:
         m_base = _rnl_m_poly(n_rnl)
@@ -2297,7 +2364,7 @@ def bench_hkex_rnl_handshake():
 
 
 def bench_hpks_stern_f():
-    print("[40] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
+    print("[41] HPKS-Stern-F sign+verify throughput (N=n, rounds=4)  [CODE-BASED PQC]")
     rounds = 4; sink = [True]
     for size in SIZES:
         sf_seed, sf_e, sf_syn = stern_f_keygen(size)
@@ -2311,7 +2378,7 @@ def bench_hpks_stern_f():
 
 def bench_zkp_rnl():
     n = 256
-    print(f"[41] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
+    print(f"[42] ZKP-RNL sign+verify throughput  (n={n})  [PQC-EXT]")
     m_base  = _rnl_m_poly(n)
     a_rand  = _rnl_rand_poly(n, RNLQ)
     m_blind = _rnl_poly_add(m_base, a_rand, RNLQ)
@@ -2328,7 +2395,7 @@ def bench_zkp_rnl():
 
 def bench_zkp_nl():
     n = 32; rounds = 16
-    print(f"[42] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
+    print(f"[43] ZKP-NL prove+verify throughput  (n={n}, rounds={rounds})  [PQC-EXT]")
     A, B, y = _zkp_nl_keygen(n)
     def fn():
         proof = _zkp_nl_prove(A, B, y, n, rounds, ZKP_MSG)
@@ -2425,6 +2492,7 @@ if __name__ == '__main__':
     test_hske_nl_aead()
     test_hdrbg()
     test_wots_xmss()
+    test_hpkst()
 
     print("--- Performance Benchmarks ---\n")
     bench_fscx()

--- a/Herradura cryptographic suite.c
+++ b/Herradura cryptographic suite.c
@@ -616,6 +616,27 @@ int main(void)
         free(xmss_leaves);
     }
 
+    puts("\n*** HPKS-T \xe2\x80\x94 n-of-n threshold aggregate Schnorr over GF(2^n)*");
+    {
+        enum { T_N = 3 };
+        BitArray t_secrets[T_N], t_pubkeys[T_N];
+        for (int j = 0; j < T_N; j++) {
+            ba_rand(&t_secrets[j], urnd);
+            gf_pow_ba(&t_pubkeys[j], &GF_GEN, &t_secrets[j]);
+        }
+        BitArray t_cagg, t_R, t_s;
+        hpkst_sign(t_secrets, t_pubkeys, T_N, &plaintext, NULL, &t_cagg, &t_R, &t_s, urnd);
+        int t_ok  = hpkst_verify(&t_cagg, &t_R, &t_s, &plaintext);
+        BitArray t_s_bad;
+        memcpy(t_s_bad.b, t_s.b, KEYBYTES);
+        t_s_bad.b[KEYBYTES-1] ^= 1;
+        int t_bad = hpkst_verify(&t_cagg, &t_R, &t_s_bad, &plaintext);
+        if (t_ok && !t_bad)
+            printf("+ HPKS-T %d-of-%d sign/verify correct, tamper rejected\n", T_N, T_N);
+        else
+            printf("+ HPKS-T FAILED: ok=%d bad=%d\n", t_ok, t_bad);
+    }
+
     /* *** EVE bypass TESTS *** */
     printf("\n\n*** EVE bypass TESTS\n");
 

--- a/Herradura cryptographic suite.go
+++ b/Herradura cryptographic suite.go
@@ -369,6 +369,31 @@ func main() {
 		}
 	}
 
+	// ── HPKS-T ───────────────────────────────────────────────────────────────────
+	fmt.Println("\n--- HPKS-T [THRESHOLD — n-of-n MuSig2-style aggregate Schnorr over GF(2^n)*]")
+	{
+		tN     := 3
+		gGen   := big.NewInt(3)
+		poly256 := GfPoly[n]
+		tSecrets := make([]*big.Int, tN)
+		tPubkeys := make([]*big.Int, tN)
+		for j := 0; j < tN; j++ {
+			kb := make([]byte, 32)
+			rand.Read(kb)
+			tSecrets[j] = new(big.Int).SetBytes(kb)
+			tPubkeys[j] = GfPow(gGen, tSecrets[j], poly256, n)
+		}
+		tMsg  := []byte("HPKS-T threshold signature test")
+		tCAgg, tR, tS := HpkstSign(tSecrets, tPubkeys, tMsg)
+		tOk  := HpkstVerify(tCAgg, tR, tS, tMsg)
+		tBad := HpkstVerify(tCAgg, tR, new(big.Int).Xor(tS, big.NewInt(1)), tMsg)
+		if tOk && !tBad {
+			fmt.Printf("- HPKS-T %d-of-%d sign/verify correct, tamper rejected\n", tN, tN)
+		} else {
+			fmt.Printf("+ HPKS-T FAILED: ok=%v bad=%v\n", tOk, tBad)
+		}
+	}
+
 	// ── HDRBG ────────────────────────────────────────────────────────────────────
 	fmt.Println("\n--- HDRBG [FORWARD-SECURE DRBG — NL-FSCX v1 ratchet, fast-key-erasure]")
 	{

--- a/Herradura cryptographic suite.py
+++ b/Herradura cryptographic suite.py
@@ -1703,6 +1703,81 @@ def haccum_verify(root: bytes, leaf_hash: bytes, proof: list, idx: int) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# 98 — HPKS-T: Threshold / Aggregate Schnorr over GF(2^n)* (TODO #98)
+#
+# n-of-n MuSig2-style key aggregation with NL-FSCX v1 challenge.
+# Rogue-key binding: μ_j = H(L || C_j) mod ord  where L = sorted pubkeys.
+# Aggregate key:     C_agg = Π C_j^{μ_j}
+# Sign:              R = Π R_j;  e = NL-FSCX v1(R, msg);
+#                    s_j = (k_j − a_j·μ_j·e) mod ord;  s = Σ s_j
+# Verify:            g^s · C_agg^e == R  (identical to single-party verify)
+# ---------------------------------------------------------------------------
+
+def _hpkst_mu_coeff(L_bytes: bytes, C_j: 'BitArray') -> int:
+    """μ_j = HFSCX-256(L || C_j_bytes) as integer mod ord."""
+    raw = hfscx_256(L_bytes + C_j.uint.to_bytes(KEYBITS // 8, 'big'))
+    return int.from_bytes(raw, 'big') % ORD or 1
+
+
+def hpkst_aggregate_pubkeys(pubkeys: 'list[BitArray]') -> 'tuple[BitArray, list[int]]':
+    """
+    Compute (C_agg, coefficients) with MuSig2 key-aggregation.
+    L = sorted pubkeys byte-strings concatenated.
+    C_agg = Π C_j^{μ_j}
+    Returns (C_agg BitArray, [μ_j ints]).
+    """
+    _poly = GF_POLY[KEYBITS]
+    L_bytes = b''.join(sorted(pk.uint.to_bytes(KEYBITS // 8, 'big') for pk in pubkeys))
+    coeffs  = [_hpkst_mu_coeff(L_bytes, pk) for pk in pubkeys]
+    agg_val = 1
+    for C_j, mu_j in zip(pubkeys, coeffs):
+        agg_val = gf_mul(agg_val,
+                         gf_pow(C_j.uint, mu_j, _poly, KEYBITS),
+                         _poly, KEYBITS)
+    return BitArray(KEYBITS, agg_val), coeffs
+
+
+def hpkst_sign(secrets: 'list[int]', pubkeys: 'list[BitArray]', msg: 'BitArray') -> 'tuple[BitArray, BitArray, BitArray]':
+    """
+    n-of-n threshold HPKS-NL sign.
+
+    secrets: [a_j ints] — private scalars for each signer
+    pubkeys: [C_j BitArrays] — public keys for each signer
+    msg:     BitArray — message (used as second input to NL-FSCX challenge)
+
+    Returns (C_agg, R, s) — the aggregate public key, nonce, and signature scalar.
+    Challenge e is implicit (re-derived during verify from R and msg).
+    """
+    _poly   = GF_POLY[KEYBITS]
+    C_agg, coeffs = hpkst_aggregate_pubkeys(pubkeys)
+    nonces  = [BitArray.random(KEYBITS) for _ in secrets]
+    R_parts = [BitArray(KEYBITS, gf_pow(GF_GEN, k.uint, _poly, KEYBITS)) for k in nonces]
+    R_val   = 1
+    for R_j in R_parts:
+        R_val = gf_mul(R_val, R_j.uint, _poly, KEYBITS)
+    R = BitArray(KEYBITS, R_val)
+    e = nl_fscx_revolve_v1(R, msg, I_VALUE)
+    s_val = 0
+    for a_j, k_j, mu_j in zip(secrets, nonces, coeffs):
+        s_j = (k_j.uint - a_j * mu_j * e.uint) % ORD
+        s_val = (s_val + s_j) % ORD
+    return C_agg, R, BitArray(KEYBITS, s_val)
+
+
+def hpkst_verify(C_agg: 'BitArray', R: 'BitArray', s: 'BitArray', msg: 'BitArray') -> bool:
+    """
+    Verify a threshold HPKS-NL signature.  Identical to single-party HPKS-NL verify:
+    g^s · C_agg^e == R   where e = nl_fscx_revolve_v1(R, msg, I_VALUE).
+    """
+    _poly = GF_POLY[KEYBITS]
+    e   = nl_fscx_revolve_v1(R, msg, I_VALUE)
+    lhs = gf_mul(gf_pow(GF_GEN, s.uint, _poly, KEYBITS),
+                 gf_pow(C_agg.uint, e.uint, _poly, KEYBITS),
+                 _poly, KEYBITS)
+    return lhs == R.uint
+
+
+# ---------------------------------------------------------------------------
 # 97 — HPKS-WOTS-F / HPKS-XMSS-F — Hash-based signatures (TODO #97)
 #
 # Hash chain:  h(x) = nl_fscx_revolve_v1(ROL(x, n/8), x, n/4)
@@ -2494,6 +2569,18 @@ def main():
         print(f"  [Bob,verify] : + HPKS-NL verified: g^s · C^e == R")
     else:
         print(f"  [Bob,verify] : - HPKS-NL verification failed!")
+
+    print("\n--- HPKS-T [THRESHOLD — n-of-n MuSig2-style aggregate Schnorr over GF(2^n)*]")
+    _t_n = 3  # 3-of-3 demo
+    _t_secrets = [BitArray.random(KEYBITS).uint for _ in range(_t_n)]
+    _t_pubkeys  = [BitArray(KEYBITS, gf_pow(GF_GEN, a_j, poly, KEYBITS)) for a_j in _t_secrets]
+    _t_cagg, _t_R, _t_s = hpkst_sign(_t_secrets, _t_pubkeys, plaintext)
+    _t_ok   = hpkst_verify(_t_cagg, _t_R, _t_s, plaintext)
+    _t_bad  = hpkst_verify(_t_cagg, _t_R, BitArray(KEYBITS, (_t_s.uint ^ 1)), plaintext)
+    if _t_ok and not _t_bad:
+        print(f"+ HPKS-T {_t_n}-of-{_t_n} sign/verify correct, tamper rejected")
+    else:
+        print(f"- HPKS-T FAILED: ok={_t_ok} bad={_t_bad}")
 
     print("\n--- HPKE-NL [NL-hardened El Gamal — NL-FSCX v2 encryption]")
     print("    (GF DLP still present; NL hardens linear HSKE sub-protocol)")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.42)
+# Herradura Cryptographic Suite (v1.9.43)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofsCode/hpks_threshold_demo.py
+++ b/SecurityProofsCode/hpks_threshold_demo.py
@@ -1,0 +1,411 @@
+"""
+hpks_threshold_demo.py — HPKS-T (Threshold/Aggregate Schnorr over GF(2^n)*)
+=============================================================================
+
+Demonstrates the n-of-n MuSig2-style threshold Schnorr signature scheme built
+on the HPKS-NL primitive.  Also proves the rogue-key attack and shows the
+coefficient-binding fix (MuSig2 key-aggregation coefficient).
+
+Mathematical basis
+------------------
+HPKS-NL sign (single-party):
+    s = (k − a·e) mod (2^n − 1)
+    Verify: g^s · C^e == R    where C = g^a, R = g^k
+
+n-of-n aggregation:
+    Each signer j has secret a_j, public C_j = g^{a_j}.
+    Aggregate key: C_agg = Π C_j = g^{Σ a_j}  (GF multiplication = exponent add mod ord)
+    Per-signer nonce: k_j random; R_j = g^{k_j}
+    Aggregate nonce: R = Π R_j = g^{Σ k_j}
+    Challenge: e = nl_fscx_revolve_v1(R, msg, n/4)
+    Per-signer response: s_j = (k_j − a_j·e) mod ord
+    Aggregate response: s = Σ s_j mod ord
+    Verify: g^s · C_agg^e == R   ✓  (because g^{Σ k_j − (Σ a_j)·e} = g^{Σ k_j} · (g^{Σ a_j})^{-e})
+
+Rogue-key attack (without key-aggregation coefficient):
+    Mallory announces C_M = g^{a_M} · C_victim^{-1}  (no proof of secret key)
+    Aggregate key becomes: C_agg = C_victim · C_M = g^{a_M}
+    Mallory can now sign alone — victim's key is cancelled.
+
+MuSig2 fix: key-aggregation coefficient μ_j = H(L, j) where L = sorted list of all pubkeys.
+    Effective secret: a_j' = a_j · μ_j mod ord
+    Effective pubkey: C_j' = C_j^{μ_j}
+    C_agg = Π C_j' = g^{Σ a_j·μ_j}
+    Mallory cannot pre-compute C_M to cancel C_victim because μ_j depends on L (which
+    includes C_M), creating a circular dependency — the attack collapses.
+
+Composite-modulus note (2^n − 1):
+    ord = 2^n − 1 is composite for all even n (Mersenne-number factorisation).
+    Shamir secret sharing over Z_{2^n−1} requires careful handling:
+    - Lagrange interpolation uses modular inverses; inverses exist only when gcd(divisor, ord)=1.
+    - Safe approach: perform Shamir sharing over a large prime q ≥ ord (embed mod q, reduce mod ord).
+    - Alternative: restrict to n-of-n (no threshold) which needs no inversion.
+    n=256: 2^256−1 factors as 3·5·17·257·641·65537·... (many small primes); naive Shamir
+    fails when a Lagrange denominator shares a factor with ord.  This demo restricts to n-of-n.
+
+References
+----------
+    HPKS-NL protocol: SecurityProofs-1.md §8 (classical), §11.3 (NL extension)
+    MuSig2: Nick, Ruffing, Seurin 2021 (https://eprint.iacr.org/2020/1261)
+    Bellare–Neven multi-sig: https://cseweb.ucsd.edu/~mihir/papers/multisig.pdf
+"""
+
+import hashlib
+import random
+import sys
+import os
+
+# ---------------------------------------------------------------------------
+# GF(2^n)* primitives (self-contained)
+# ---------------------------------------------------------------------------
+
+# n=256 irreducible polynomial: x^256 + x^10 + x^5 + x^2 + 1  (low bits = 0x425)
+GF_N    = 256
+GF_POLY = (1 << 256) | 0x425
+GF_GEN  = 3
+GF_ORD  = (1 << 256) - 1  # 2^256 − 1  (composite Mersenne number)
+
+
+def gf_mul(a: int, b: int, poly: int = GF_POLY, n: int = GF_N) -> int:
+    """Carryless GF(2^n) multiplication mod poly."""
+    result = 0
+    mask   = (1 << n) - 1
+    while b:
+        if b & 1:
+            result ^= a
+        a <<= 1
+        if a >> n:
+            a ^= poly
+        a &= mask
+        b >>= 1
+    return result
+
+
+def gf_pow(base: int, exp: int, poly: int = GF_POLY, n: int = GF_N) -> int:
+    """Square-and-multiply GF(2^n) exponentiation."""
+    result = 1
+    base   = base % ((1 << n) | 1)
+    while exp:
+        if exp & 1:
+            result = gf_mul(result, base, poly, n)
+        base = gf_mul(base, base, poly, n)
+        exp >>= 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# NL-FSCX v1 (self-contained, n=32 for speed in the demo script)
+# ---------------------------------------------------------------------------
+
+DEMO_N = 32   # use 32-bit for fast demo; the algebra is identical at n=256
+
+
+def _rol32(x: int, r: int) -> int:
+    r %= 32
+    return ((x << r) | (x >> (32 - r))) & 0xFFFFFFFF
+
+
+def _fscx32(a: int, b: int) -> int:
+    return (a ^ b ^ _rol32(a, 1) ^ _rol32(b, 1) ^ _rol32(a, 31) ^ _rol32(b, 31)) & 0xFFFFFFFF
+
+
+def _nl_add32(a: int, b: int) -> int:
+    return (a + b) & 0xFFFFFFFF
+
+
+def _nl_fscx_v1_step32(a: int, b: int) -> int:
+    return _fscx32(_nl_add32(a, b), b)
+
+
+def nl_fscx_revolve_v1_32(a: int, b: int, steps: int) -> int:
+    for _ in range(steps):
+        a = _nl_fscx_v1_step32(a, b)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# HPKS-NL (single-party) at n=32 for the demo
+# ---------------------------------------------------------------------------
+
+GF32_N    = 32
+GF32_POLY = (1 << 32) | 0x0000008D   # x^32+x^7+x^3+x^2+1
+GF32_GEN  = 3
+GF32_ORD  = (1 << 32) - 1
+DEMO_I    = GF32_N // 4              # = 8
+
+
+def _challenge32(R: int, msg: int) -> int:
+    return nl_fscx_revolve_v1_32(R, msg, DEMO_I)
+
+
+def hpks_nl_keygen_32() -> tuple:
+    """Returns (a, C) where C = g^a in GF(2^32)*."""
+    a = random.randint(1, GF32_ORD - 1)
+    C = gf_pow(GF32_GEN, a, GF32_POLY, GF32_N)
+    return a, C
+
+
+def hpks_nl_sign_32(a: int, k: int, msg: int) -> tuple:
+    """Single-party HPKS-NL sign. Returns (R, e, s)."""
+    R = gf_pow(GF32_GEN, k, GF32_POLY, GF32_N)
+    e = _challenge32(R, msg)
+    s = (k - a * e) % GF32_ORD
+    return R, e, s
+
+
+def hpks_nl_verify_32(C: int, R: int, e: int, s: int, msg: int) -> bool:
+    """Single-party HPKS-NL verify."""
+    lhs = gf_mul(gf_pow(GF32_GEN, s, GF32_POLY, GF32_N),
+                 gf_pow(C,          e, GF32_POLY, GF32_N), GF32_POLY, GF32_N)
+    return lhs == R
+
+
+# ---------------------------------------------------------------------------
+# Key-aggregation coefficient (MuSig2 style)
+# Using HFSCX-256 substitute: SHA-256 for the demo script
+# ---------------------------------------------------------------------------
+
+def _mu_coeff(L_bytes: bytes, j_pubkey: int) -> int:
+    """μ_j = H(L || C_j) mod GF32_ORD, where L = sorted concatenated pubkeys."""
+    h = hashlib.sha256(L_bytes + j_pubkey.to_bytes(4, 'big')).digest()
+    return int.from_bytes(h, 'big') % GF32_ORD or 1  # avoid 0
+
+
+def aggregate_pubkeys(pubkeys: list[int]) -> tuple:
+    """
+    Compute (C_agg, coefficients) with MuSig2 key-aggregation.
+    L = sorted pubkeys concatenated.
+    μ_j = H(L, C_j) mod ord
+    C_agg = Π C_j^{μ_j}
+    """
+    L_bytes = b''.join(sorted(pk.to_bytes(4, 'big') for pk in pubkeys))
+    coeffs  = [_mu_coeff(L_bytes, pk) for pk in pubkeys]
+    C_agg   = 1
+    for C_j, mu_j in zip(pubkeys, coeffs):
+        C_agg = gf_mul(C_agg,
+                       gf_pow(C_j, mu_j, GF32_POLY, GF32_N),
+                       GF32_POLY, GF32_N)
+    return C_agg, coeffs
+
+
+# ---------------------------------------------------------------------------
+# n-of-n threshold signing (MuSig2 key-aggregation, single-round nonce)
+# ---------------------------------------------------------------------------
+
+def hpks_threshold_sign(signers: list[tuple], msg: int) -> tuple:
+    """
+    n-of-n threshold HPKS-NL sign.
+
+    signers: list of (a_j, C_j) for j=0..n-1
+    msg:     32-bit message representative
+
+    Protocol:
+      1. Each signer picks nonce k_j, computes R_j = g^{k_j}.
+      2. Aggregate nonce: R = Π R_j.
+      3. Challenge: e = nl_fscx_revolve_v1(R, msg, I).
+      4. Each signer computes s_j = (k_j − a_j·μ_j·e) mod ord.
+      5. Aggregate: s = Σ s_j mod ord.
+    Returns (C_agg, R, e, s).
+    """
+    pubkeys = [C for _a, C in signers]
+    C_agg, coeffs = aggregate_pubkeys(pubkeys)
+
+    # Per-signer nonces
+    nonces  = [random.randint(1, GF32_ORD - 1) for _ in signers]
+    R_parts = [gf_pow(GF32_GEN, k, GF32_POLY, GF32_N) for k in nonces]
+
+    # Aggregate nonce R = Π R_j
+    R = 1
+    for R_j in R_parts:
+        R = gf_mul(R, R_j, GF32_POLY, GF32_N)
+
+    # Challenge (NL-FSCX v1)
+    e = _challenge32(R, msg)
+
+    # Per-signer partial signatures
+    s = 0
+    for j, ((a_j, _C_j), k_j, mu_j) in enumerate(zip(signers, nonces, coeffs)):
+        s_j = (k_j - a_j * mu_j * e) % GF32_ORD
+        s = (s + s_j) % GF32_ORD
+
+    return C_agg, R, e, s
+
+
+def hpks_threshold_verify(C_agg: int, R: int, e: int, s: int, msg: int) -> bool:
+    """Verify an aggregate HPKS-NL threshold signature — identical to single-party verify."""
+    lhs = gf_mul(gf_pow(GF32_GEN, s, GF32_POLY, GF32_N),
+                 gf_pow(C_agg,     e, GF32_POLY, GF32_N), GF32_POLY, GF32_N)
+    return lhs == R
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+def separator(title: str):
+    print(f"\n{'='*70}")
+    print(f"  {title}")
+    print('='*70)
+
+
+def demo_single_party():
+    separator("1. Single-party HPKS-NL baseline (n=32)")
+    a, C = hpks_nl_keygen_32()
+    msg  = random.randint(0, 0xFFFFFFFF)
+    k    = random.randint(1, GF32_ORD - 1)
+    R, e, s = hpks_nl_sign_32(a, k, msg)
+    ok = hpks_nl_verify_32(C, R, e, s, msg)
+    print(f"  a (priv) : {a:08x}")
+    print(f"  C (pub)  : {C:08x}")
+    print(f"  msg      : {msg:08x}")
+    print(f"  R        : {R:08x}")
+    print(f"  e        : {e:08x}")
+    print(f"  s        : {s:08x}")
+    print(f"  g^s·C^e  : {'== R  ✓ PASS' if ok else '≠ R  ✗ FAIL'}")
+
+
+def demo_rogue_key_attack():
+    separator("2. Rogue-key attack (naive aggregation, no coefficient binding)")
+    # Victim
+    a_v, C_v = hpks_nl_keygen_32()
+    # Mallory claims C_M = g^{a_M} · C_v^{-1}  (so C_v · C_M = g^{a_M})
+    a_M, _   = hpks_nl_keygen_32()
+    # GF mul inverse of C_v: g^{ord-1} · C_v in GF
+    C_v_inv  = gf_pow(C_v, GF32_ORD - 1, GF32_POLY, GF32_N)
+    g_aM     = gf_pow(GF32_GEN, a_M, GF32_POLY, GF32_N)
+    C_M_rogue = gf_mul(g_aM, C_v_inv, GF32_POLY, GF32_N)
+
+    # Naive aggregate (no coefficient): C_agg = C_v · C_M = g^{a_M}
+    C_agg_naive = gf_mul(C_v, C_M_rogue, GF32_POLY, GF32_N)
+    assert C_agg_naive == g_aM, "Rogue key did not cancel victim key"
+
+    # Mallory signs alone against the aggregate
+    msg  = random.randint(0, 0xFFFFFFFF)
+    k    = random.randint(1, GF32_ORD - 1)
+    R, e, s = hpks_nl_sign_32(a_M, k, msg)
+    ok = hpks_nl_verify_32(C_agg_naive, R, e, s, msg)
+
+    print(f"  Victim pubkey C_v     : {C_v:08x}")
+    print(f"  Mallory rogue C_M     : {C_M_rogue:08x}   (chosen to cancel C_v)")
+    print(f"  Naive C_agg = C_v·C_M : {C_agg_naive:08x}  == g^{{a_M}} = {g_aM:08x}")
+    print(f"  Mallory signs alone   : {'FORGED ✗  (attack succeeds)' if ok else 'failed'}")
+    print()
+    print("  → Naive key aggregation is INSECURE: Mallory can cancel any victim key.")
+
+
+def demo_threshold_2_of_2():
+    separator("3. 2-of-2 threshold HPKS-NL with MuSig2 key-aggregation coefficients")
+    a1, C1 = hpks_nl_keygen_32()
+    a2, C2 = hpks_nl_keygen_32()
+    msg    = random.randint(0, 0xFFFFFFFF)
+
+    C_agg, R, e, s = hpks_threshold_sign([(a1, C1), (a2, C2)], msg)
+    ok = hpks_threshold_verify(C_agg, R, e, s, msg)
+
+    print(f"  Signer 1: a={a1:08x}  C={C1:08x}")
+    print(f"  Signer 2: a={a2:08x}  C={C2:08x}")
+    print(f"  C_agg    : {C_agg:08x}  (keyed aggregate, rogue-key protected)")
+    print(f"  msg      : {msg:08x}")
+    print(f"  R (agg)  : {R:08x}")
+    print(f"  e        : {e:08x}")
+    print(f"  s (agg)  : {s:08x}")
+    print(f"  Verify   : {'✓ PASS' if ok else '✗ FAIL'}")
+
+
+def demo_threshold_3_of_3():
+    separator("4. 3-of-3 threshold HPKS-NL — tamper and wrong-key rejection")
+    signers = [hpks_nl_keygen_32() for _ in range(3)]
+    msg     = random.randint(0, 0xFFFFFFFF)
+
+    C_agg, R, e, s = hpks_threshold_sign(signers, msg)
+    ok_valid = hpks_threshold_verify(C_agg, R, e, s, msg)
+
+    # Tamper: flip one bit of s
+    s_bad  = s ^ 1
+    ok_bad = hpks_threshold_verify(C_agg, R, e, s_bad, msg)
+
+    # Wrong pubkey: replace C_agg with a random one
+    C_rand   = gf_pow(GF32_GEN, random.randint(1, GF32_ORD - 1), GF32_POLY, GF32_N)
+    ok_wrong = hpks_threshold_verify(C_rand, R, e, s, msg)
+
+    print(f"  3-of-3 sign+verify    : {'✓ PASS' if ok_valid else '✗ FAIL'}")
+    print(f"  Tampered s (s^1)      : {'✓ rejected' if not ok_bad else '✗ accepted (FAIL)'}")
+    print(f"  Wrong aggregate pubkey: {'✓ rejected' if not ok_wrong else '✗ accepted (FAIL)'}")
+
+
+def demo_coefficient_binding_blocks_rogue_key():
+    separator("5. MuSig2 coefficient binding blocks the rogue-key attack")
+    a_v, C_v = hpks_nl_keygen_32()
+    a_M, _   = hpks_nl_keygen_32()
+
+    # Mallory tries rogue key C_M such that keyed aggregate = g^{a_M}
+    # With coefficient binding: C_agg = C_v^{μ_v} · C_M^{μ_M}
+    # μ_j depends on L = {C_v, C_M}  ← circular: C_M affects its own μ_M
+    # Mallory cannot pre-compute C_M to cancel C_v^{μ_v} without solving
+    # a circular equation involving the hash.
+
+    # Best Mallory can do: pick C_M and compute what the aggregate becomes
+    g_aM  = gf_pow(GF32_GEN, a_M, GF32_POLY, GF32_N)
+    C_M   = gf_pow(GF32_GEN, a_M, GF32_POLY, GF32_N)   # honest announcement
+
+    C_agg, coeffs = aggregate_pubkeys([C_v, C_M])
+    mu_v, mu_M = coeffs
+
+    # Mallory tries to sign against C_agg using only a_M
+    # Would need a_eff = a_M·μ_M such that g^{a_eff·μ_M^{-1}} = C_M  ← consistent,
+    # but also needs contribution of C_v^{μ_v} which Mallory cannot forge without a_v.
+    msg = random.randint(0, 0xFFFFFFFF)
+    k   = random.randint(1, GF32_ORD - 1)
+    R   = gf_pow(GF32_GEN, k, GF32_POLY, GF32_N)
+    e   = _challenge32(R, msg)
+    s_mallory = (k - a_M * mu_M * e) % GF32_ORD   # Mallory's partial sig alone
+    ok_forge  = hpks_threshold_verify(C_agg, R, e, s_mallory, msg)
+
+    print(f"  μ_v = {mu_v:016x}")
+    print(f"  μ_M = {mu_M:016x}")
+    print(f"  C_agg (keyed) = {C_agg:08x}")
+    print(f"  Mallory partial-sig alone: {'✗ accepted (FAIL)' if ok_forge else '✓ rejected — attack blocked'}")
+
+
+def demo_composite_modulus_note():
+    separator("6. Composite-modulus note for t-of-n Shamir sharing")
+    from math import gcd
+    ord_val = GF32_ORD  # 2^32 − 1
+    # Factor: 2^32-1 = 3 × 5 × 17 × 257 × 65537
+    factors = [3, 5, 17, 257, 65537]
+    print(f"  GF32_ORD = 2^32 − 1 = {ord_val}")
+    print(f"  Known factors: {' × '.join(str(f) for f in factors)}")
+    print(f"  Product check: {' × '.join(str(f) for f in factors)} = {3*5*17*257*65537}")
+
+    # For Shamir, Lagrange denominator (i-j) must be invertible mod ord
+    # gcd(i-j, ord) = 1 iff (i-j) shares no factor with ord
+    # Example: if i-j = 3, gcd(3, ord) = 3 ≠ 1 → no inverse → Shamir fails
+    bad_diff = 3
+    print(f"\n  Shamir Lagrange denominator example: (i−j) = {bad_diff}")
+    print(f"  gcd({bad_diff}, ord) = {gcd(bad_diff, ord_val)} ≠ 1  → no modular inverse → Shamir FAILS")
+    print()
+    print("  Safe approaches for t-of-n over composite ord:")
+    print("  A. Embed secret in a prime field q > ord (e.g. nearest prime above 2^32−1)")
+    print("     → share mod q, sign mod ord; works but requires prime arithmetic")
+    print("  B. Restrict to n-of-n (no threshold), avoiding Lagrange inversion entirely")
+    print("  C. Ensure signer indices chosen so (i−j) is coprime to ord for all pairs")
+    print("     → restrictive; not general; fragile if signers drop out")
+    print()
+    print("  This demo restricts to n-of-n (approach B) — t-of-n is future work (TODO #106).")
+
+
+if __name__ == '__main__':
+    print("HPKS-T: Threshold/Aggregate Schnorr over GF(2^n)*")
+    print("MuSig2-style key aggregation with NL-FSCX v1 challenge")
+    print(f"Demo uses n={GF32_N} for speed; production uses n=256.\n")
+
+    demo_single_party()
+    demo_rogue_key_attack()
+    demo_threshold_2_of_2()
+    demo_threshold_3_of_3()
+    demo_coefficient_binding_blocks_rogue_key()
+    demo_composite_modulus_note()
+
+    print("\n" + "="*70)
+    print("  All demos complete.")
+    print("="*70)

--- a/TODO.md
+++ b/TODO.md
@@ -5995,7 +5995,7 @@ challenge weakness.
 2-party demo, rogue-key counterexample, composite-modulus discussion); promote to suite
 functions only after the rogue-key binding design is fixed.
 
-Status: **OPEN**
+Status: **DONE v1.9.43**
 
 ---
 
@@ -6155,3 +6155,49 @@ Status: **DONE v1.9.41**
 2. Add a `[asm-14]` (or next available number after TODO #103) dedicated ZKP-RNL test assertion to `CryptosuiteTests/Herradura_tests.s` and `CryptosuiteTests/Herradura_tests.asm` (both currently run ZKP-RNL in the demo flow but have no test file assertion).
 
 Status: **DONE v1.9.40**
+
+---
+
+### 106. CLI multi-party threshold signature capability for files (CLI Extension, Medium)
+
+**Discovered:** TODO #98 implementation plan, 2026-06-14.
+
+**Goal:** Extend `HerraduraCli/` (Python, C, Go) to support n-of-n threshold (HPKS-T) signing and verification of files, following the same PEM wire format as single-party `sign`/`verify`.
+
+**Design:**
+
+The threshold workflow is a 3-phase protocol over files:
+
+1. **Phase 1 — Commitment round** (`sign --threshold commit`):
+   - Each signer generates a fresh nonce k_j, computes R_j = g^{k_j}, writes a "commitment PEM" (`HPKST COMMITMENT`).
+   - Output: `{signer}_commit.pem` containing R_j (public nonce) and the signer's public key C_j.
+   - Private nonce k_j is saved to `{signer}_nonce.pem` (`HPKST NONCE`, kept secret, deleted after signing).
+
+2. **Phase 2 — Aggregation** (`sign --threshold aggregate`):
+   - A coordinator collects all commitment PEMs and the file to sign.
+   - Computes R = Π R_j, C_agg = Π C_j^{μ_j}, e = NL-FSCX(R, msg_hash).
+   - Broadcasts an "aggregate PEM" (`HPKST AGGREGATE`) containing R, C_agg, e to all signers.
+
+3. **Phase 3 — Response round** (`sign --threshold respond`):
+   - Each signer reads aggregate PEM and their nonce PEM, computes s_j = (k_j − a_j·μ_j·e) mod ord.
+   - Writes a "partial signature PEM" (`HPKST PARTIAL`).
+
+4. **Final — Combine** (`sign --threshold combine`):
+   - Coordinator collects all partial PEMs, computes s = Σ s_j mod ord.
+   - Writes final signature file (`HPKST SIGNATURE`) containing C_agg, R, s.
+   - Identical format to `HPKS SIGNATURE` — can be verified with `verify`.
+
+5. **Verify** (`verify --algo hpks-t`):
+   - Reads `HPKST SIGNATURE`, verifies g^s · C_agg^e == R (same as single-party verify).
+
+**Work items:**
+1. Define PEM types: `HPKST COMMITMENT`, `HPKST NONCE`, `HPKST AGGREGATE`, `HPKST PARTIAL`, `HPKST SIGNATURE` in `HerraduraCli/herradura_codec.h` and `HerraduraCli/codec.py`.
+2. Add `sign --threshold commit/aggregate/respond/combine` subcommand flow to Python CLI (`HerraduraCli/herradura.py`).
+3. Add same to C CLI (`HerraduraCli/herradura_cli.c`).
+4. Add same to Go CLI (`HerraduraCli/herradura_cli.go`).
+5. Add CLI integration tests to `CliTest/test_threshold_sign.sh` and `CliTest/test_threshold_interop.sh` (cross-language: Python commits + Go responds + C combines).
+6. Document in `docs/TUTORIAL.md` under a new "Threshold Signing" section.
+
+**Note:** The `hpkst_sign`/`HpkstSign` library functions perform all rounds internally (for demos/tests). The CLI must expose the individual rounds so that different parties can run different phases on different machines.
+
+Status: OPEN

--- a/herradura.h
+++ b/herradura.h
@@ -3064,6 +3064,205 @@ static int hpake_login_demo(uint8_t session_key[KEYBYTES],
     return 1;
 }
 
+/* Generator as BitArray alias (value 3, same as GF_GEN). */
+#define GF_GEN_BA GF_GEN
+
+/* dst = (a + b) mod (2^256-1) */
+static void ba_add_mod_ord(BitArray *dst, const BitArray *a, const BitArray *b)
+{
+    uint16_t carry = 0;
+    int i, all_ff;
+    for (i = KEYBYTES - 1; i >= 0; i--) {
+        uint16_t s = (uint16_t)a->b[i] + (uint16_t)b->b[i] + carry;
+        dst->b[i] = (uint8_t)s;
+        carry = s >> 8;
+    }
+    if (carry) {
+        /* wrapped: add 1 (because 2^256 mod (2^256-1) = 1) */
+        uint16_t add1 = 1;
+        for (i = KEYBYTES - 1; i >= 0; i--) {
+            uint16_t s = (uint16_t)dst->b[i] + add1;
+            dst->b[i] = (uint8_t)s;
+            add1 = s >> 8;
+            if (!add1) break;
+        }
+    }
+    /* 2^256-1 is the identity for addition mod ord; map it to 0 */
+    all_ff = 1;
+    for (i = 0; i < KEYBYTES; i++) all_ff &= (dst->b[i] == 0xFF);
+    if (all_ff) memset(dst->b, 0, KEYBYTES);
+}
+
+/* Aliases used by hpkst_sign */
+#define _ba_mod_mul_ord ba_mul_mod_ord
+#define _ba_mod_sub_ord ba_sub_mod_ord
+#define _ba_mod_add_ord ba_add_mod_ord
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 98 — HPKS-T: Threshold / Aggregate Schnorr over GF(2^n)* (TODO #98)
+ *
+ * n-of-n MuSig2-style key aggregation with NL-FSCX v1 challenge.
+ * μ_j = HFSCX-256(L || C_j_bytes) mod ord  (rogue-key binding)
+ * C_agg = Π C_j^{μ_j}
+ * Sign:   R = Π R_j;  e = nl_fscx_revolve_v1(R, msg, n/4);
+ *         s_j = (k_j − a_j·μ_j·e) mod ord;  s = Σ s_j mod ord
+ * Verify: g^s · C_agg^e == R  (identical to single-party HPKS-NL verify)
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/* Compute μ_j = HFSCX-256(L_bytes, llen || C_j.b) mod ord, result in mu_out.
+ * ord = 2^KEYBITS − 1 treated as a big-endian KEYBYTES-byte value. */
+static void _hpkst_mu_coeff(const uint8_t *L_bytes, size_t llen,
+                              const BitArray *C_j, uint8_t mu_out[KEYBYTES])
+{
+    uint8_t *buf = (uint8_t *)malloc(llen + KEYBYTES);
+    if (!buf) { fprintf(stderr, "_hpkst_mu_coeff: oom\n"); exit(1); }
+    memcpy(buf, L_bytes, llen);
+    memcpy(buf + llen, C_j->b, KEYBYTES);
+    hfscx_256(buf, llen + KEYBYTES, NULL, mu_out);
+    free(buf);
+    /* mu mod ord: ord = 0xFF...FF (all ones); result is already in [0,2^n-1].
+     * If all-zero, set to 1. */
+    int all_zero = 1;
+    for (int i = 0; i < KEYBYTES; i++) if (mu_out[i]) { all_zero = 0; break; }
+    if (all_zero) mu_out[KEYBYTES-1] = 1;
+}
+
+/* Compute C_agg = Π C_j^{μ_j} with key-aggregation coefficients.
+ * pubkeys: array of n BitArrays.  mu_out: array of n uint8_t[KEYBYTES] (caller allocs).
+ * L_bytes must be the sorted concatenation of all pubkey bytes. */
+static void _hpkst_aggregate(const BitArray *pubkeys, size_t n,
+                               const uint8_t *L_bytes, size_t llen,
+                               uint8_t (*mu_out)[KEYBYTES],
+                               BitArray *C_agg)
+{
+    memset(C_agg->b, 0, KEYBYTES);
+    C_agg->b[KEYBYTES-1] = 1;  /* start at 1 */
+    for (size_t j = 0; j < n; j++) {
+        _hpkst_mu_coeff(L_bytes, llen, &pubkeys[j], mu_out[j]);
+        BitArray mu_ba, Cj_pow;
+        memcpy(mu_ba.b, mu_out[j], KEYBYTES);
+        gf_pow_ba(&Cj_pow, &pubkeys[j], &mu_ba);
+        gf_mul_ba(C_agg, C_agg, &Cj_pow);
+    }
+}
+
+/* Build sorted L_bytes from pubkeys array. Caller frees result. */
+static uint8_t *_hpkst_build_L(const BitArray *pubkeys, size_t n, size_t *llen_out)
+{
+    /* collect and sort KEYBYTES-byte representations */
+    uint8_t (*sorted)[KEYBYTES] = (uint8_t (*)[KEYBYTES])malloc(n * KEYBYTES);
+    if (!sorted) { fprintf(stderr, "_hpkst_build_L: oom\n"); exit(1); }
+    for (size_t j = 0; j < n; j++) memcpy(sorted[j], pubkeys[j].b, KEYBYTES);
+    /* bubble sort (small n) */
+    for (size_t i = 0; i < n; i++)
+        for (size_t j = i+1; j < n; j++)
+            if (memcmp(sorted[i], sorted[j], KEYBYTES) > 0) {
+                uint8_t tmp[KEYBYTES];
+                memcpy(tmp, sorted[i], KEYBYTES);
+                memcpy(sorted[i], sorted[j], KEYBYTES);
+                memcpy(sorted[j], tmp, KEYBYTES);
+            }
+    *llen_out = n * KEYBYTES;
+    return (uint8_t *)sorted;
+}
+
+/* HPKS-T n-of-n sign.
+ * secrets[n]: private scalars (BitArray, each < ord).
+ * pubkeys[n]: corresponding public keys C_j = g^{a_j}.
+ * msg:        message BitArray (NL-FSCX v1 challenge input).
+ * Outputs: C_agg, R, s.
+ * Caller must supply per-signer random nonces in nonces[n] (fresh BitArrays).
+ * Pass NULL for nonces to generate internally from /dev/urandom. */
+static void hpkst_sign(const BitArray *secrets, const BitArray *pubkeys, size_t n,
+                        const BitArray *msg, const BitArray *nonces_in,
+                        BitArray *C_agg_out, BitArray *R_out, BitArray *s_out,
+                        FILE *urnd)
+{
+    size_t llen;
+    uint8_t *L_bytes = _hpkst_build_L(pubkeys, n, &llen);
+    uint8_t (*mu)[KEYBYTES] = (uint8_t (*)[KEYBYTES])malloc(n * KEYBYTES);
+    if (!mu) { fprintf(stderr, "hpkst_sign: oom\n"); exit(1); }
+
+    _hpkst_aggregate(pubkeys, n, L_bytes, llen, mu, C_agg_out);
+
+    /* Per-signer nonces */
+    BitArray *nonces = (BitArray *)malloc(n * sizeof(BitArray));
+    if (!nonces) { fprintf(stderr, "hpkst_sign: oom\n"); exit(1); }
+    for (size_t j = 0; j < n; j++) {
+        if (nonces_in) nonces[j] = nonces_in[j];
+        else           ba_rand(&nonces[j], urnd);
+    }
+
+    /* R = Π g^{k_j} */
+    memset(R_out->b, 0, KEYBYTES); R_out->b[KEYBYTES-1] = 1;
+    for (size_t j = 0; j < n; j++) {
+        BitArray R_j;
+        gf_pow_ba(&R_j, &GF_GEN_BA, &nonces[j]);
+        gf_mul_ba(R_out, R_out, &R_j);
+    }
+
+    /* e = nl_fscx_revolve_v1(R, msg, I_VALUE) */
+    BitArray e;
+    nl_fscx_revolve_v1_ba(&e, R_out, msg, I_VALUE);
+
+    /* s = Σ (k_j − a_j·μ_j·e) mod ord */
+    /* Use 512-bit intermediate to avoid overflow: keep mod ord per step */
+    uint64_t s_acc[KEYBYTES/8] = {0};  /* simple big-int accumulator */
+    /* For simplicity use BitArray arithmetic mod ord (already defined): */
+    memset(s_out->b, 0, KEYBYTES);
+    for (size_t j = 0; j < n; j++) {
+        /* mu_j as BitArray */
+        BitArray mu_ba;
+        memcpy(mu_ba.b, mu[j], KEYBYTES);
+        /* a_j * mu_j mod ord (integer multiply mod 2^n-1) */
+        /* Use gf_mul for GF multiply? No — this is integer multiply mod ord. */
+        /* Compute via Python-style: (a_j.uint * mu_j.uint * e.uint) mod ord */
+        /* We need big-integer multiply mod ord.  Use a helper. */
+        /* Strategy: compute via ba_mod_mul helper below. */
+        /* s_j = (k_j - a_j*mu_j*e) mod ord */
+        /* Since all values fit in KEYBYTES bytes and ord = 2^n-1, we implement
+         * the modular multiply as:  a * b mod (2^n-1)  via the identity
+         * a * b mod (2^n-1) = ((a*b) >> n) + (a*b & (2^n-1))  iterated. */
+        /* For correctness we use __int128 for n=32; for n=256 we need a
+         * proper big-int.  Use OpenSSL BN or manual implementation.
+         * Since herradura.h has no OpenSSL dep, implement a simple 256-bit
+         * multiply-mod-ord using the schoolbook method. */
+
+        /* ---- ba_mod_mul: multiply two KEYBITS-wide values mod 2^KEYBITS-1 ---- */
+        /* result = (a * b) mod (2^n - 1) */
+        /* We compute via repeated doubling and reduction. */
+        /* a_j * mu_ba mod ord */
+        BitArray am;
+        _ba_mod_mul_ord(&am, &secrets[j], &mu_ba);
+        /* am * e mod ord */
+        BitArray ame;
+        _ba_mod_mul_ord(&ame, &am, &e);
+        /* s_j = (k_j - ame) mod ord */
+        BitArray s_j;
+        _ba_mod_sub_ord(&s_j, &nonces[j], &ame);
+        /* s_out += s_j mod ord */
+        BitArray tmp;
+        _ba_mod_add_ord(&tmp, s_out, &s_j);
+        *s_out = tmp;
+    }
+
+    free(nonces);
+    free(mu);
+    free(L_bytes);
+}
+
+/* Verify a threshold HPKS-NL signature — identical to single-party verify. */
+static int hpkst_verify(const BitArray *C_agg, const BitArray *R,
+                         const BitArray *s, const BitArray *msg)
+{
+    BitArray e, gs, Ce, lhs;
+    nl_fscx_revolve_v1_ba(&e, R, msg, I_VALUE);
+    gf_pow_ba(&gs, &GF_GEN_BA, s);
+    gf_pow_ba(&Ce, C_agg, &e);
+    gf_mul_ba(&lhs, &gs, &Ce);
+    return ba_equal(&lhs, R);
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
  * 97 — HPKS-WOTS-F / HPKS-XMSS-F — Hash-based signatures (TODO #97/#102)
  *

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -2562,3 +2562,125 @@ func RatchetAdvance(state *BitArray) (*BitArray, []byte) {
 	next    := NlFscxRevolveV1(state, ratchetDomain, 1)
 	return next, msgKey
 }
+
+// ---------------------------------------------------------------------------
+// 98 — HPKS-T: Threshold / Aggregate Schnorr over GF(2^n)* (TODO #98)
+//
+// n-of-n MuSig2-style key aggregation with NL-FSCX v1 challenge.
+// μ_j = HFSCX-256(L || C_j_bytes) mod ord  (rogue-key binding)
+// C_agg = Π C_j^{μ_j}
+// Sign:   R = Π R_j;  e = NlFscxRevolveV1(R, msg, n/4);
+//         s_j = (k_j − a_j·μ_j·e) mod ord;  s = Σ s_j mod ord
+// Verify: g^s · C_agg^e == R
+// ---------------------------------------------------------------------------
+
+var hpkstOrd  = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)) // 2^256-1
+var hpkstPoly = GfPoly[256]
+const hpkstN  = 256
+
+func hpkstMuCoeff(lBytes []byte, cj *big.Int) *big.Int {
+	cjB := make([]byte, 32)
+	cj.FillBytes(cjB)
+	buf := append(append([]byte(nil), lBytes...), cjB...)
+	h   := Hfscx256(buf, nil)
+	mu  := new(big.Int).SetBytes(h)
+	mu.Mod(mu, hpkstOrd)
+	if mu.Sign() == 0 {
+		mu.SetInt64(1)
+	}
+	return mu
+}
+
+func hpkstBuildL(pubkeys []*big.Int) []byte {
+	sorted := make([][]byte, len(pubkeys))
+	for i, pk := range pubkeys {
+		b := make([]byte, 32)
+		pk.FillBytes(b)
+		sorted[i] = b
+	}
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && bytes.Compare(sorted[j-1], sorted[j]) > 0; j-- {
+			sorted[j-1], sorted[j] = sorted[j], sorted[j-1]
+		}
+	}
+	var out []byte
+	for _, b := range sorted {
+		out = append(out, b...)
+	}
+	return out
+}
+
+// HpkstAggregatePublickeys computes C_agg = Π C_j^{μ_j} and returns (C_agg, μ coefficients).
+// pubkeys are GF elements (big.Int values).
+func HpkstAggregatePublickeys(pubkeys []*big.Int) (*big.Int, []*big.Int) {
+	lBytes := hpkstBuildL(pubkeys)
+	coeffs := make([]*big.Int, len(pubkeys))
+	for i, pk := range pubkeys {
+		coeffs[i] = hpkstMuCoeff(lBytes, pk)
+	}
+	agg := big.NewInt(1)
+	for i, pk := range pubkeys {
+		pkMu := GfPow(pk, coeffs[i], hpkstPoly, hpkstN)
+		agg   = GfMul(agg, pkMu, hpkstPoly, hpkstN)
+	}
+	return agg, coeffs
+}
+
+// HpkstSign produces a threshold signature over msg.
+// secrets and pubkeys are GF scalars and elements (big.Int).
+// Returns (C_agg, R, s) as BitArrays for use with NlFscxRevolveV1.
+func HpkstSign(secrets, pubkeys []*big.Int, msg []byte) (*big.Int, *big.Int, *big.Int) {
+	n    := len(secrets)
+	gGen := big.NewInt(3)
+	cAgg, coeffs := HpkstAggregatePublickeys(pubkeys)
+
+	nonces := make([]*big.Int, n)
+	for j := range nonces {
+		k := make([]byte, 32)
+		rand.Read(k) //nolint:errcheck
+		nonces[j] = new(big.Int).SetBytes(k)
+	}
+
+	// R = Π g^{k_j}
+	R := big.NewInt(1)
+	for j := 0; j < n; j++ {
+		Rj := GfPow(gGen, nonces[j], hpkstPoly, hpkstN)
+		R   = GfMul(R, Rj, hpkstPoly, hpkstN)
+	}
+
+	// e = NlFscxRevolveV1(R_ba, msg_ba, 64)
+	RBa   := NewBitArray(256, R)
+	msgBa := NewBitArray(256, new(big.Int).SetBytes(msg))
+	eBa   := NlFscxRevolveV1(RBa, msgBa, 64)
+	eBig  := new(big.Int).SetBytes(eBa.Bytes())
+
+	// s = Σ (k_j - a_j·μ_j·e) mod ord
+	sAcc := big.NewInt(0)
+	for j := 0; j < n; j++ {
+		ame := new(big.Int).Mul(secrets[j], coeffs[j])
+		ame.Mul(ame, eBig)
+		ame.Mod(ame, hpkstOrd)
+		sj := new(big.Int).Sub(nonces[j], ame)
+		sj.Mod(sj, hpkstOrd)
+		if sj.Sign() < 0 {
+			sj.Add(sj, hpkstOrd)
+		}
+		sAcc.Add(sAcc, sj)
+		sAcc.Mod(sAcc, hpkstOrd)
+	}
+
+	return cAgg, R, sAcc
+}
+
+// HpkstVerify checks g^s · C_agg^e == R.
+func HpkstVerify(cAgg, R, s *big.Int, msg []byte) bool {
+	gGen  := big.NewInt(3)
+	RBa   := NewBitArray(256, R)
+	msgBa := NewBitArray(256, new(big.Int).SetBytes(msg))
+	eBa   := NlFscxRevolveV1(RBa, msgBa, 64)
+	eBig  := new(big.Int).SetBytes(eBa.Bytes())
+	gs    := GfPow(gGen, s, hpkstPoly, hpkstN)
+	Ce    := GfPow(cAgg, eBig, hpkstPoly, hpkstN)
+	lhs   := GfMul(gs, Ce, hpkstPoly, hpkstN)
+	return lhs.Cmp(R) == 0
+}


### PR DESCRIPTION
## Summary

- Implements HPKS-T (MuSig2-style n-of-n threshold Schnorr) in Python, C, and Go with coefficient binding to prevent rogue-key attacks
- Adds `ba_add_mod_ord`, `GF_GEN_BA`, `hpkst_sign`/`hpkst_verify` to `herradura.h`; `HpkstSign`/`HpkstVerify` to `herradura/herradura.go`
- Adds security test [31] in all three test files (C/Go/Python); benchmarks renumbered [32]–[43]
- Adds `SecurityProofsCode/hpks_threshold_demo.py` standalone analysis script
- Adds TODO #106 for CLI multi-party threshold signing capability (4-phase commit/aggregate/respond/combine protocol)

## Protocol

μ_j = HFSCX-256(L ∥ C_j) mod ord; C_agg = Π C_j^{μ_j}; R = Π g^{k_j}; e = nl_fscx_revolve_v1(R, msg, n/4); s = Σ (k_j − a_j·μ_j·e) mod ord. Verify: g^s · C_agg^e == R.

## Test plan

- [ ] C suite: `./Herradura\ cryptographic\ suite_c` — check `HPKS-T 3-of-3 sign/verify correct, tamper rejected`
- [ ] Go suite: `go run Herradura\ cryptographic\ suite.go` — check `HPKS-T 3-of-3 sign/verify correct, tamper rejected`
- [ ] Python suite: `python3 Herradura\ cryptographic\ suite.py` — check same
- [ ] C tests: `./CryptosuiteTests/Herradura_tests_c -r 2` → `[31] ... [PASS]`
- [ ] Go tests: `cd CryptosuiteTests && go run Herradura_tests.go -r 2` → `[31] ... [PASS]`
- [ ] Python tests: `python3 CryptosuiteTests/Herradura_tests.py -r 2` → `[31] ... [PASS]`
- [ ] Analysis: `python3 SecurityProofsCode/hpks_threshold_demo.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)