### PR TITLE
Tutorial documentation gaps — TODOs #107–#117 — v1.9.50→v1.9.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.60] - 2026-06-15
+
+### Documentation — HPKS-WOTS-F / HPKS-XMSS-F tutorial examples (TODO #111)
+
+- **`docs/TUTORIAL.md`:** added `### HPKS-WOTS-F / HPKS-XMSS-F (hash-based
+  stateful signatures)` subsections to C, Go, and Python integration sections,
+  inserted after the `### HPKE-Stern-F KEM` subsection.  Each snippet shows
+  keygen, sign, and verify for both WOTS-F (one-time) and XMSS-F (multi-use
+  Merkle tree) with a prominent statefulness warning.
+- Added a `### Hash-based stateful signatures` table to the protocol reference
+  section listing both constructions, their hard problem, and their
+  single-use/multi-use characterisation.
+
+---
+
 ## [1.9.59] - 2026-06-15
 
 ### Documentation — HDRBG tutorial examples (TODO #110)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.54] - 2026-06-15
+
+### Documentation — HSKE-NL-AEAD tutorial coverage (TODO #109)
+
+- **`docs/TUTORIAL.md`:** added `### HSKE-NL-AEAD authenticated encryption (NL/PQC)`
+  subsections to C, Go, and Python integration sections showing encrypt/decrypt
+  with associated data (AAD) and nonce handling.  Added `### Authenticated
+  encryption (HSKE-NL-AEAD)` subsection to the CLI quickstart covering the
+  `--aead` and `--ad` flags with a cross-reference to `CliTest/test_aead.sh`.
+  Added HSKE-NL-AEAD row to the NL/PQC protocol reference table.  Added security
+  notes on nonce reuse and key commitment to the NL/PQC security section.
+
+---
+
 ## [1.9.53] - 2026-06-15
 
 ### Documentation — HSKE-NL-A2 C and Go tutorial examples (TODO #108)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.50] - 2026-06-15
+
+### Documentation fix — Go OPRF tutorial import path (TODO #114)
+
+- **`docs/TUTORIAL.md`:** corrected the Go OPRF snippet import from `"herradurakex"` to
+  `import h "herradurakex/herradura"` and updated all call sites to use the `h.` prefix.
+  The OPRF functions (`OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`)
+  live in the `herradura` package, not the root module; the previous import would fail
+  to compile.
+
+---
+
 ## [1.9.49] - 2026-06-15
 
 ### Security — HKEX-RNL contributory KDF (TODO #89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.56] - 2026-06-15
+
+### Documentation — aPAKE C and Go library API (TODO #116)
+
+- **`docs/TUTORIAL.md`:** added `### aPAKE library API (C)` and `### aPAKE library
+  API (Go)` subsections to the `## OPRF and aPAKE` section, before the existing
+  Python CLI usage subsection.  C snippet shows `HpakeRecord`, `hpake_register`,
+  and `hpake_login_demo` from `herradura.h`.  Go snippet shows `HpakeRegister` and
+  `HpakeLoginDemo` from the `herradura` package.  Updated the aPAKE CLI note and
+  the OPRF/aPAKE reference table to reflect that the library API is available in
+  C, Go, and Python, while the CLI flow is Python-only.  Updated the Python
+  integration section note accordingly.
+
+---
+
 ## [1.9.55] - 2026-06-15
 
 ### Documentation — HPKS-NL and HPKE-NL tutorial examples (TODO #107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.51] - 2026-06-15
+
+### Documentation — Go tutorial HPKS and HPKE examples (TODO #113)
+
+- **`docs/TUTORIAL.md`:** added `### HPKS Schnorr signature (classical)` and
+  `### HPKE El Gamal encryption (classical)` subsections to the Go integration
+  section, between `### HSKE symmetric encryption` and `### HSKE-NL-A1`.
+  Both snippets use the same primitives (`GfPow`, `GfMul`, `FscxRevolve`) as the
+  existing Go HKEX-GF and HSKE examples, and mirror the structure of the C section.
+
+---
+
 ## [1.9.50] - 2026-06-15
 
 ### Documentation fix — Go OPRF tutorial import path (TODO #114)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.57] - 2026-06-15
+
+### Documentation — threshold signing library API (TODO #115)
+
+- **`docs/TUTORIAL.md`:** added `### Library API` subsection to
+  `## Threshold Signing (HPKS-T)`, before the closing `---`.  Shows
+  `hpkst_sign` / `hpkst_verify` in C, `HpkstSign` / `HpkstVerify` in Go,
+  and `hpkst_sign` / `hpkst_verify` in Python, each with a 3-of-3 demo.
+  The subsection intro clearly distinguishes the all-in-one library call
+  (for demos/tests/single-process simulations) from the 4-phase CLI workflow
+  (for real multi-party deployments where signers run independently).
+
+---
+
 ## [1.9.56] - 2026-06-15
 
 ### Documentation — aPAKE C and Go library API (TODO #116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.53] - 2026-06-15
+
+### Documentation — HSKE-NL-A2 C and Go tutorial examples (TODO #108)
+
+- **`docs/TUTORIAL.md`:** added `### HSKE-NL-A2 symmetric encryption (NL/PQC)`
+  subsections to both the C and Go integration sections, immediately after the
+  existing HSKE-NL-A1 subsection.  C snippet uses `nl_fscx_revolve_v2_ba` /
+  `nl_fscx_revolve_v2_inv_ba` from `herradura.h`; Go snippet uses
+  `NlFscxRevolveV2` / `NlFscxRevolveV2Inv` from the `herradura` package.
+  Both include a brief note that A2 is bijective and requires no nonce.
+
+---
+
 ## [1.9.52] - 2026-06-15
 
 ### Documentation — CLI quickstart section (TODO #112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.52] - 2026-06-15
+
+### Documentation — CLI quickstart section (TODO #112)
+
+- **`docs/TUTORIAL.md`:** added `## CLI quickstart` as the first major section
+  (before the language integration sections), with subsections covering:
+  key generation and inspection (`genpkey`, `pkey --text`), HKEX-GF key exchange
+  (`kex`), HSKE encryption/decryption (`enc`/`dec`), HPKS sign/verify, HPKE
+  El Gamal encryption, and the two-round HKEX-RNL workflow.  Notes that all three
+  CLIs share identical subcommands and cross-references `CliTest/` for full
+  integration tests.  Contents list updated to include the new section as item 1.
+
+---
+
 ## [1.9.51] - 2026-06-15
 
 ### Documentation — Go tutorial HPKS and HPKE examples (TODO #113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.59] - 2026-06-15
+
+### Documentation — HDRBG tutorial examples (TODO #110)
+
+- **`docs/TUTORIAL.md`:** added `### HDRBG (forward-secure DRBG)` subsections
+  to C, Go, and Python integration sections, inserted after the existing
+  `### HFSCX-256 hash and MAC` subsection.  Each snippet shows seed, generate,
+  and reseed usage.  Added a note in the C integration section intro that
+  `HDrbg` can substitute for `/dev/urandom` on embedded targets without a
+  filesystem.
+
+---
+
 ## [1.9.58] - 2026-06-15
 
 ### Documentation — HPKE-Stern-F KEM tutorial examples (TODO #117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.58] - 2026-06-15
+
+### Documentation — HPKE-Stern-F KEM tutorial examples (TODO #117)
+
+- **`docs/TUTORIAL.md`:** added `### HPKE-Stern-F KEM (code-based PQC, demo)`
+  subsections to C, Go, and Python integration sections, inserted after the
+  existing HPKS-Stern-F subsection.  Each snippet shows keygen (shared with
+  HPKS-Stern-F), encapsulation (`hpke_stern_f_encap` / `HpkeSternFEncap` /
+  `hpke_stern_f_encap_with_e`), and demo decapsulation using the known error
+  vector (`hpke_stern_f_decap_known` / `HpkeSternFDecapKnown` /
+  `hpke_stern_f_decap`).  Each snippet includes a prominent note that
+  production decapsulation requires a QC-MDPC decoder to recover `e'` from
+  the syndrome.
+
+---
+
 ## [1.9.57] - 2026-06-15
 
 ### Documentation — threshold signing library API (TODO #115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.55] - 2026-06-15
+
+### Documentation — HPKS-NL and HPKE-NL tutorial examples (TODO #107)
+
+- **`docs/TUTORIAL.md`:** added `### HPKS-NL Schnorr signature (NL/PQC)` and
+  `### HPKE-NL El Gamal encryption (NL/PQC)` subsections to the C, Go, and
+  Python integration sections, inserted after the classical HPKE subsection and
+  before HSKE-NL-A1.  Each snippet notes that the public key is a GF(2^256)*
+  element (same as HPKS/HPKE) and that only the challenge (HPKS-NL) or symmetric
+  sub-protocol (HPKE-NL) is hardened with NL-FSCX.
+
+---
+
 ## [1.9.54] - 2026-06-15
 
 ### Documentation — HSKE-NL-AEAD tutorial coverage (TODO #109)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.53)
+# Herradura Cryptographic Suite (v1.9.54)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.55)
+# Herradura Cryptographic Suite (v1.9.56)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.59)
+# Herradura Cryptographic Suite (v1.9.60)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.58)
+# Herradura Cryptographic Suite (v1.9.59)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.56)
+# Herradura Cryptographic Suite (v1.9.57)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.51)
+# Herradura Cryptographic Suite (v1.9.52)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.52)
+# Herradura Cryptographic Suite (v1.9.53)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.57)
+# Herradura Cryptographic Suite (v1.9.58)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.54)
+# Herradura Cryptographic Suite (v1.9.55)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.50)
+# Herradura Cryptographic Suite (v1.9.51)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.49)
+# Herradura Cryptographic Suite (v1.9.50)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6373,4 +6373,4 @@ Status: **DONE v1.9.56**
 1. Add a `### HPKE-Stern-F KEM (code-based PQC, demo)` subsection to the C, Go, and Python integration sections showing keygen, encapsulate, and decapsulate (with a comment that the demo uses a known error vector).
 2. Add a security note explaining the QC-MDPC decoder requirement and that the demo should not be used in production.
 
-Status: Open
+Status: **DONE v1.9.58**

--- a/TODO.md
+++ b/TODO.md
@@ -6209,3 +6209,168 @@ The threshold workflow is a 3-phase protocol over files:
 **Note:** The `hpkst_sign`/`HpkstSign` library functions perform all rounds internally (for demos/tests). The CLI must expose the individual rounds so that different parties can run different phases on different machines.
 
 Status: **DONE v1.9.44**
+
+---
+
+### 107. Tutorial gap: HPKS-NL and HPKE-NL have no code examples (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** Both `HPKS-NL` and `HPKE-NL` appear in the protocol table at the top of `docs/TUTORIAL.md` and in the NL/PQC protocol reference table (§"NL/PQC protocols"), but neither has a code snippet in the C, Go, or Python integration sections.  A reader cannot use either protocol from the docs alone.
+
+**Work items:**
+1. Add `### HPKS-NL Schnorr signature (NL/PQC)` subsection to C, Go, and Python integration sections with minimal sign/verify snippets using the NL-FSCX challenge.
+2. Add `### HPKE-NL El Gamal encryption (NL/PQC)` subsection to C, Go, and Python integration sections with encrypt/decrypt snippets.
+3. Note in each snippet that the public key is still a GF(2^256)* element (same as HPKS/HPKE) and that only the symmetric sub-protocol is hardened.
+
+**Reference:** `herradura.h` (`hpks_nl_sign`, `hpks_nl_verify`, `hpke_nl_encrypt`, `hpke_nl_decrypt`), Go equivalents, Python equivalents.
+
+Status: Open
+
+---
+
+### 108. Tutorial gap: HSKE-NL-A2 missing from C and Go sections (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The Python integration section has a `### HSKE-NL-A2 symmetric encryption (NL/PQC)` subsection with an encrypt/decrypt snippet.  The C and Go integration sections have no equivalent subsection despite `nl_fscx_revolve_v2` / `nl_fscx_revolve_v2_inv` being present in both `herradura.h` and `herradura.go`.
+
+**Work items:**
+1. Add `### HSKE-NL-A2 symmetric encryption (NL/PQC)` to the C integration section.
+2. Add the same subsection to the Go integration section.
+
+**Reference:** Python snippet at `docs/TUTORIAL.md` line 484; `herradura.h` `nl_fscx_revolve_v2` / `nl_fscx_revolve_v2_inv`.
+
+Status: Open
+
+---
+
+### 109. Tutorial gap: HSKE-NL-AEAD entirely absent (Documentation, Medium)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** `hske_nl_aead_encrypt`/`hske_nl_aead_decrypt` were added in v1.9.33 (TODO #95) to C, Go, and Python as the recommended authenticated encryption mode.  The tutorial has no mention of HSKE-NL-AEAD anywhere — no subsection, no CLI example, no entry in the protocol table or parameter reference.
+
+**Work items:**
+1. Add `### HSKE-NL-AEAD authenticated encryption (NL/PQC)` to C, Go, and Python integration sections with encrypt/decrypt snippets showing AAD and nonce usage.
+2. Add `HSKE-NL-AEAD` to the NL/PQC protocol reference table.
+3. Add a CLI usage block showing `--aead` flag with `enc`/`dec` subcommands.
+4. Add a security note distinguishing AEAD from the unauthenticated A1/A2 modes.
+
+Status: Open
+
+---
+
+### 110. Tutorial gap: HDRBG (forward-secure DRBG) entirely absent (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** `drbg_seed`/`drbg_generate`/`drbg_reseed` were added in v1.9.34 (TODO #96).  The tutorial has no mention of HDRBG — no subsection, no use-case guidance, no note that it can substitute for `/dev/urandom` in constrained or deterministic-test contexts.
+
+**Work items:**
+1. Add a `### HDRBG (forward-secure DRBG)` subsection to the C and Python integration sections (and Go if implemented) showing seed/generate/reseed usage.
+2. Add a note in the C integration intro that HDRBG can be used instead of `FILE *urnd = fopen("/dev/urandom", "rb")` when `/dev/urandom` is unavailable (e.g. embedded targets).
+
+**Reference:** `herradura.h` `drbg_seed`, `drbg_generate`, `drbg_reseed`; Python equivalents in the suite file.
+
+Status: Open
+
+---
+
+### 111. Tutorial gap: HPKS-WOTS-F and HPKS-XMSS-F entirely absent (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** Hash-based stateful signatures (`hpks_wots_f_sign`, `hpks_xmss_f_sign`, and their verify counterparts) were added in TODO #97 (v1.9.39) for Python and TODO #102 (v1.9.42) for C and Go.  The tutorial has no mention of either construction.
+
+**Work items:**
+1. Add a `### HPKS-WOTS-F / HPKS-XMSS-F (hash-based stateful signature)` subsection to C, Go, and Python integration sections with keygen/sign/verify snippets.
+2. Add both constructions to the code-based PQC protocol reference table (or create a new "Hash-based PQC" table row).
+3. Include a security note on statefulness: a WOTS-F key must never be used twice; XMSS-F tracks the leaf index and is the recommended multi-use variant.
+
+Status: Open
+
+---
+
+### 112. Tutorial gap: no CLI quickstart for classical protocols (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The ZKP, OPRF/aPAKE, and Threshold sections all include CLI usage blocks, but the C/Go/Python integration sections for HKEX-GF, HSKE, HPKS, and HPKE show only library-API snippets.  A first-time user wanting to test key exchange or signing from the command line must infer the subcommand names from the CLI source code.
+
+**Work items:**
+1. Add a `### CLI quickstart` subsection to the C integration section (or a top-level `## CLI quickstart` section before the language sections) demonstrating: `genpkey`, `pkey --pubout`, `kex`, `sign`, `verify`, `enc`, `dec` for the classical protocols using the Python CLI (simplest for getting started).
+2. Note that the C and Go CLIs accept identical subcommands.
+3. Cross-reference `CliTest/` integration test scripts for further examples.
+
+Status: Open
+
+---
+
+### 113. Tutorial gap: Go section skips HPKS and HPKE examples (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The C integration section has `### HPKS Schnorr signature (classical)` and `### HPKE El Gamal encryption (classical)` subsections.  The Go integration section skips from `### HSKE symmetric encryption (classical)` directly to `### HSKE-NL-A1 counter-mode encryption (NL/PQC)`, leaving HPKS and HPKE undocumented for Go.
+
+**Work items:**
+1. Add `### HPKS Schnorr signature (classical)` and `### HPKE El Gamal encryption (classical)` subsections to the Go integration section, mirroring the C section structure.
+
+Status: Open
+
+---
+
+### 114. Tutorial bug: Go OPRF example uses wrong import path (Documentation/Bug, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The Go OPRF snippet at `docs/TUTORIAL.md` (OPRF section, Go integration) begins with `import "herradurakex"` and calls `herradurakex.OprfKeygen(256)`.  Every other Go snippet in the tutorial imports `"herradurakex/herradura"` (the `herradura` package).  The OPRF functions (`OprfKeygen`, `OprfBlind`, `OprfEval`, `OprfUnblind`, `OprfDirect`) live in the `herradura` package, not the root module, so this import is incorrect.
+
+**Work items:**
+1. Fix the import in the Go OPRF snippet to `import h "herradurakex/herradura"` and update the call sites to use the `h.` prefix (or dot-import), consistent with the rest of the Go section.
+2. Verify the corrected snippet compiles against the actual Go package.
+
+Status: **DONE v1.9.50**
+
+---
+
+### 115. Tutorial gap: threshold signing library API not documented (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The Threshold Signing section (`## Threshold Signing (HPKS-T)`) covers only the CLI workflow (4-phase `threshold-commit/aggregate/respond/combine`).  The library functions that allow embedding threshold signing in C/Go/Python code (e.g. `hpkst_commit`, `hpkst_aggregate`, `hpkst_respond`, `hpkst_combine` or the all-in-one `hpkst_sign`) are not shown.
+
+**Work items:**
+1. Add a `### Library API` subsection to the Threshold Signing section with C, Go, and Python code snippets showing the per-round function calls.
+2. Note which functions are "all-in-one" (for demos/tests) vs. which expose individual rounds (for multi-party scenarios).
+
+Status: Open
+
+---
+
+### 116. Tutorial gap: aPAKE C and Go library API not documented (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** The aPAKE CLI usage section notes "The C and Go CLIs support OPRF but not the full aPAKE registration/login flow."  However, `HpakeRecord`, `HpakeRegister`, and `HpakeLoginDemo` were added to both `herradura.h` and `herradura.go` as part of TODO #80 batch 4.  The tutorial Python library section documents `hpake_register`/`hpake_login_demo`; there are no equivalent C or Go snippets.
+
+**Work items:**
+1. Add C snippet for `hpake_register` / `hpake_login_demo` to the C integration section (or to the aPAKE section alongside the Python example).
+2. Add Go snippet for `HpakeRegister` / `HpakeLoginDemo` to the Go integration section.
+3. Update the aPAKE CLI note to clarify that the library API is available in all three languages even though the CLI flow is Python-only.
+
+Status: Open
+
+---
+
+### 117. Tutorial gap: HPKE-Stern-F not documented (Documentation, Small)
+
+**Discovered:** tutorial review, 2026-06-15.
+
+**Current state:** `HPKE-Stern-F` appears in the code-based PQC reference table with `Status: Demo only; decap requires QC-MDPC decoder for production`, but has no subsection, no code example, and no CLI usage anywhere in the tutorial.
+
+**Work items:**
+1. Add a `### HPKE-Stern-F KEM (code-based PQC, demo)` subsection to the C, Go, and Python integration sections showing keygen, encapsulate, and decapsulate (with a comment that the demo uses a known error vector).
+2. Add a security note explaining the QC-MDPC decoder requirement and that the demo should not be used in production.
+
+Status: Open

--- a/TODO.md
+++ b/TODO.md
@@ -6241,7 +6241,7 @@ Status: Open
 
 **Reference:** Python snippet at `docs/TUTORIAL.md` line 484; `herradura.h` `nl_fscx_revolve_v2` / `nl_fscx_revolve_v2_inv`.
 
-Status: Open
+Status: **DONE v1.9.53**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6303,7 +6303,7 @@ Status: Open
 2. Note that the C and Go CLIs accept identical subcommands.
 3. Cross-reference `CliTest/` integration test scripts for further examples.
 
-Status: Open
+Status: **DONE v1.9.52**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6257,7 +6257,7 @@ Status: **DONE v1.9.53**
 3. Add a CLI usage block showing `--aead` flag with `enc`/`dec` subcommands.
 4. Add a security note distinguishing AEAD from the unauthenticated A1/A2 modes.
 
-Status: Open
+Status: **DONE v1.9.54**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6344,7 +6344,7 @@ Status: **DONE v1.9.50**
 1. Add a `### Library API` subsection to the Threshold Signing section with C, Go, and Python code snippets showing the per-round function calls.
 2. Note which functions are "all-in-one" (for demos/tests) vs. which expose individual rounds (for multi-party scenarios).
 
-Status: Open
+Status: **DONE v1.9.57**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6316,7 +6316,7 @@ Status: Open
 **Work items:**
 1. Add `### HPKS Schnorr signature (classical)` and `### HPKE El Gamal encryption (classical)` subsections to the Go integration section, mirroring the C section structure.
 
-Status: Open
+Status: **DONE v1.9.51**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6359,7 +6359,7 @@ Status: Open
 2. Add Go snippet for `HpakeRegister` / `HpakeLoginDemo` to the Go integration section.
 3. Update the aPAKE CLI note to clarify that the library API is available in all three languages even though the CLI flow is Python-only.
 
-Status: Open
+Status: **DONE v1.9.56**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6273,7 +6273,7 @@ Status: **DONE v1.9.54**
 
 **Reference:** `herradura.h` `drbg_seed`, `drbg_generate`, `drbg_reseed`; Python equivalents in the suite file.
 
-Status: Open
+Status: **DONE v1.9.59**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6225,7 +6225,7 @@ Status: **DONE v1.9.44**
 
 **Reference:** `herradura.h` (`hpks_nl_sign`, `hpks_nl_verify`, `hpke_nl_encrypt`, `hpke_nl_decrypt`), Go equivalents, Python equivalents.
 
-Status: Open
+Status: **DONE v1.9.55**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6288,7 +6288,7 @@ Status: **DONE v1.9.59**
 2. Add both constructions to the code-based PQC protocol reference table (or create a new "Hash-based PQC" table row).
 3. Include a security note on statefulness: a WOTS-F key must never be used twice; XMSS-F tracks the leaf index and is the recommended multi-use variant.
 
-Status: Open
+Status: **DONE v1.9.60**
 
 ---
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1281,6 +1281,89 @@ compatible with all other CLIs.  The test `CliTest/test_threshold_interop.sh` ve
 - **NL-FSCX challenge.** The challenge hash uses `nl_fscx_revolve_v1(R, msg, n/4)`,
   giving the same security properties as HPKS-NL single-party signing.
 
+### Library API
+
+The all-in-one library functions collapse all four CLI phases into a single call
+and are intended for demos, tests, and single-process multi-party simulations.
+For real multi-party deployments use the CLI phases so each signer runs
+independently.
+
+#### C
+
+```c
+#include "herradura.h"
+
+FILE *urnd = fopen("/dev/urandom", "rb");
+
+/* Key pairs: each signer holds a private scalar and its GF public key. */
+BitArray secrets[3], pubkeys[3];
+for (int j = 0; j < 3; j++) {
+    ba_rand(&secrets[j], urnd);
+    gf_pow_ba(&pubkeys[j], &GF_GEN_BA, &secrets[j]);
+}
+
+BitArray msg;
+ba_rand(&msg, urnd);
+
+/* Sign: all secrets and pubkeys known to the coordinator in a demo. */
+BitArray C_agg, R, s;
+hpkst_sign(secrets, pubkeys, 3, &msg, NULL /* auto-generate nonces */, &C_agg, &R, &s, urnd);
+
+/* Verify: identical to single-party HPKS-NL verify. */
+int ok = hpkst_verify(&C_agg, &R, &s, &msg);  /* 1 if valid */
+
+fclose(urnd);
+```
+
+#### Go
+
+```go
+import (
+    "math/big"
+    h "herradurakex/herradura"
+)
+
+n   := 3
+g   := big.NewInt(h.GfGen)
+poly := h.GfPoly[256]
+
+secrets := make([]*big.Int, n)
+pubkeys := make([]*big.Int, n)
+for j := range secrets {
+    k := h.NewRandBitArray(256)
+    secrets[j] = &k.Val
+    pubkeys[j]  = h.GfPow(g, secrets[j], poly, 256)
+}
+
+msg := h.NewRandBitArray(256)
+
+// Sign (returns aggregate pubkey, nonce, scalar)
+cAgg, R, s := h.HpkstSign(secrets, pubkeys, msg.Bytes())
+
+// Verify (identical to single-party HPKS-NL verify)
+ok := h.HpkstVerify(cAgg, R, s, msg.Bytes())
+```
+
+#### Python
+
+```python
+n_sig = 3
+poly  = h.GF_POLY[n]
+
+secrets = [h.BitArray.random(n).uint for _ in range(n_sig)]
+pubkeys = [h.BitArray(n, h.gf_pow(h.GF_GEN, a_j, poly, n)) for a_j in secrets]
+
+msg = h.BitArray.random(n)
+
+# Sign — returns (C_agg, R, s) BitArrays
+C_agg, R, s = h.hpkst_sign(secrets, pubkeys, msg)
+
+# Verify — identical to single-party HPKS-NL verify
+ok  = h.hpkst_verify(C_agg, R, s, msg)
+bad = h.hpkst_verify(C_agg, R, h.BitArray(n, s.uint ^ 1), msg)  # tamper → False
+assert ok and not bad
+```
+
 ---
 
 ## OPRF and aPAKE

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -958,8 +958,9 @@ assert wrong_pw is None
 ```
 
 `hpake_register` and `hpake_login_demo` are defined in
-`Herradura cryptographic suite.py`.  The Python CLI (`herradura.py`) exposes the
-same flow via `pake-register` and `pake-demo` subcommands — see the
+`Herradura cryptographic suite.py`.  Equivalent library APIs exist in C and Go
+(see below).  The Python CLI (`herradura.py`) exposes the same flow via
+`pake-register` and `pake-demo` subcommands — see the
 [OPRF and aPAKE](#oprf-and-apake) section for CLI examples.
 
 Demo parameters: `_HPAKE_ZKP_N = 32`, `_HPAKE_ROUNDS = 16`.
@@ -1337,10 +1338,77 @@ PEM files produced by any implementation are byte-for-byte compatible with the
 others.  See `CliTest/test_oprf_interop.sh` for a 6-way cross-language
 interop test (Python/C/Go key × blind × eval × unblind).
 
+### aPAKE library API (C)
+
+The C library exposes `hpake_register` and `hpake_login_demo` in `herradura.h`.
+The `HpakeRecord` struct (32-byte salt, two `uint32_t` ZKBoo values) is the
+server-side record; store it in your database alongside the OPRF key.
+
+```c
+#include "herradura.h"
+
+FILE *urnd = fopen("/dev/urandom", "rb");
+BitArray oprf_key;
+oprf_keygen(&oprf_key, urnd);         /* server OPRF key — keep secret */
+
+/* Registration (server side) */
+HpakeRecord rec;
+hpake_register(&rec,
+               (const uint8_t *)"s3cr3t", 6,
+               &oprf_key, urnd);
+/* Store rec and oprf_key on the server; never store the password. */
+
+/* Login (both sides — demo collapses into one call) */
+uint8_t session_key[KEYBYTES];
+int ok = hpake_login_demo(session_key, &rec,
+                           (const uint8_t *)"s3cr3t", 6,
+                           &oprf_key, urnd);
+/* ok == 1 and session_key holds the 32-byte derived key */
+
+int bad = hpake_login_demo(session_key, &rec,
+                            (const uint8_t *)"wrong", 5,
+                            &oprf_key, urnd);
+/* bad == 0 — wrong password rejected */
+
+fclose(urnd);
+```
+
+Demo parameters: `HPAKE_ZKP_N = 32`, `HPAKE_ROUNDS = 16`.
+
+### aPAKE library API (Go)
+
+The Go package exposes `HpakeRegister` and `HpakeLoginDemo`.  `HpakeRecord` is
+the server-side record type; `OprfKeygen` produces the server OPRF key.
+
+```go
+import (
+    "fmt"
+    h "herradurakex/herradura"
+)
+
+// Key generation (server side, one time)
+oprfKey, _ := h.OprfKeygen(256)
+
+// Registration (server side)
+rec, _ := h.HpakeRegister([]byte("s3cr3t"), oprfKey)
+// Store rec (*HpakeRecord) in your database; keep oprfKey secret.
+
+// Login (both sides — demo collapses into one call)
+sessionKey, _ := h.HpakeLoginDemo(rec, []byte("s3cr3t"), oprfKey)
+// sessionKey is a 32-byte slice on success, nil on wrong password.
+fmt.Printf("session key: %x\n", sessionKey)
+
+wrongKey, _ := h.HpakeLoginDemo(rec, []byte("wrong"), oprfKey)
+// wrongKey == nil — wrong password rejected
+```
+
+Demo parameters: `HpakeZkpN = 32`, `HpakeRounds = 16`.
+
 ### aPAKE CLI usage (Python CLI)
 
-The aPAKE flow requires the Python CLI.  The C and Go CLIs support OPRF
-but not the full aPAKE registration/login flow.
+The aPAKE CLI flow requires the Python CLI.  The C and Go CLIs support OPRF
+but not the `pake-register` / `pake-demo` subcommands; use the library APIs
+above for C and Go aPAKE integration.
 
 ```bash
 # 1. Generate OPRF server key (one time)
@@ -1402,7 +1470,7 @@ for a wrong password.  See `CliTest/test_pake.sh` for the full integration test.
 | Protocol | Key type | Hard problem | Availability |
 |----------|----------|--------------|--------------|
 | OPRF (2HashDH) | `oprf` | DLP in GF(2^256) | C, Go, Python, all CLIs |
-| aPAKE | `oprf` | DLP + Ring-LWR + NL-FSCX OWF | Python suite + Python CLI |
+| aPAKE | `oprf` | DLP + Ring-LWR + NL-FSCX OWF | C, Go, Python (library); Python CLI only |
 
 The OPRF output is `F(k, x) = gf_pow(H(x), k)` where `H` is HFSCX-256 hash-to-field.
 The aPAKE protocol uses HKEX-RNL for the key exchange channel, ZKBoo for the

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -402,6 +402,35 @@ hpks_stern_f_sign(&sig, &msg, &e, &seed, urnd);           /* sign   */
 int ok = hpks_stern_f_verify(&sig, &msg, &seed, syndr);   /* verify */
 ```
 
+### HPKE-Stern-F KEM (code-based PQC, demo)
+
+Niederreiter KEM: the ciphertext is a syndrome `H·e'^T`; the session key is
+`hash(seed, e')`.  Decapsulation requires recovering `e'` from the syndrome —
+this is the syndrome decoding problem.  The demo uses `hpke_stern_f_decap_known`
+which takes the plaintext error vector directly; **production requires a
+QC-MDPC or similar decoder** to recover `e'` from the syndrome.
+
+```c
+#include "herradura.h"
+
+/* Keygen: same as HPKS-Stern-F — seed is private, syndrome is public. */
+BitArray seed2, e2;
+uint8_t  syndr2[SDF_SYNBYTES];
+stern_f_keygen(&seed2, &e2, syndr2, urnd);
+
+/* Encapsulate: generate fresh error e', compute ct = H·e'^T, derive K. */
+BitArray K_enc, e_prime;
+uint8_t  ct[SDF_SYNBYTES];
+hpke_stern_f_encap(&K_enc, ct, &e_prime, &seed2, urnd);
+/* Send ct to the recipient; keep e_prime secret (demo only). */
+
+/* Decapsulate (demo — known e'): re-derive K from seed and e'. */
+BitArray K_dec;
+hpke_stern_f_decap_known(&K_dec, &e_prime, &seed2);
+/* ba_equal(&K_enc, &K_dec) == 1 */
+/* Production: recover e_prime from ct using a QC-MDPC decoder first. */
+```
+
 ### HFSCX-256 hash and MAC
 
 Merkle-Damgård hash built on NL-FSCX v1; returns 32 bytes.  Pass `iv = NULL`
@@ -683,6 +712,29 @@ sig := HpksSternFSign(msg, e, seed, SdfRounds)
 ok  := HpksSternFVerify(msg, sig, seed, syn)
 ```
 
+### HPKE-Stern-F KEM (code-based PQC, demo)
+
+Niederreiter KEM: ciphertext is a syndrome; session key is `hash(seed, e')`.
+**Production requires a QC-MDPC decoder** to recover `e'` from the syndrome.
+`HpkeSternFEncap` also returns `ePrime` for the demo decapsulation path.
+
+```go
+// Keygen: same as HPKS-Stern-F
+seed2, _, _ := SternFKeygen(n)
+
+// Encapsulate: returns (K, ct, ePrime)
+//   K      — session key
+//   ct     — syndrome *big.Int (send to recipient)
+//   ePrime — plaintext error (keep secret; needed for demo decap)
+Kenc, ct2, ePrime := HpkeSternFEncap(seed2, n)
+
+// Decapsulate (demo — known ePrime)
+Kdec := HpkeSternFDecapKnown(ePrime, seed2)
+// bytes.Equal(Kenc.Bytes(), Kdec.Bytes())
+// Production: recover ePrime from ct2 with a QC-MDPC decoder first.
+_ = ct2
+```
+
 ### HFSCX-256 hash and MAC
 
 ```go
@@ -896,6 +948,31 @@ seed, e_int, syndrome = h.stern_f_keygen(n)
 msg = h.BitArray.random(n)
 sig = h.hpks_stern_f_sign(msg, e_int, seed, syndrome, n)
 ok  = h.hpks_stern_f_verify(msg, sig, seed, syndrome, n)
+```
+
+### HPKE-Stern-F KEM (code-based PQC, demo)
+
+Niederreiter KEM: ciphertext is a syndrome; session key is `hash(seed, e')`.
+`hpke_stern_f_encap_with_e` returns the plaintext error for the demo
+decapsulation path.  **Production requires a QC-MDPC decoder** to recover
+`e'` from the syndrome; `hpke_stern_f_decap(ct, 0, seed)` attempts brute-force
+but refuses if `C(n, t) > 2^32`.
+
+```python
+# Keygen: same as HPKS-Stern-F — seed private, syndrome public.
+seed2, _, _ = h.stern_f_keygen(n)
+
+# Encapsulate — returns (K, ct, e_prime)
+#   K       — session key (BitArray)
+#   ct      — syndrome int (send to recipient)
+#   e_prime — plaintext error int (keep secret; needed for demo decap)
+K_enc, ct2, e_prime = h.hpke_stern_f_encap_with_e(seed2, n)
+
+# Decapsulate (demo — known e_prime)
+K_dec = h.hpke_stern_f_decap(ct2, e_prime, seed2, n)
+assert K_enc == K_dec
+# Production: recover e_prime from ct2 with a QC-MDPC decoder, then call
+# hpke_stern_f_decap(ct2, e_prime, seed2, n).
 ```
 
 ### HFSCX-256 hash and MAC

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -160,6 +160,10 @@ Copy `herradura.h` into your project (or keep it in the repo and use `-I`) then:
 
 No additional source files, no link flags, no build system changes.
 
+On embedded targets without `/dev/urandom`, seed `HDrbg` from any available
+hardware entropy source (ADC noise, TRNG peripheral, etc.) and use
+`drbg_generate` in place of `fopen("/dev/urandom", "rb")` throughout.
+
 ### Build
 
 ```bash
@@ -450,6 +454,42 @@ uint8_t mac_iv[KEYBYTES];
 for (int i = 0; i < KEYBYTES; i++)
     mac_iv[i] = alice_shared.b[i] ^ _HFSCX256_IV[i];
 hfscx_256(msg, sizeof msg - 1, mac_iv, digest);
+```
+
+### HDRBG (forward-secure DRBG)
+
+Fast-key-erasure DRBG built on NL-FSCX v1.  Suitable for constrained targets
+where `/dev/urandom` is unavailable, or for deterministic test vectors.
+Seed from a full-entropy source (≥ 32 bytes recommended); reseed after at most
+`DRBG_MAX_BLOCKS` (2^20) output blocks.
+
+```c
+#include "herradura.h"
+
+HDrbg drbg;
+
+/* Seed from OS entropy (or any full-entropy source). */
+uint8_t seed_bytes[32];
+FILE *urnd2 = fopen("/dev/urandom", "rb");
+fread(seed_bytes, 1, sizeof seed_bytes, urnd2);
+fclose(urnd2);
+
+drbg_seed(&drbg,
+          seed_bytes, sizeof seed_bytes,  /* entropy */
+          NULL, 0);                        /* personalization (optional) */
+
+/* Generate output. */
+uint8_t out[64];
+int ok = drbg_generate(&drbg, out, sizeof out);   /* 1 on success */
+/* ok == 0 means DRBG_MAX_BLOCKS reached — call drbg_reseed first. */
+
+/* Reseed with fresh entropy to forward-securely advance the state. */
+uint8_t fresh[32];
+/* ... fill fresh from entropy source ... */
+drbg_reseed(&drbg, fresh, sizeof fresh);
+
+explicit_bzero(seed_bytes, sizeof seed_bytes);
+explicit_bzero(fresh, sizeof fresh);
 ```
 
 ### OPRF (2HashDH oblivious PRF)
@@ -752,6 +792,28 @@ for i := range macIV {
 mac := Hfscx256(data, macIV)
 ```
 
+### HDRBG (forward-secure DRBG)
+
+```go
+import h "herradurakex/herradura"
+import "crypto/rand"
+
+// Seed from OS entropy.
+entropy := make([]byte, 32)
+rand.Read(entropy)
+
+d := h.DrbgSeed(entropy, nil) // nil personalization
+
+// Generate output.
+out, ok := d.DrbgGenerate(64) // ok == false if DRBG_MAX_BLOCKS exceeded
+_ = ok
+
+// Reseed to forward-securely advance the state.
+fresh := make([]byte, 32)
+rand.Read(fresh)
+d.DrbgReseed(fresh)
+```
+
 ### OPRF (2HashDH oblivious PRF)
 
 ```go
@@ -986,6 +1048,24 @@ digest = h.hfscx_256(data)
 # Keyed MAC: iv = key XOR IV
 mac_iv = h.BitArray(n, alice_shared.uint ^ int.from_bytes(h._HFSCX256_IV_BYTES, 'big'))
 mac = h.hfscx_256(data, iv=mac_iv)
+```
+
+### HDRBG (forward-secure DRBG)
+
+```python
+import importlib, importlib.util, pathlib, os
+
+# Seed from OS entropy.
+entropy = os.urandom(32)
+
+d = h.drbg_seed(entropy, personalization=None)
+
+# Generate output.
+out = h.drbg_generate(d, 64)
+
+# Reseed to forward-securely advance the state.
+fresh = os.urandom(32)
+h.drbg_reseed(d, fresh)
 ```
 
 ### OPRF (2HashDH oblivious PRF)

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -83,7 +83,26 @@ $CLI dec --algo hske --key alice_sk.pem --in ct.pem        --out recovered.bin
 # cmp msg.bin recovered.bin  →  identical
 ```
 
-Use `--algo hske-nla1` or `--algo hske-nla2` for the NL/PQC encryption modes.
+Use `--algo hske-nla1` or `--algo hske-nla2` for the unauthenticated NL/PQC modes.
+
+### Authenticated encryption (HSKE-NL-AEAD)
+
+Add `--aead` to any `hske-nla1` enc/dec command.  The `--ad` flag supplies
+associated data (authenticated but not encrypted).
+
+```bash
+# Encrypt with AEAD (nonce embedded in ct.pem alongside ciphertext and tag)
+$CLI enc --algo hske-nla1 --aead --ad "header-v1" \
+         --key alice_sk.pem --in msg.bin --out ct_aead.pem
+
+# Decrypt (--ad must match exactly; fails if ct, tag, or AD is tampered with)
+$CLI dec --algo hske-nla1 --ad "header-v1" \
+         --key alice_sk.pem --in ct_aead.pem --out recovered.bin
+# cmp msg.bin recovered.bin  →  identical
+```
+
+The C and Go CLIs accept the same `--aead` and `--ad` flags.  AEAD PEMs are
+cross-language compatible — see `CliTest/test_aead.sh` for a 9-way interop test.
 
 ### Signing and verification (HPKS)
 
@@ -250,6 +269,36 @@ ba_rand(&plaintext2, urnd);
 nl_fscx_revolve_v2_ba    (&ciphertext2, &plaintext2, &key2, R_VALUE);  /* encrypt */
 nl_fscx_revolve_v2_inv_ba(&recovered2,  &ciphertext2, &key2, R_VALUE); /* decrypt */
 /* ba_equal(&plaintext2, &recovered2) == 1 */
+```
+
+### HSKE-NL-AEAD authenticated encryption (NL/PQC)
+
+Authenticated encryption with associated data built on HSKE-NL-A1.  A fresh
+random 256-bit nonce must be generated for every encryption; the 32-byte tag
+authenticates both the ciphertext and the associated data (AD).  Decryption is
+verify-then-decrypt and returns 0 if the tag does not match.
+
+```c
+#include "herradura.h"
+#include <string.h>
+
+BitArray aead_key, aead_nonce;
+ba_rand(&aead_key,   urnd);
+ba_rand(&aead_nonce, urnd);   /* must never be reused with the same key */
+
+const uint8_t *pt  = (const uint8_t *)"hello AEAD";
+size_t         pt_len = 10;
+const uint8_t *ad  = (const uint8_t *)"header-v1";
+size_t         ad_len = 9;
+
+uint8_t ct[10], tag[32], recovered[10];
+
+hske_nl_aead_encrypt(&aead_key, &aead_nonce, ad, ad_len, pt, pt_len, ct, tag);
+
+int ok = hske_nl_aead_decrypt(&aead_key, &aead_nonce,
+                               ad, ad_len, ct, pt_len, tag, recovered);
+/* ok == 1 and memcmp(pt, recovered, pt_len) == 0 */
+/* ok == 0 if ct, tag, ad, or nonce is tampered with */
 ```
 
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
@@ -495,6 +544,28 @@ dec2 := NlFscxRevolveV2Inv(ct2, key2, 3*n/4)        /* decrypt */
 /* dec2.Equal(plaintext2) */
 ```
 
+### HSKE-NL-AEAD authenticated encryption (NL/PQC)
+
+Authenticated encryption with associated data built on HSKE-NL-A1.  Returns
+`(ct []byte, tag []byte)` on encrypt; returns `(pt []byte, ok bool)` on decrypt.
+Decryption is verify-then-decrypt; `ok` is false if the tag does not match.
+
+```go
+import h "herradurakex/herradura"
+
+aeadKey   := h.NewRandBitArray(n)
+aeadNonce := h.NewRandBitArray(n)   // must never be reused with the same key
+
+pt := []byte("hello AEAD")
+ad := []byte("header-v1")
+
+ct, tag := h.HskeNlAeadEncrypt(aeadKey, aeadNonce, ad, pt)
+
+recovered, ok := h.HskeNlAeadDecrypt(aeadKey, aeadNonce, ad, ct, tag)
+// ok == true and bytes.Equal(pt, recovered)
+// ok == false if ct, tag, ad, or nonce is tampered with
+```
+
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
 
 ```go
@@ -644,6 +715,29 @@ plaintext = h.BitArray.random(n)
 ciphertext = h.nl_fscx_revolve_v2(plaintext, key, h.R_VALUE)
 recovered  = h.nl_fscx_revolve_v2_inv(ciphertext, key, h.R_VALUE)
 assert plaintext == recovered
+```
+
+### HSKE-NL-AEAD authenticated encryption (NL/PQC)
+
+Authenticated encryption with associated data built on HSKE-NL-A1.  Returns
+`(nonce, ct, tag)` on encrypt; returns the plaintext or `None` on decrypt.
+Decryption is verify-then-decrypt using `hmac.compare_digest`.
+
+```python
+aead_key = h.BitArray.random(n)
+pt = b"hello AEAD"
+ad = b"header-v1"
+
+# encrypt — nonce is generated internally if not supplied
+nonce, ct, tag = h.hske_nl_aead_encrypt(aead_key, pt, ad)
+
+# decrypt — returns plaintext or None if tag/ct/ad/nonce is tampered with
+recovered = h.hske_nl_aead_decrypt(aead_key, nonce, ct, tag, ad)
+assert recovered == pt
+
+# tamper detection
+assert h.hske_nl_aead_decrypt(aead_key, nonce,
+                               bytes([ct[0] ^ 1]) + ct[1:], tag, ad) is None
 ```
 
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
@@ -1154,6 +1248,7 @@ for a wrong password.  See `CliTest/test_pake.sh` for the full integration test.
 |----------|-----------|-----------|
 | HSKE-NL-A1 | `nl_fscx_revolve_v1` | counter-mode (one-way) |
 | HSKE-NL-A2 | `nl_fscx_revolve_v2` / `_inv` | revolve-mode (invertible) |
+| HSKE-NL-AEAD | HSKE-NL-A1 + HFSCX-256 MAC | authenticated encryption (recommended) |
 | HKEX-RNL | Ring-LWR polynomial arithmetic | key exchange |
 | HPKS-NL | `nl_fscx_revolve_v1` as Schnorr challenge | signature |
 | HPKE-NL | `nl_fscx_revolve_v2` / `_inv` | El Gamal encryption |
@@ -1288,6 +1383,16 @@ models that exclude quantum adversaries.
 - **HPKS-NL and HPKE-NL** still use GF(2^256)* DLP for the public key; the NL
   extension hardens only the symmetric sub-protocol.  They are not fully PQC.
 - **HSKE-NL-A1/A2** are symmetric-only and do not depend on any public-key assumption.
+- **HSKE-NL-AEAD nonce reuse is catastrophic.**  Reusing a (key, nonce) pair with
+  different plaintexts exposes the XOR of the two plaintexts and invalidates all
+  confidentiality guarantees.  Always generate the nonce from a cryptographic RNG;
+  in library code `BitArray.random(256)` / `NewRandBitArray(256)` / `ba_rand` do
+  this.  The Python `hske_nl_aead_encrypt` function auto-generates the nonce when
+  none is supplied.
+- **HSKE-NL-AEAD does not provide key commitment** in the standard sense — a
+  malicious server holding a different key cannot be distinguished from a MAC
+  failure.  For applications requiring key commitment (e.g. OPAQUE/aPAKE), apply
+  an additional commitment step or use the OPRF-based aPAKE construction instead.
 
 ### Code-based PQC (HPKS-Stern-F, HPKE-Stern-F)
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -228,6 +228,59 @@ hpke_encrypt(&plaintext,  &alice_pub,  &R_ephem, &ciphertext, urnd);
 hpke_decrypt(&ciphertext, &R_ephem, &alice_priv, &recovered);
 ```
 
+### HPKS-NL Schnorr signature (NL/PQC)
+
+Same key type as HPKS.  The only difference is the challenge hash: NL-FSCX v1
+replaces the linear FSCX revolve, hardening the challenge against preimage attacks.
+The public key is still a GF(2^256)* element; DLP protection is unchanged.
+
+```c
+BitArray msg_nl, k_nl, R_nl, e_nl, s_nl;
+ba_rand(&msg_nl, urnd);
+ba_rand(&k_nl,   urnd);                              /* per-signature nonce */
+
+gf_pow_ba(&R_nl, &GF_GEN, &k_nl);                   /* R = g^k             */
+nl_fscx_revolve_v1_ba(&e_nl, &R_nl, &msg_nl, I_VALUE); /* NL challenge e   */
+ba_mul_mod_ord(&(BitArray){0}, &alice_priv, &e_nl);  /* ae = a·e            */
+BitArray ae_nl, s_nl2;
+ba_mul_mod_ord(&ae_nl, &alice_priv, &e_nl);
+ba_sub_mod_ord(&s_nl2, &k_nl, &ae_nl);              /* s = k - a·e mod ord */
+
+/* Verify: g^s · C^e == R (same check as HPKS; challenge recomputed with NL) */
+BitArray e_v, gs, Ce, lhs;
+nl_fscx_revolve_v1_ba(&e_v, &R_nl, &msg_nl, I_VALUE);
+gf_pow_ba(&gs, &GF_GEN, &s_nl2);
+gf_pow_ba(&Ce, &alice_pub, &e_v);
+gf_mul_ba(&lhs, &gs, &Ce);
+int ok_nl = ba_equal(&lhs, &R_nl);  /* 1 if valid */
+
+explicit_bzero(&k_nl,  sizeof(k_nl));
+explicit_bzero(&ae_nl, sizeof(ae_nl));
+```
+
+### HPKE-NL El Gamal encryption (NL/PQC)
+
+Same key type as HPKE.  The symmetric sub-protocol uses NL-FSCX v2 (bijective)
+instead of the linear FSCX revolve, hardening the ciphertext against key recovery.
+
+```c
+BitArray r_nl, R_nl2, enc_nl, ct_nl, dec_nl, pt_nl;
+ba_rand(&r_nl, urnd);
+
+gf_pow_ba(&R_nl2,  &GF_GEN,      &r_nl);    /* ephemeral R = g^r          */
+gf_pow_ba(&enc_nl, &alice_pub,   &r_nl);    /* enc key = C^r              */
+nl_fscx_revolve_v2_ba(&ct_nl, &plaintext, &enc_nl, I_VALUE);  /* encrypt  */
+
+gf_pow_ba(&dec_nl, &R_nl2, &alice_priv);    /* dec key = R^a              */
+nl_fscx_revolve_v2_inv_ba(&pt_nl, &ct_nl, &dec_nl, I_VALUE);  /* decrypt  */
+/* ba_equal(&pt_nl, &plaintext) == 1 */
+/* Transmit R_nl2 alongside ct_nl; Alice decrypts with her private key. */
+
+explicit_bzero(&r_nl,   sizeof(r_nl));
+explicit_bzero(&enc_nl, sizeof(enc_nl));
+explicit_bzero(&dec_nl, sizeof(dec_nl));
+```
+
 ### HSKE-NL-A1 counter-mode encryption (NL/PQC)
 
 Counter-mode stream cipher based on NL-FSCX v1.  A fresh random nonce must be
@@ -514,6 +567,43 @@ dec    := FscxRevolve(ct, decKey, 3*n/4)                              /* recover
 /* Transmit RHpke alongside ct; Alice decrypts with her private key. */
 ```
 
+### HPKS-NL Schnorr signature (NL/PQC)
+
+Same key type as HPKS.  The challenge hash uses `NlFscxRevolveV1` instead of
+`FscxRevolve`, hardening the challenge against preimage attacks.
+
+```go
+msgNl := NewRandBitArray(n)
+kNl   := NewRandBitArray(n)                                          /* per-signature nonce */
+
+RNl  := NewBitArray(n, GfPow(g, &kNl.Val, poly, n))                 /* R = g^k             */
+eNl  := NlFscxRevolveV1(RNl, msgNl, n/4)                            /* NL challenge e      */
+sNl  := new(big.Int).Mod(new(big.Int).Sub(&kNl.Val,
+            new(big.Int).Mul(&alicePriv.Val, &eNl.Val)), ord)        /* s = k - a·e         */
+
+/* Verify: g^s · C^e == R */
+eV  := NlFscxRevolveV1(RNl, msgNl, n/4)
+lhs := GfMul(GfPow(g, sNl, poly, n), GfPow(&alicePub.Val, &eV.Val, poly, n), poly, n)
+okNl := lhs.Cmp(&RNl.Val) == 0
+```
+
+### HPKE-NL El Gamal encryption (NL/PQC)
+
+Same key type as HPKE.  The symmetric sub-protocol uses `NlFscxRevolveV2`
+(bijective) instead of `FscxRevolve`, hardening ciphertext against key recovery.
+
+```go
+rNl    := NewRandBitArray(n)
+RNl2   := NewBitArray(n, GfPow(g, &rNl.Val, poly, n))               /* ephemeral R = g^r  */
+encNl  := NewBitArray(n, GfPow(&alicePub.Val, &rNl.Val, poly, n))   /* enc key = C^r      */
+ctNl   := NlFscxRevolveV2(plaintext, encNl, n/4)                     /* encrypt            */
+
+decNl  := NewBitArray(n, GfPow(&RNl2.Val, &alicePriv.Val, poly, n)) /* dec key = R^a      */
+ptNl   := NlFscxRevolveV2Inv(ctNl, decNl, n/4)                      /* decrypt            */
+/* ptNl.Equal(plaintext) */
+/* Transmit RNl2 alongside ctNl; Alice decrypts with her private key. */
+```
+
 ### HSKE-NL-A1 counter-mode encryption (NL/PQC)
 
 ```go
@@ -688,6 +778,46 @@ plaintext  = h.BitArray.random(n)
 ciphertext = h.fscx_revolve(plaintext,  alice_shared, h.I_VALUE)
 recovered  = h.fscx_revolve(ciphertext, alice_shared, h.R_VALUE)
 assert plaintext == recovered
+```
+
+### HPKS-NL Schnorr signature (NL/PQC)
+
+Same key type as HPKS.  The challenge uses `nl_fscx_revolve_v1` instead of
+`fscx_revolve`, hardening against challenge preimage attacks.
+
+```python
+poly = h.GF_POLY[n]
+ord_ = (1 << n) - 1                              # group order 2^n - 1
+
+msg_nl = h.BitArray.random(n)
+k_nl   = h.BitArray.random(n)                    # per-signature nonce
+
+R_nl   = h.BitArray(n, h.gf_pow(h.GF_GEN, k_nl.uint, poly, n))   # R = g^k
+e_nl   = h.nl_fscx_revolve_v1(R_nl, msg_nl, h.I_VALUE)            # NL challenge
+s_nl   = (k_nl.uint - alice_priv.uint * e_nl.uint) % ord_         # s = k - a·e
+
+# Verify: g^s · C^e == R
+e_v   = h.nl_fscx_revolve_v1(R_nl, msg_nl, h.I_VALUE)
+lhs   = h.gf_mul(h.gf_pow(h.GF_GEN, s_nl, poly, n),
+                 h.gf_pow(alice_pub.uint, e_v.uint, poly, n), poly, n)
+assert lhs == R_nl.uint
+```
+
+### HPKE-NL El Gamal encryption (NL/PQC)
+
+Same key type as HPKE.  The symmetric layer uses `nl_fscx_revolve_v2` (bijective)
+instead of the linear FSCX revolve, hardening ciphertext against key recovery.
+
+```python
+r_nl    = h.BitArray.random(n)
+R_nl2   = h.BitArray(n, h.gf_pow(h.GF_GEN, r_nl.uint, poly, n))   # R = g^r
+enc_nl  = h.BitArray(n, h.gf_pow(alice_pub.uint, r_nl.uint, poly, n))  # C^r
+ct_nl   = h.nl_fscx_revolve_v2(plaintext, enc_nl, h.I_VALUE)       # encrypt
+
+dec_nl  = h.BitArray(n, h.gf_pow(R_nl2.uint, alice_priv.uint, poly, n))  # R^a
+pt_nl   = h.nl_fscx_revolve_v2_inv(ct_nl, dec_nl, h.I_VALUE)       # decrypt
+assert pt_nl == plaintext
+# Transmit R_nl2 alongside ct_nl; Alice decrypts with her private key.
 ```
 
 ### HSKE-NL-A1 counter-mode encryption (NL/PQC)

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -435,6 +435,52 @@ hpke_stern_f_decap_known(&K_dec, &e_prime, &seed2);
 /* Production: recover e_prime from ct using a QC-MDPC decoder first. */
 ```
 
+### HPKS-WOTS-F / HPKS-XMSS-F (hash-based stateful signatures)
+
+> **Statefulness warning:** A WOTS-F leaf key must **never** be reused.  Sign
+> only one message per leaf index.  XMSS-F is the recommended multi-signature
+> variant — it tracks the Merkle tree so each signing call advances the leaf
+> counter automatically.
+
+**WOTS-F** (one-time, single leaf):
+
+```c
+#include "herradura.h"
+
+/* Keygen: master_seed is the long-term secret; leaf_idx=0 for a one-time key. */
+uint8_t master_seed[KEYBYTES];
+ba_rand_bytes(master_seed, KEYBYTES, urnd);
+
+BitArray sk[WOTS_L], pk[WOTS_L];
+hpks_wots_keygen(sk, pk, master_seed, /*leaf_idx=*/0);
+
+const uint8_t msg[] = "hello world";
+BitArray sig[WOTS_L];
+hpks_wots_sign(sig, msg, sizeof msg - 1, master_seed, /*leaf_idx=*/0);
+
+int ok = hpks_wots_verify(msg, sizeof msg - 1, sig, pk);   /* 1 = valid */
+/* Do NOT reuse leaf_idx=0 — use a fresh leaf_idx for every message. */
+```
+
+**XMSS-F** (multi-signature, Merkle tree):
+
+```c
+/* Keygen: h=4 builds a tree with 2^4=16 leaves (16 one-time slots). */
+uint8_t root[KEYBYTES];
+uint8_t *flat_leaves;
+size_t   num_leaves;
+hpks_xmss_keygen(root, &flat_leaves, &num_leaves, master_seed, /*h=*/4);
+
+/* Sign at leaf_idx=0, then 1, 2, … (never repeat an index). */
+HpksXmssSig sig0;
+hpks_xmss_sign(&sig0, msg, sizeof msg - 1, master_seed,
+                flat_leaves, num_leaves, /*leaf_idx=*/0);
+
+int ok2 = hpks_xmss_verify(msg, sizeof msg - 1, &sig0, root); /* 1 = valid */
+hpks_xmss_sig_free(&sig0);   /* frees auth_path */
+free(flat_leaves);
+```
+
 ### HFSCX-256 hash and MAC
 
 Merkle-Damgård hash built on NL-FSCX v1; returns 32 bytes.  Pass `iv = NULL`
@@ -775,6 +821,35 @@ Kdec := HpkeSternFDecapKnown(ePrime, seed2)
 _ = ct2
 ```
 
+### HPKS-WOTS-F / HPKS-XMSS-F (hash-based stateful signatures)
+
+> **Statefulness warning:** A WOTS-F leaf key must **never** be reused.  Sign
+> only one message per leaf index.  XMSS-F is the recommended multi-signature
+> variant; advance the leaf counter monotonically across restarts.
+
+```go
+import h "herradurakex/herradura"
+import "crypto/rand"
+
+masterSeed := make([]byte, 32)
+rand.Read(masterSeed)
+
+msg := []byte("hello world")
+
+// --- WOTS-F (one-time) ---
+_, pk0 := h.HpksWotsKeygen(masterSeed, 0)     // sk, pk for leaf 0
+sig0   := h.HpksWotsSign(msg, masterSeed, 0)
+ok     := h.HpksWotsVerify(msg, sig0, pk0)    // true
+// Never call HpksWotsSign again with the same masterSeed and leaf index 0.
+
+// --- XMSS-F (multi-signature, h=4 → 16 one-time slots) ---
+kp    := h.HpksXmssKeygen(masterSeed, 4)     // builds 2^4-leaf Merkle tree
+xsig  := h.HpksXmssSign(msg, kp, 0)          // sign at leaf 0
+ok2   := h.HpksXmssVerify(msg, xsig, kp.Root)
+_ = ok; _ = ok2
+// Next signing call uses HpksXmssSign(msg2, kp, 1), then leaf 2, etc.
+```
+
 ### HFSCX-256 hash and MAC
 
 ```go
@@ -1035,6 +1110,31 @@ K_dec = h.hpke_stern_f_decap(ct2, e_prime, seed2, n)
 assert K_enc == K_dec
 # Production: recover e_prime from ct2 with a QC-MDPC decoder, then call
 # hpke_stern_f_decap(ct2, e_prime, seed2, n).
+```
+
+### HPKS-WOTS-F / HPKS-XMSS-F (hash-based stateful signatures)
+
+> **Statefulness warning:** A WOTS-F leaf key must **never** be reused.  Sign
+> only one message per leaf index.  XMSS-F is the recommended multi-signature
+> variant; persist the next unused leaf index across restarts.
+
+```python
+import os
+
+master_seed = os.urandom(32)
+msg = b"hello world"
+
+# --- WOTS-F (one-time, single leaf) ---
+sk0, pk0 = h.hpks_wots_keygen(master_seed, leaf_idx=0)
+sig0, _  = h.hpks_wots_sign(msg, master_seed, leaf_idx=0)
+ok       = h.hpks_wots_verify(msg, sig0, pk0)   # True
+# Never call hpks_wots_sign with the same master_seed and leaf_idx=0 again.
+
+# --- XMSS-F (multi-signature, h=4 → 16 one-time slots) ---
+ms, root, leaf_hashes = h.hpks_xmss_keygen(master_seed, h=4)
+xsig = h.hpks_xmss_sign(msg, ms, leaf_hashes, leaf_idx=0)
+ok2  = h.hpks_xmss_verify(msg, xsig, root)      # True
+# Next message: hpks_xmss_sign(msg2, ms, leaf_hashes, leaf_idx=1), etc.
 ```
 
 ### HFSCX-256 hash and MAC
@@ -1697,6 +1797,13 @@ for a wrong password.  See `CliTest/test_pake.sh` for the full integration test.
 |----------|----------|--------|
 | HPKS-Stern-F | SD(N,t) + NL-FSCX v1 PRF | Demo params (rounds=32); production needs rounds≥219 |
 | HPKE-Stern-F | SD(N,t) | Demo only; decap requires QC-MDPC decoder for production |
+
+### Hash-based stateful signatures
+
+| Protocol | Hard problem | Availability | Notes |
+|----------|-------------|--------------|-------|
+| HPKS-WOTS-F | Second-preimage of HFSCX-256 | C, Go, Python | One-time: one message per leaf index; reuse breaks security |
+| HPKS-XMSS-F | Second-preimage of HFSCX-256 | C, Go, Python | Multi-use: 2^h slots per master seed; persist leaf counter |
 
 ### ZKP protocols
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -323,11 +323,42 @@ recovered  := FscxRevolve(ciphertext, aliceShared, rValue)
 /* plaintext.Equal(recovered) */
 ```
 
-### HSKE-NL-A1 counter-mode encryption (NL/PQC)
+### HPKS Schnorr signature (classical)
 
 ```go
 import "math/big"
 
+ord := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(n)), big.NewInt(1)) /* 2^n - 1 */
+
+msg := NewRandBitArray(n)
+kS  := NewRandBitArray(n)                                         /* per-signature nonce */
+RS  := NewBitArray(n, GfPow(g, &kS.Val, poly, n))                /* commitment R = g^k  */
+eS  := FscxRevolve(RS, msg, n/4)                                  /* challenge e         */
+sS  := new(big.Int).Mod(new(big.Int).Sub(&kS.Val,
+           new(big.Int).Mul(&alicePriv.Val, &eS.Val)), ord)       /* response s = k-a·e  */
+
+/* Verify: g^s · C^e == R */
+lhs := GfMul(GfPow(g, sS, poly, n), GfPow(&alicePub.Val, &eS.Val, poly, n), poly, n)
+ok  := lhs.Cmp(&RS.Val) == 0
+```
+
+### HPKE El Gamal encryption (classical)
+
+```go
+rHpke  := NewRandBitArray(n)                                         /* ephemeral scalar   */
+RHpke  := NewBitArray(n, GfPow(g, &rHpke.Val, poly, n))             /* ephemeral pubkey   */
+encKey := NewBitArray(n, GfPow(&alicePub.Val, &rHpke.Val, poly, n)) /* enc key = C^r      */
+ct     := FscxRevolve(plaintext, encKey, n/4)                        /* ciphertext         */
+
+decKey := NewBitArray(n, GfPow(&RHpke.Val, &alicePriv.Val, poly, n)) /* dec key = R^a     */
+dec    := FscxRevolve(ct, decKey, 3*n/4)                              /* recovered = P      */
+/* dec.Equal(plaintext) */
+/* Transmit RHpke alongside ct; Alice decrypts with her private key. */
+```
+
+### HSKE-NL-A1 counter-mode encryption (NL/PQC)
+
+```go
 key       := NewRandBitArray(n)
 plaintext := NewRandBitArray(n)
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -388,22 +388,22 @@ mac := Hfscx256(data, macIV)
 ### OPRF (2HashDH oblivious PRF)
 
 ```go
-import "herradurakex"
+import h "herradurakex/herradura"
 
 // Key generation (server side)
-k, _ := herradurakex.OprfKeygen(256)
+k, _ := h.OprfKeygen(256)
 
 // Blinding (client side)
-r, alpha, _ := herradurakex.OprfBlind([]byte("my-password"), 256)
+r, alpha, _ := h.OprfBlind([]byte("my-password"), 256)
 
 // Evaluation (server side)
-beta := herradurakex.OprfEval(alpha, k, 256)
+beta := h.OprfEval(alpha, k, 256)
 
 // Unblinding (client side): yields F(k, input)
-F := herradurakex.OprfUnblind(beta, r, 256)
+F := h.OprfUnblind(beta, r, 256)
 
 // Direct evaluation — result matches
-check := herradurakex.OprfDirect([]byte("my-password"), k, 256)
+check := h.OprfDirect([]byte("my-password"), k, 256)
 // F.Cmp(check) == 0
 ```
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -236,6 +236,22 @@ explicit_bzero(&seed_a1, sizeof(seed_a1));
 explicit_bzero(&base_a1, sizeof(base_a1));
 ```
 
+### HSKE-NL-A2 symmetric encryption (NL/PQC)
+
+Bijective revolve-mode encryption based on NL-FSCX v2.  Unlike A1, no nonce is
+needed — the same key encrypts and decrypts via a dedicated inverse function.
+
+```c
+BitArray key2, plaintext2, ciphertext2, recovered2;
+
+ba_rand(&key2,       urnd);
+ba_rand(&plaintext2, urnd);
+
+nl_fscx_revolve_v2_ba    (&ciphertext2, &plaintext2, &key2, R_VALUE);  /* encrypt */
+nl_fscx_revolve_v2_inv_ba(&recovered2,  &ciphertext2, &key2, R_VALUE); /* decrypt */
+/* ba_equal(&plaintext2, &recovered2) == 1 */
+```
+
 ### HKEX-RNL key exchange (Ring-LWR, PQC)
 
 ```c
@@ -463,6 +479,20 @@ ct     := NewBitArray(n, new(big.Int).Xor(&plaintext.Val, &ks.Val))
 dec    := NewBitArray(n, new(big.Int).Xor(&ct.Val, &ks.Val))
 /* dec.Equal(plaintext) */
 /* Transmit nA1 alongside ct so the recipient can reproduce the keystream. */
+```
+
+### HSKE-NL-A2 symmetric encryption (NL/PQC)
+
+Bijective revolve-mode encryption based on NL-FSCX v2.  Unlike A1, no nonce is
+needed — the same key encrypts and decrypts via a dedicated inverse function.
+
+```go
+key2       := NewRandBitArray(n)
+plaintext2 := NewRandBitArray(n)
+
+ct2  := NlFscxRevolveV2(plaintext2, key2, 3*n/4)    /* encrypt (R_VALUE = 3n/4) */
+dec2 := NlFscxRevolveV2Inv(ct2, key2, 3*n/4)        /* decrypt */
+/* dec2.Equal(plaintext2) */
 ```
 
 ### HKEX-RNL key exchange (Ring-LWR, PQC)

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -26,14 +26,107 @@ with toy examples and verified references.
 
 ## Contents
 
-1. [C integration](#c-integration)
-2. [Go integration](#go-integration)
-3. [Python integration](#python-integration)
-4. [ZKP Protocols](#zkp-protocols)
-5. [OPRF and aPAKE](#oprf-and-apake)
-6. [Protocol reference](#protocol-reference)
-7. [Parameter reference](#parameter-reference)
-8. [Security notes](#security-notes)
+1. [CLI quickstart](#cli-quickstart)
+2. [C integration](#c-integration)
+3. [Go integration](#go-integration)
+4. [Python integration](#python-integration)
+5. [ZKP Protocols](#zkp-protocols)
+6. [OPRF and aPAKE](#oprf-and-apake)
+7. [Protocol reference](#protocol-reference)
+8. [Parameter reference](#parameter-reference)
+9. [Security notes](#security-notes)
+
+---
+
+## CLI quickstart
+
+The three CLIs (`herradura.py`, `herradura_cli`, `herradura_cli_go`) share identical
+subcommands and PEM wire formats.  PEM files produced by one implementation are
+byte-for-byte compatible with all others.  The Python CLI requires no build step and
+is the easiest starting point.
+
+```bash
+CLI="python3 HerraduraCli/herradura.py"
+# C CLI:  ./HerraduraCli/herradura_cli
+# Go CLI: ./HerraduraCli/herradura_cli_go
+```
+
+### Key generation and inspection
+
+```bash
+# Generate a private key (hkex-gf, hpks, hpke, hkex-rnl, hpks-stern, …)
+$CLI genpkey --algo hkex-gf --out alice.pem
+$CLI genpkey --algo hkex-gf --out bob.pem
+
+# Extract the public key
+$CLI pkey --in alice.pem --pubout --out alice_pub.pem
+
+# Print key parameters in human-readable form
+$CLI pkey --in alice.pem --text
+```
+
+### Key exchange (HKEX-GF)
+
+```bash
+$CLI kex --algo hkex-gf --our alice.pem --their bob_pub.pem   --out alice_sk.pem
+$CLI kex --algo hkex-gf --our bob.pem   --their alice_pub.pem --out bob_sk.pem
+# alice_sk.pem and bob_sk.pem contain the same 256-bit session key.
+```
+
+### Symmetric encryption / decryption (HSKE)
+
+```bash
+echo -n "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345" > msg.bin   # 32-byte (256-bit) message
+
+$CLI enc --algo hske --key alice_sk.pem --in msg.bin       --out ct.pem
+$CLI dec --algo hske --key alice_sk.pem --in ct.pem        --out recovered.bin
+# cmp msg.bin recovered.bin  →  identical
+```
+
+Use `--algo hske-nla1` or `--algo hske-nla2` for the NL/PQC encryption modes.
+
+### Signing and verification (HPKS)
+
+```bash
+$CLI genpkey --algo hpks --out sign_key.pem
+$CLI pkey    --in sign_key.pem --pubout --out sign_pub.pem
+
+$CLI sign   --algo hpks --key sign_key.pem --in msg.bin --out sig.pem
+$CLI verify --algo hpks --pubkey sign_pub.pem --in msg.bin --sig sig.pem
+# Prints: Signature OK
+```
+
+### El Gamal encryption (HPKE)
+
+```bash
+$CLI genpkey --algo hpke --out enc_key.pem
+$CLI pkey    --in enc_key.pem --pubout --out enc_pub.pem
+
+$CLI enc --algo hpke --key enc_pub.pem  --in msg.bin --out ct.pem
+$CLI dec --algo hpke --key enc_key.pem  --in ct.pem  --out recovered.bin
+```
+
+### Key exchange (HKEX-RNL, PQC, two rounds)
+
+HKEX-RNL requires two steps: Bob responds first, then Alice completes.
+
+```bash
+$CLI genpkey --algo hkex-rnl --out alice_rnl.pem
+$CLI pkey    --in alice_rnl.pem --pubout --out alice_rnl_pub.pem
+$CLI genpkey --algo hkex-rnl --out bob_rnl.pem
+
+# Round 1 — Bob sees Alice's public key and produces a RESPONSE PEM
+$CLI kex --algo hkex-rnl --our bob_rnl.pem --their alice_rnl_pub.pem \
+         --out bob_resp.pem
+
+# Round 2 — Alice sees Bob's response and derives the session key
+$CLI kex --algo hkex-rnl --our alice_rnl.pem --their bob_resp.pem \
+         --out alice_sk_rnl.pem
+# Both bob_resp.pem and alice_sk_rnl.pem hold the same session key.
+```
+
+See `CliTest/` for full integration test scripts covering all algorithms
+and cross-language interoperability.
 
 ---
 


### PR DESCRIPTION
## Summary

- Filled 11 tutorial documentation gaps identified by reviewing `docs/TUTORIAL.md` against all implemented features (TODOs #107–#117)
- Added code snippets for every protocol not yet covered: Go HPKS/HPKE classical, HSKE-NL-A2, HSKE-NL-AEAD, HPKS-NL, HPKE-NL, aPAKE, threshold signing (HPKS-T), HPKE-Stern-F KEM, HDRBG, HPKS-WOTS-F/XMSS-F
- Added a full CLI quickstart section covering all classical protocols
- Fixed incorrect Go OPRF import path (`herradurakex` → `herradurakex/herradura`)
- Added and updated protocol reference tables for hash-based stateful signatures
- Versions v1.9.50 through v1.9.60; each TODO = one PATCH bump

## Commits (11 TODOs, 11 commits)

| Version | TODO | Change |
|---------|------|--------|
| v1.9.50 | #114 | Fix Go OPRF import path; add tutorial TODO items #107–#117 |
| v1.9.51 | #113 | Add Go HPKS and HPKE classical snippets |
| v1.9.52 | #112 | Add CLI quickstart section |
| v1.9.53 | #108 | Add HSKE-NL-A2 C and Go examples |
| v1.9.54 | #109 | Full HSKE-NL-AEAD docs (C, Go, Python, CLI, table, security notes) |
| v1.9.55 | #107 | Add HPKS-NL and HPKE-NL examples (C, Go, Python) |
| v1.9.56 | #116 | Add aPAKE C and Go library API docs |
| v1.9.57 | #115 | Add threshold signing (HPKS-T) library API (C, Go, Python) |
| v1.9.58 | #117 | Add HPKE-Stern-F KEM examples (C, Go, Python) |
| v1.9.59 | #110 | Add HDRBG subsections + embedded-target note |
| v1.9.60 | #111 | Add HPKS-WOTS-F / HPKS-XMSS-F subsections + protocol table |

## Test plan

- [x] Verify `docs/TUTORIAL.md` renders correctly on GitHub (math expressions, code blocks)
- [x] Spot-check each new code snippet compiles/runs against `herradura.h` and `herradura/herradura.go`
- [x] Confirm CLI quickstart commands match `CliTest/` integration test scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)