### PR TITLE
Close TODO #94: ZKP-RNL soundness gaps — C/Go parity, NTT, formal reduction, ZKB++ size, hybrid credential (v1.9.63–v1.9.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.66] - 2026-06-24
+
+### Docs/Analysis — ZKB++ proof-size breakdown corrects 180 KB estimate (TODO #94 item 3c)
+
+- **`SecurityProofsCode/zkp_pqc_exploration.py`:** added §3.7 — a first-principles ZKB++
+  (Chase et al. 2017) vs basic ZKBoo size accounting from the NL-FSCX circuit parameters.
+  Itemises the four ZKB++ encodings (seed-derived input shares, single online-party AND
+  broadcast, hidden-party-only commitment) and computes both totals at n=8/32/256.
+- **`SecurityProofs-3.md` §11.10.4 / §11.10.6 direction 3:** corrected the over-optimistic
+  "5×/180 KB" ZKB++ estimate. The NL-FSCX circuit is AND-gate-broadcast-dominated
+  (2 040 B/round vs ~224 B overhead at n=256), so ZKB++ yields only **≈457 KB (2.0×)**,
+  governed by the 2×→1× online-party gate term. Reaching ~180 KB additionally requires a
+  sparse (LowMC-like) circuit to cut the AND-gate count — a separate circuit redesign,
+  now recorded as such. KaTeX validated (258 OK, 0 FAIL).
+
+---
+
 ## [1.9.65] - 2026-06-24
 
 ### Docs/Proof — Conditional Ring-LWR reduction for ZKP-RNL soundness (TODO #94 item 3a)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.64] - 2026-06-24
+
+### Docs/Analysis — ZKP-RNL Σ-protocol NTT acceleration confirmed (TODO #94 item 3b)
+
+- **`SecurityProofsCode/zkp_pqc_exploration.py`:** added §2.7 — a self-checking
+  negacyclic-NTT multiply (`_poly_mul_ntt`, iterative Cooley-Tukey `_ntt_inplace`) that
+  cross-validates against the O(n²) schoolbook multiply and benchmarks both at n=256/512.
+  Measured pure-Python speedup ≈6.8× at n=256 and ≈12.7× at n=512.
+- **`SecurityProofs-3.md` §11.10.6:** marked open direction 2 (NTT-accelerated Σ-protocol)
+  **Resolved** — the suite's prover/verifier already use the negacyclic NTT
+  (`rnl_poly_mul` / `_rnl_poly_mul` / `RnlPolyMul`) at the production degree n=256, with
+  schoolbook retained only for the n=32 didactic demo. Corrected the stale "prototype uses
+  schoolbook" claim.
+
+---
+
 ## [1.9.63] - 2026-06-24
 
 ### Test — ZKP-RNL structured-cheat parity in C and Go test [21] (TODO #94 item 2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.65] - 2026-06-24
+
+### Docs/Proof — Conditional Ring-LWR reduction for ZKP-RNL soundness (TODO #94 item 3a)
+
+- **`SecurityProofs-3.md` §11.10.7 (new):** formal conditional reduction of the relaxed
+  $\Sigma$-protocol soundness to Ring-LWR, routed through an intermediate approximate
+  Ring-SIS step. The forked relaxed witness $(\bar z, \bar c)$ yields a short vector
+  $v = \bar z - \bar c\cdot s$ with $\lVert m\cdot v\rVert_\infty \le 4t\lceil q/(2p)\rceil$;
+  either $v\ne 0$ (an approximate Ring-SIS solution for $m$) or $v=0$ (recovers a ring
+  multiple $\bar c\cdot s$ of the secret, contradicting pseudorandomness of $C$). The
+  rounding slack is quantified as the SIS modulus $\mu = 36t$ (144 at $n{=}32$, 576 at
+  $n{=}256$; ratios 0.22% / 0.88% of $q$), the precise gap vs the exact-witness
+  Lyubashevsky 2012 template. Marked open direction 1 Addressed (still conditional on
+  aR-SIS hardness for the HKEX-RNL $m$).
+- KaTeX validated (246 OK, 0 FAIL, 0 PIPE-FAIL).
+
+---
+
 ## [1.9.64] - 2026-06-24
 
 ### Docs/Analysis — ZKP-RNL Σ-protocol NTT acceleration confirmed (TODO #94 item 3b)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.63] - 2026-06-24
+
+### Test — ZKP-RNL structured-cheat parity in C and Go test [21] (TODO #94 item 2)
+
+- **`CryptosuiteTests/Herradura_tests.c` / `.go`:** extended security test [21] with the
+  three structured-cheat rejections already present in the Python suite — wrong-key witness
+  (honest signer run with a fresh `s' != s` against the original `C`), tampered commitment
+  `w` (must fail Fiat-Shamir re-derivation), and perturbed response `z` (must be caught by
+  the residual-norm check).  Runs at n=32 and n=256; output now reports
+  `wrongkey_reject`, `w_tamper`, and `z_tamper` columns alongside `verify`/`tamper_reject`.
+  All five checks PASS in both languages.  Closes the cross-language parity follow-up
+  deferred at v1.9.32.
+
+---
+
 ## [1.9.62] - 2026-06-24
 
 ### Feature — HSKE-NL-V2-Duplex: MonkeyDuplex-style single-pass AEAD (TODO #95 Option 2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.67] - 2026-06-24
+
+### Docs/Design — Hybrid Ring-LWR + Stern-F credential design sketch (TODO #94 item 3d; closes #94)
+
+- **`SecurityProofs-3.md` §11.10.8 (new):** design sketch for a compound zero-knowledge
+  credential proving knowledge of a Ring-LWR secret `s` matching public key `C` AND a
+  code-based credential bound to `s`. AND-composition of the §11.10.2 Ring-LWR Σ-protocol
+  and the Stern identification protocol (§11.8.4), glued by a binding commitment to `s`
+  with a single Fiat-Shamir challenge. States completeness, soundness (extractor recovers
+  both witnesses; commitment binding forces a consistent `s`), and zero-knowledge under
+  parallel composition. Estimated proof size ≈80 KB (Stern-F-dominated). Identifies the
+  open crux: the binding map φ relating the ternary ring secret to the fixed-weight binary
+  Stern witness with a cheap gadget.
+- **`SecurityProofs-3.md` §11.10.6:** marked open direction 4 Scoped.
+- **TODO #94 closed** — items 1–2 and research directions 3(a)–(d) all addressed at the
+  analysis/proof/design level; two open-ended implementation follow-ups (full ZKB++
+  encoder + sparse circuit; hybrid-credential gadget) recorded as future work.
+- KaTeX validated (315 OK, 0 FAIL, 0 PIPE-FAIL).
+
+---
+
 ## [1.9.66] - 2026-06-24
 
 ### Docs/Analysis — ZKB++ proof-size breakdown corrects 180 KB estimate (TODO #94 item 3c)

--- a/CryptosuiteTests/Herradura_tests.c
+++ b/CryptosuiteTests/Herradura_tests.c
@@ -4,7 +4,9 @@
      -t, --time   T   benchmark duration and per-test wall-clock cap in seconds
    Env:  HTEST_ROUNDS=N  HTEST_TIME=T  (CLI flags override env) */
 
-/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.43
+/*  Herradura KEx -- Security & Performance Tests (C, multi-size BitArray + scalar GF) v1.9.63
+    v1.9.63: ZKP-RNL test [21] structured cheats — wrong-key, tampered-w, perturbed-z rejection
+            (C/Go parity with Python, TODO #94 item 2).
     v1.9.43: HPKS-T threshold Schnorr test [31] (TODO #98); benchmarks renumbered [32]–[43].
     v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
@@ -3751,12 +3753,16 @@ static void test_zkp_rnl_correctness(void)
         int n = zkp_rnl_sizes[si];
         int N = g_rounds > 0 ? g_rounds : 5;
         int ok_verify = 0, ok_tamper = 0, i;
+        int ok_wrongkey = 0, ok_wtamper = 0, ok_ztamper = 0;
         struct timespec t0;
         clock_gettime(CLOCK_MONOTONIC, &t0);
         for (i = 0; i < N; i++) {
             int32_t m_base[256], a_rand[256], m_blind[256];
             int32_t s[256], C[256];
             int32_t w[256], c_poly[256], z[256];
+            int32_t s2[256], C2[256];
+            int32_t w2[256], c2[256], z2[256];
+            int32_t w_t[256], z_t[256];
             rnl_m_poly_n(m_base, n);
             rnl_rand_poly_n(a_rand, n);
             rnl_poly_add_n(m_blind, m_base, a_rand, n);
@@ -3775,11 +3781,40 @@ static void test_zkp_rnl_correctness(void)
             } else {
                 N = i + 1; break;
             }
+            /* Structured cheats (TODO #94 item 2 — C/Go parity):           */
+            /* (a) wrong-key witness: honest signer run with a fresh s' != s */
+            /*     against the original public key C — must not verify.      */
+            rnl_keygen_n(s2, C2, m_blind, n);
+            if (rnl_sigma_sign(s2, m_blind, C, n,
+                               zkp_msg, sizeof(zkp_msg) - 1, urnd_fp,
+                               w2, c2, z2) == 0) {
+                if (!rnl_sigma_verify(m_blind, C, n,
+                                      zkp_msg, sizeof(zkp_msg) - 1, w2, c2, z2))
+                    ok_wrongkey++;
+            } else {
+                ok_wrongkey++;   /* rejection-limit on a wrong key is a reject */
+            }
+            /* (b) tampered commitment w — must fail Fiat-Shamir re-derivation. */
+            memcpy(w_t, w, (size_t)n * sizeof(int32_t));
+            w_t[0] += 1;
+            if (!rnl_sigma_verify(m_blind, C, n,
+                                  zkp_msg, sizeof(zkp_msg) - 1, w_t, c_poly, z))
+                ok_wtamper++;
+            /* (c) perturbed response z (FS check still passes; the residual */
+            /*     norm check must catch it).                                */
+            memcpy(z_t, z, (size_t)n * sizeof(int32_t));
+            z_t[0] += 1;
+            if (!rnl_sigma_verify(m_blind, C, n,
+                                  zkp_msg, sizeof(zkp_msg) - 1, w, c_poly, z_t))
+                ok_ztamper++;
             if (g_time_limit > 0.0 && time_exceeded(&t0)) { N = i + 1; break; }
         }
-        printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
+        printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d"
+               "  wrongkey_reject=%d/%d  w_tamper=%d/%d  z_tamper=%d/%d  [%s]\n",
                n, ok_verify, N, ok_tamper, N,
-               (ok_verify == N && ok_tamper == N) ? "PASS" : "FAIL");
+               ok_wrongkey, N, ok_wtamper, N, ok_ztamper, N,
+               (ok_verify == N && ok_tamper == N && ok_wrongkey == N &&
+                ok_wtamper == N && ok_ztamper == N) ? "PASS" : "FAIL");
     }
     putchar('\n');
 }

--- a/CryptosuiteTests/Herradura_tests.go
+++ b/CryptosuiteTests/Herradura_tests.go
@@ -1,4 +1,6 @@
-/*  Herradura KEx — Security & Performance Tests (Go) v1.9.43
+/*  Herradura KEx — Security & Performance Tests (Go) v1.9.63
+    v1.9.63: ZKP-RNL test [21] structured cheats — wrong-key, tampered-w, perturbed-z rejection
+            (C/Go parity with Python, TODO #94 item 2).
     v1.9.43: HPKS-T threshold Schnorr test [31] (TODO #98); benchmarks renumbered [32]–[43].
     v1.9.42: HPKS-WOTS-F / HPKS-XMSS-F test [30] (TODO #102); benchmarks renumbered [31]–[42].
     v1.9.35: HFSCX-256-DM finalization of Stern parity-matrix rows (TODO #88);
@@ -935,6 +937,7 @@ func testZkpRnlCorrectness() {
 	for _, n := range zkpRnlSizes {
 		N := testRounds(5)
 		okVerify, okTamper := 0, 0
+		okWrongkey, okWtamper, okZtamper := 0, 0, 0
 		t0 := time.Now()
 		mBase := RnlMPoly(n)
 		for i := 0; i < N; i++ {
@@ -949,12 +952,38 @@ func testZkpRnlCorrectness() {
 			if !RnlSigmaVerify(mBlind, C, n, zkpMsg2, w, c, z) {
 				okTamper++
 			}
+			// Structured cheats (TODO #94 item 2 — C/Go parity):
+			// (a) wrong-key witness: honest signer run with a fresh s' != s
+			//     against the original public key C — must not verify.
+			s2, _ := RnlKeygen(mBlind, n, RnlQ, RnlP)
+			w2, c2, z2, err2 := RnlSigmaSign(s2, mBlind, C, n, zkpMsg)
+			if err2 != nil {
+				okWrongkey++ // rejection-limit on a wrong key is also a reject
+			} else if !RnlSigmaVerify(mBlind, C, n, zkpMsg, w2, c2, z2) {
+				okWrongkey++
+			}
+			// (b) tampered commitment w — must fail Fiat-Shamir re-derivation.
+			wT := append([]int(nil), w...)
+			wT[0]++
+			if !RnlSigmaVerify(mBlind, C, n, zkpMsg, wT, c, z) {
+				okWtamper++
+			}
+			// (c) perturbed response z (FS check still passes; the residual
+			//     norm check must catch it).
+			zT := append([]int(nil), z...)
+			zT[0]++
+			if !RnlSigmaVerify(mBlind, C, n, zkpMsg, w, c, zT) {
+				okZtamper++
+			}
 			if timeExceeded(t0) { N = i + 1; break }
 		}
 		status := "PASS"
-		if okVerify != N || okTamper != N { status = "FAIL" }
-		fmt.Printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d  [%s]\n",
-			n, okVerify, N, okTamper, N, status)
+		if okVerify != N || okTamper != N || okWrongkey != N ||
+			okWtamper != N || okZtamper != N { status = "FAIL" }
+		fmt.Printf("    n=%3d  verify=%d/%d  tamper_reject=%d/%d"+
+			"  wrongkey_reject=%d/%d  w_tamper=%d/%d  z_tamper=%d/%d  [%s]\n",
+			n, okVerify, N, okTamper, N, okWrongkey, N, okWtamper, N,
+			okZtamper, N, status)
 	}
 	fmt.Println()
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.63)
+# Herradura Cryptographic Suite (v1.9.64)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.64)
+# Herradura Cryptographic Suite (v1.9.65)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.66)
+# Herradura Cryptographic Suite (v1.9.67)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.65)
+# Herradura Cryptographic Suite (v1.9.66)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.62)
+# Herradura Cryptographic Suite (v1.9.63)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -122,7 +122,7 @@ The Fiat-Shamir seed includes $y$; a cheating prover supplying wrong $A$ (so $F_
 | 32 | 248 | 49.2 KB | — |
 | 256, $r=64$ | 16 320 | **920 KB** | 78 KB (Stern-F) |
 
-At production parameters ($n=256$, $R=219$), basic ZKBoo yields approximately 920 KB.  ZKB++ (Chase et al. 2017) achieves roughly $5\times$ reduction through an optimised decomposition, yielding approximately 180 KB — larger than Stern-F but applicable to NL-FSCX witness statements where Stern does not apply.
+At production parameters ($n=256$, $R=219$), basic ZKBoo yields approximately 920 KB.  ZKB++ (Chase et al. 2017) re-encodes each round — input shares from 16-byte seeds, a single online party's AND-gate broadcast (the dominant term drops from $2\times$ to $1\times$), and only the hidden party's commitment.  The often-quoted $5\times$ reduction assumes the per-round *overhead* (commitments, tapes) dominates; for the NL-FSCX circuit the AND-gate broadcast dominates instead (2 040 B/round vs ~224 B overhead/round at $n=256$), so the realistic reduction is governed by the $2\times{\to}1\times$ gate term.  A first-principles accounting (`zkp_pqc_exploration.py` §3.7) gives **≈457 KB at $n=256$, a $2.0\times$ reduction** — not 180 KB.  Reaching ~180 KB would require reducing the AND-gate count itself (e.g. a LowMC-like sparse circuit), a circuit redesign separate from the ZKB++ transcript encoding.
 
 **Honest limitation.** The NL-FSCX OWF assumption (§11.8.3) must hold.  The rotational-structure open concern (§11.8.3, TODO #75) affects two-sided rotation only (WOTS hash chain); one-sided rotation (all PRF uses, including the carry-chain circuit) gives coincidence probability $\approx 0$, so the ZKBoo construction is unaffected.
 
@@ -155,7 +155,7 @@ ARM Thumb-2 and NASM i386 targets implement ZKP-RNL only (`rnl_sigma_sign_32`, `
 
 ZKP-RNL at n=256 produces a 1,056-byte proof — smaller than both HPKS-Stern-F (78 KB) and the NIST reference scheme ML-DSA-44 (2,420 bytes).  It is therefore the most compact PQC signing option in the suite for Ring-LWR keys, at the cost of heuristic rather than tight security.
 
-ZKP-NL at n=256 and R=219 yields 920 KB, which exceeds practical limits for most use cases.  The CLI defaults to n=8 (35.5 KB) for this reason.  The ZKB++ optimisation (§11.10.6 open direction 3) would reduce the n=256 proof to approximately 180 KB.
+ZKP-NL at n=256 and R=219 yields 920 KB, which exceeds practical limits for most use cases.  The CLI defaults to n=8 (35.5 KB) for this reason.  The ZKB++ optimisation (§11.10.6 open direction 3) would reduce the n=256 proof to approximately 457 KB ($2.0\times$, gate-broadcast-dominated — see §11.10.4 size breakdown), not the generic $5\times$/180 KB.
 
 CLI integration is documented in `docs/TUTORIAL.md §ZKP Protocols`.  Cross-language interop is verified by `CliTest/test_zkp_interop.sh` (14-way test: 6 signing directions per protocol, plus 2 tamper-rejection checks).
 
@@ -166,7 +166,8 @@ CLI integration is documented in `docs/TUTORIAL.md §ZKP Protocols`.  Cross-lang
 | PQC signature | HPKS-Stern-F (§11.8.4) | 78 KB | **Demo parameters** ($N=256$, ~30–40 bits security); 128-bit requires $N \geq 17000$ |
 | Ring-LWR key proof / anonymous cred | Ring-LWR $\Sigma$-protocol (§11.10.2) | 1 KB | Implemented v1.9.x; heuristic security |
 | NL-FSCX witness proof | ZKBoo (§11.10.3) | 920 KB | Implemented v1.9.x; CLI defaults to n=8 |
-| NL-FSCX with circuit optimisation | ZKB++ / Picnic variant | ~180 KB (est.) | Future work |
+| NL-FSCX with ZKB++ encoding | ZKB++ / Picnic variant | ~457 KB ($2.0\times$, est.) | Future work |
+| NL-FSCX with sparse circuit | ZKB++ + LowMC-like circuit | ~180 KB (est.) | Future work (circuit redesign) |
 
 For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-protocol is the most practical option: its 1 KB proof size is competitive with ML-DSA-44 (2.4 KB).
 
@@ -176,7 +177,7 @@ For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-pr
 
 2. **NTT-accelerated $\Sigma$-protocol.** *(Resolved v1.9.64.)*  The prover and verifier polynomial products in the reference suite (`rnl_poly_mul` / `_rnl_poly_mul` / `RnlPolyMul`) use the negacyclic NTT over $Z_q[x]/(x^n+1)$ (the same path as HKEX-RNL, §11.4.2) at the production degree $n=256$, giving $O(n \log n)$ prover and verifier; the $O(n^2)$ schoolbook multiply is retained only for the $n=32$ didactic demo, where NTT twiddles are not precomputed and the cost is negligible.  `SecurityProofsCode/zkp_pqc_exploration.py` §2.7 cross-checks the NTT result against schoolbook and measures the speedup ($\approx 6.8\times$ at $n=256$, $\approx 12.7\times$ at $n=512$ in pure Python).
 
-3. **ZKB++ on NL-FSCX.** Implement Chase et al. 2017's optimised MPC-in-the-head decomposition to reduce NL-FSCX ZKBoo proofs from 920 KB to approximately 180 KB.
+3. **ZKB++ on NL-FSCX.** *(Scoped v1.9.66 — see §11.10.4 and `zkp_pqc_exploration.py` §3.7.)*  Implement Chase et al. 2017's optimised MPC-in-the-head decomposition.  A first-principles size accounting shows ZKB++ reduces the $n=256$ proof from 920 KB to **≈457 KB ($2.0\times$)**, not the generic 180 KB — the NL-FSCX circuit is AND-gate-broadcast-dominated, so only the $2\times{\to}1\times$ online-party term helps.  Reaching ~180 KB additionally requires a sparse (LowMC-like) circuit to cut the AND-gate count; that circuit redesign remains open.
 
 4. **Hybrid credential scheme.** Combine the Ring-LWR $\Sigma$-protocol with HPKS-Stern-F to prove "I hold a Ring-LWR private key $s$ matching public key $C$ AND a Stern-F signature valid under $s$" — enabling privacy-preserving authentication with a single compound proof.
 

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -172,13 +172,47 @@ For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-pr
 
 ### 11.10.6 Open Research Directions
 
-1. **Formal Ring-LWR reduction.** Establish a tight security reduction from the $\Sigma$-protocol soundness to Ring-LWR distinguishing hardness.  Quantify the effect of the rounding slack ($\leq t \cdot q/(2p) = 32$) on the security margin relative to the Lyubashevsky 2012 template.
+1. **Formal Ring-LWR reduction.** *(Addressed v1.9.65 — conditional reduction in §11.10.7.)*  A reduction from relaxed $\Sigma$-protocol soundness to Ring-LWR is given via an intermediate approximate Ring-SIS step; the rounding slack enters as the SIS modulus $4t \lceil q/(2p) \rceil$ (= $36t$ for the suite's $q, p$).  It remains conditional on the hardness of approximate Ring-SIS for the HKEX-RNL blinding polynomial $m$ (itself implied by Ring-LWR for $m$), so it is not yet a fully tight standard-model reduction.
 
 2. **NTT-accelerated $\Sigma$-protocol.** *(Resolved v1.9.64.)*  The prover and verifier polynomial products in the reference suite (`rnl_poly_mul` / `_rnl_poly_mul` / `RnlPolyMul`) use the negacyclic NTT over $Z_q[x]/(x^n+1)$ (the same path as HKEX-RNL, §11.4.2) at the production degree $n=256$, giving $O(n \log n)$ prover and verifier; the $O(n^2)$ schoolbook multiply is retained only for the $n=32$ didactic demo, where NTT twiddles are not precomputed and the cost is negligible.  `SecurityProofsCode/zkp_pqc_exploration.py` §2.7 cross-checks the NTT result against schoolbook and measures the speedup ($\approx 6.8\times$ at $n=256$, $\approx 12.7\times$ at $n=512$ in pure Python).
 
 3. **ZKB++ on NL-FSCX.** Implement Chase et al. 2017's optimised MPC-in-the-head decomposition to reduce NL-FSCX ZKBoo proofs from 920 KB to approximately 180 KB.
 
 4. **Hybrid credential scheme.** Combine the Ring-LWR $\Sigma$-protocol with HPKS-Stern-F to prove "I hold a Ring-LWR private key $s$ matching public key $C$ AND a Stern-F signature valid under $s$" — enabling privacy-preserving authentication with a single compound proof.
+
+### 11.10.7 Conditional Reduction of Relaxed Soundness to Ring-LWR (TODO #94 item 3a)
+
+This subsection makes open direction 1 concrete: it reduces the relaxed special soundness of the §11.10.2 $\Sigma$-protocol to the hardness of Ring-LWR, routing through an intermediate *approximate Ring-SIS* problem, and quantifies exactly how the rounding slack enters the security margin.  The reduction is conditional (stated assumptions below) rather than a fully tight standard-model reduction, matching the honest limitation already recorded in §11.10.2.
+
+**Hardness assumptions.**  Work in $\mathcal{R}_q = \mathbb{Z}_q[x]/(x^n+1)$ with $q = 65537$, $p = 4096$.
+
+- **(R-LWR) Decision Ring-LWR with rounding.**  For $m \xleftarrow{R} \mathcal{R}_q$ and ternary $s \xleftarrow{R} \{-1,0,1\}^n$, the pair $(m, \text{round-p}(m \cdot s))$ is computationally indistinguishable from $(m, u)$ with $u \xleftarrow{R} \mathbb{Z}_p^n$.  Write the distinguishing advantage bound as $\epsilon_{\text{RLWR}}$.
+- **(aR-SIS) Approximate Ring-SIS for the suite modulus.**  Given $m \xleftarrow{R} \mathcal{R}_q$, it is hard to find a nonzero $v \in \mathcal{R}_q$ with $\lVert v \rVert_\infty \leq \beta$ and $\lVert m \cdot v \rVert_\infty \leq \mu$ for the parameters $(\beta, \mu)$ derived below.  For $m$ sampled as in HKEX-RNL this is implied by R-LWR (a short kernel-like relation for a pseudorandom $m$ would itself distinguish $m \cdot s$ from uniform).
+
+**Extracted relaxed witness (from §11.10.2).**  Forking a cheating prover that succeeds with probability $\delta$ over $Q_H$ random-oracle queries yields, with probability at least $\delta^2/Q_H - \text{negl}$, two accepting transcripts $(w, c, z)$ and $(w, c', z')$ with $c \neq c'$.  Setting $\bar{z} = z - z'$ and $\bar{c} = c - c'$, subtracting the two third verification equations gives
+
+$$\lVert m \cdot \bar{z} - \bar{c} \cdot \text{lift}(C) \rVert_\infty \leq 2t \lceil q/(2p) \rceil, \quad \bar{c} \neq 0, \quad \lVert \bar{z} \rVert_\infty \leq 2(\gamma - t).$$
+
+**Reduction to aR-SIS.**  By definition of rounding, $\text{lift}(C) = m \cdot s - \varepsilon$ with $\lVert \varepsilon \rVert_\infty \leq \lceil q/(2p) \rceil$.  Substitute:
+
+$$m \cdot \bar{z} - \bar{c} \cdot \text{lift}(C) = m \cdot \bar{z} - \bar{c} \cdot (m \cdot s - \varepsilon) = m \cdot (\bar{z} - \bar{c} \cdot s) + \bar{c} \cdot \varepsilon.$$
+
+Let $v = \bar{z} - \bar{c} \cdot s$.  Then $\lVert m \cdot v \rVert_\infty \leq 2t \lceil q/(2p) \rceil + \lVert \bar{c} \cdot \varepsilon \rVert_\infty$.  Since $\bar{c}$ has at most $2t$ nonzero coefficients each of magnitude $\leq 2$ and $\lVert \varepsilon \rVert_\infty \leq \lceil q/(2p) \rceil$, we have $\lVert \bar{c} \cdot \varepsilon \rVert_\infty \leq 2t \lceil q/(2p) \rceil$, hence
+
+$$\lVert m \cdot v \rVert_\infty \leq 4t \lceil q/(2p) \rceil =: \mu, \qquad \lVert v \rVert_\infty \leq 2(\gamma - t) + 2t = 2\gamma =: \beta.$$
+
+**Two cases.**
+
+- **$v \neq 0$:** the pair $v$ is a valid aR-SIS solution for $m$ with slack $\mu$ and norm $\beta$ — directly contradicting (aR-SIS), hence (by the stated implication) R-LWR.
+- **$v = 0$:** then $\bar{z} = \bar{c} \cdot s$, so the extractor has recovered a nonzero ring multiple $\bar{c} \cdot s$ of the secret from public data alone.  Recovering a $\bar{c}$-multiple of $s$ given only $(m, C)$ contradicts the pseudorandomness of $C$ under R-LWR (a simulator that learns $\bar{c} \cdot s$ for known sparse $\bar{c}$ can test it against $C$ and so distinguish $C$ from uniform).
+
+In both cases a successful cheating prover breaks R-LWR, up to the forking loss $\delta \mapsto \delta^2/Q_H$ and the $2\times$ witness-norm widening inherent to relaxed soundness.
+
+**Rounding-slack quantification.**  The slack modulus is
+
+$$\mu = 4t \lceil q/(2p) \rceil = 4t \lceil 65537/8192 \rceil = 4t \cdot 9 = 36t.$$
+
+Numerically $\mu = 144$ at $t = 4$ ($n = 32$) and $\mu = 576$ at $t = 16$ ($n = 256$), against $q = 65537$.  The ratio $\mu/q$ is 0.22% and 0.88% respectively — the extracted relation $m \cdot v$ is genuinely short relative to $q$, so the aR-SIS instance is non-trivial (a random $v$ of norm $\beta = 2\gamma$ would give $\lVert m \cdot v \rVert_\infty \approx q/2$).  Relative to the Lyubashevsky 2012 template — prime $q$ and a challenge ring chosen so that $\bar{c}$ is always invertible, yielding an *exact* ($\mu = 0$) inhomogeneous-SIS witness — the suite trades exactness for the rounding slack $\mu = 36t$.  This is the precise quantitative gap requested by open direction 1; it scales linearly in the challenge weight $t$ and is independent of $n$, so wider challenges (stronger soundness per round) cost proportionally more slack.
 
 **References.**
 - Lyubashevsky 2012. *Lattice Signatures Without Trapdoors*. Eurocrypt 2012, LNCS 7237, pp. 738–755.

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -179,7 +179,7 @@ For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-pr
 
 3. **ZKB++ on NL-FSCX.** *(Scoped v1.9.66 — see §11.10.4 and `zkp_pqc_exploration.py` §3.7.)*  Implement Chase et al. 2017's optimised MPC-in-the-head decomposition.  A first-principles size accounting shows ZKB++ reduces the $n=256$ proof from 920 KB to **≈457 KB ($2.0\times$)**, not the generic 180 KB — the NL-FSCX circuit is AND-gate-broadcast-dominated, so only the $2\times{\to}1\times$ online-party term helps.  Reaching ~180 KB additionally requires a sparse (LowMC-like) circuit to cut the AND-gate count; that circuit redesign remains open.
 
-4. **Hybrid credential scheme.** Combine the Ring-LWR $\Sigma$-protocol with HPKS-Stern-F to prove "I hold a Ring-LWR private key $s$ matching public key $C$ AND a Stern-F signature valid under $s$" — enabling privacy-preserving authentication with a single compound proof.
+4. **Hybrid credential scheme.** *(Scoped v1.9.67 — design sketch in §11.10.8.)*  Combine the Ring-LWR $\Sigma$-protocol with HPKS-Stern-F to prove "I hold a Ring-LWR private key $s$ matching public key $C$ AND a code-based credential bound to $s$" — an AND-composition glued by a binding commitment to $s$, single Fiat-Shamir challenge, estimated proof size $\approx 80$ KB (Stern-F-dominated).  The unresolved crux is the binding map $\phi$ relating the ternary ring secret to the fixed-weight binary Stern witness with a cheap gadget; until that is settled the scheme stays a design sketch.
 
 ### 11.10.7 Conditional Reduction of Relaxed Soundness to Ring-LWR (TODO #94 item 3a)
 
@@ -214,6 +214,32 @@ In both cases a successful cheating prover breaks R-LWR, up to the forking loss 
 $$\mu = 4t \lceil q/(2p) \rceil = 4t \lceil 65537/8192 \rceil = 4t \cdot 9 = 36t.$$
 
 Numerically $\mu = 144$ at $t = 4$ ($n = 32$) and $\mu = 576$ at $t = 16$ ($n = 256$), against $q = 65537$.  The ratio $\mu/q$ is 0.22% and 0.88% respectively — the extracted relation $m \cdot v$ is genuinely short relative to $q$, so the aR-SIS instance is non-trivial (a random $v$ of norm $\beta = 2\gamma$ would give $\lVert m \cdot v \rVert_\infty \approx q/2$).  Relative to the Lyubashevsky 2012 template — prime $q$ and a challenge ring chosen so that $\bar{c}$ is always invertible, yielding an *exact* ($\mu = 0$) inhomogeneous-SIS witness — the suite trades exactness for the rounding slack $\mu = 36t$.  This is the precise quantitative gap requested by open direction 1; it scales linearly in the challenge weight $t$ and is independent of $n$, so wider challenges (stronger soundness per round) cost proportionally more slack.
+
+### 11.10.8 Hybrid Ring-LWR + Stern-F Credential — Design Sketch (TODO #94 item 3d)
+
+This subsection scopes open direction 4: a single compound zero-knowledge proof asserting *"I hold a Ring-LWR secret $s$ matching public key $C$ **and** a code-based credential bound to $s$,"* without revealing $s$ or the credential.  The construction is an AND-composition of the two $\Sigma$-protocols the suite already provides — the §11.10.2 Ring-LWR protocol and the Stern identification protocol underlying HPKS-Stern-F (§11.8.4) — glued by a commitment that forces both to speak about the same secret.
+
+**Statement and witness.**
+
+- *Public:* the Ring-LWR pair $(m, C)$ with $C = \text{round-p}(m \cdot s)$; a binary parity-check matrix $H \in \mathbb{F}_2^{(N-k) \times N}$ and a syndrome $y = H e^{\top}$ (the Stern statement).
+- *Witness:* the ternary $s \in \{-1,0,1\}^n$ and a low-weight $e \in \mathbb{F}_2^N$ with $\text{wt}(e) = t_{\text{S}}$, subject to a binding relation $e = \phi(s)$ for a fixed public map $\phi$ (below).
+
+**Binding the two witnesses.**  The two relations live in different algebras — $s$ is ternary in $\mathcal{R}_q$, $e$ is binary in $\mathbb{F}_2^N$ — so "the same $s$" must be enforced explicitly.  The design commits to $s$ once with a binding commitment $\text{cmt}(s; r)$ (a BDLOP-style lattice commitment, or a hash commitment to the bit-decomposition of $s$) and runs both sub-protocols against that single commitment:
+
+1. the Ring-LWR $\Sigma$-protocol proves $C = \text{round-p}(m \cdot s)$ for the committed $s$;
+2. a bit-decomposition gadget proves $e = \phi(s)$ (e.g. $\phi$ maps the sign pattern of $s$ to a fixed-weight binary word) for the committed $s$, after which the Stern protocol proves $H e^{\top} = y$ with $\text{wt}(e) = t_{\text{S}}$.
+
+**AND-composition (non-interactive).**  Run both sub-protocols in parallel with independent prover randomness and derive a single Fiat-Shamir challenge $\text{ch} = H_{\text{FS}}(\text{cmt}(s), \text{transcript}_{\text{RLWR}}, \text{transcript}_{\text{Stern}}, m, C, H, y)$, then split $\text{ch}$ into the per-protocol challenges.  Hashing both commitment phases together binds the two proofs to one prover and one $s$.
+
+**Security.**
+
+- *Completeness* follows from the completeness of each sub-protocol.
+- *Soundness:* AND-composition of two sound $\Sigma$-protocols is sound — an extractor that rewinds the shared challenge recovers a relaxed Ring-LWR witness (§11.10.7) **and** a Stern witness; the binding of $\text{cmt}(s)$ forces the extracted $s$ to be consistent across both, so a prover lacking either secret fails one branch.  Soundness error is the max of the two per-round errors; both are driven to $2^{-128}$ by their existing round counts ($R = 219$ for Stern; one relaxed FS round for Ring-LWR).
+- *Zero-knowledge:* parallel composition with independent randomness preserves honest-verifier ZK; the commitment is hiding, so $\text{cmt}(s)$ leaks nothing.
+
+**Proof size (estimate).**  Additive minus the shared commitment: ZKP-RNL ($\approx 1.03$ KB at $n=256$, §11.10.2) $+$ Stern-F ($\approx 78$ KB at $N=256$, $R=219$) $+$ the bit-decomposition gadget and commitment ($\approx 1$–2 KB) $\approx$ **80 KB**, dominated by the Stern-F component.
+
+**Open problem.**  The crux is the binding map $\phi$ and its gadget: a sound, ZK proof that a committed ternary ring element and a committed fixed-weight binary word are related requires either (a) an arithmetic-circuit proof of the bit-decomposition (expensive), or (b) choosing $\phi$ so the relation is linear over a common ring (restrictive).  Designing $\phi$ so that $\text{wt}(\phi(s)) = t_{\text{S}}$ holds for honest $s$ while keeping the gadget cheap is the main unresolved question; until it is settled the scheme remains a design sketch rather than an implementation.
 
 **References.**
 - Lyubashevsky 2012. *Lattice Signatures Without Trapdoors*. Eurocrypt 2012, LNCS 7237, pp. 738–755.

--- a/SecurityProofs-3.md
+++ b/SecurityProofs-3.md
@@ -174,7 +174,7 @@ For anonymous credential applications on HKEX-RNL keys, the Ring-LWR $\Sigma$-pr
 
 1. **Formal Ring-LWR reduction.** Establish a tight security reduction from the $\Sigma$-protocol soundness to Ring-LWR distinguishing hardness.  Quantify the effect of the rounding slack ($\leq t \cdot q/(2p) = 32$) on the security margin relative to the Lyubashevsky 2012 template.
 
-2. **NTT-accelerated $\Sigma$-protocol.** The prototype uses $O(n^2)$ schoolbook multiplication.  Extend to NTT-based negacyclic multiply (already in HKEX-RNL, §11.4.2) for $O(n \log n)$ prover and verifier at $n=256$.
+2. **NTT-accelerated $\Sigma$-protocol.** *(Resolved v1.9.64.)*  The prover and verifier polynomial products in the reference suite (`rnl_poly_mul` / `_rnl_poly_mul` / `RnlPolyMul`) use the negacyclic NTT over $Z_q[x]/(x^n+1)$ (the same path as HKEX-RNL, §11.4.2) at the production degree $n=256$, giving $O(n \log n)$ prover and verifier; the $O(n^2)$ schoolbook multiply is retained only for the $n=32$ didactic demo, where NTT twiddles are not precomputed and the cost is negligible.  `SecurityProofsCode/zkp_pqc_exploration.py` §2.7 cross-checks the NTT result against schoolbook and measures the speedup ($\approx 6.8\times$ at $n=256$, $\approx 12.7\times$ at $n=512$ in pure Python).
 
 3. **ZKB++ on NL-FSCX.** Implement Chase et al. 2017's optimised MPC-in-the-head decomposition to reduce NL-FSCX ZKBoo proofs from 920 KB to approximately 180 KB.
 

--- a/SecurityProofsCode/zkp_pqc_exploration.py
+++ b/SecurityProofsCode/zkp_pqc_exploration.py
@@ -23,6 +23,8 @@ This script covers the two NOT-yet-implemented pillars:
       §2.5  Proof-size analysis
       §2.6  Challenge-difference invertibility in R_q (relaxed soundness
             motivation: x^n+1 splits over F_q since 2n | q-1)
+      §2.7  NTT-accelerated multiply vs O(n²) schoolbook (TODO #94 item 2):
+            self-checking correctness + measured speedup at n=256/512
   §3  NL-FSCX ZKP via MPC-in-the-head (ZKBoo, 3-party Boolean circuit)
       §3.1  NL-FSCX v1 bit-level circuit (n=8 toy)
       §3.2  ZKBoo 3-party evaluation with per-AND-gate commitments
@@ -456,6 +458,85 @@ def section2_invertibility():
     print("  of c-c' is taken.")
 
 
+# ── §2.7  NTT-accelerated Σ-protocol multiply (TODO #94 item 2) ──────────────
+
+def _ntt_inplace(a, omega, q, n):
+    """Iterative in-place Cooley-Tukey NTT.  omega: primitive n-th root of 1."""
+    j = 0
+    for i in range(1, n):                       # bit-reversal permutation
+        bit = n >> 1
+        while j & bit:
+            j ^= bit
+            bit >>= 1
+        j ^= bit
+        if i < j:
+            a[i], a[j] = a[j], a[i]
+    length = 2
+    while length <= n:
+        wlen = pow(omega, n // length, q)
+        for i in range(0, n, length):
+            w = 1
+            half = length >> 1
+            for k in range(i, i + half):
+                u = a[k]
+                v = a[k + half] * w % q
+                a[k] = (u + v) % q
+                a[k + half] = (u - v) % q
+                w = w * wlen % q
+        length <<= 1
+
+
+def _poly_mul_ntt(f, g, q, n):
+    """Negacyclic multiply in Z_q[x]/(x^n+1) via NTT.  O(n log n).
+
+    Requires n a power of two with 2n | q-1.  Mirrors the suite's
+    negacyclic-NTT path (rnl_poly_mul / _rnl_poly_mul / RnlPolyMul):
+    pre-twist by psi^i, length-n cyclic NTT with omega=psi^2, pointwise
+    product, inverse NTT, post-twist by psi^{-i} and scale by n^{-1}."""
+    assert (q - 1) % (2 * n) == 0, "x^n+1 does not split fully over Z_q"
+    psi     = pow(3, (q - 1) // (2 * n), q)      # primitive 2n-th root (psi^n=-1)
+    psi_inv = pow(psi, q - 2, q)
+    n_inv   = pow(n, q - 2, q)
+    omega   = psi * psi % q                      # primitive n-th root
+    fa = [f[i] * pow(psi, i, q) % q for i in range(n)]
+    ga = [g[i] * pow(psi, i, q) % q for i in range(n)]
+    _ntt_inplace(fa, omega, q, n)
+    _ntt_inplace(ga, omega, q, n)
+    ha = [fa[i] * ga[i] % q for i in range(n)]
+    _ntt_inplace(ha, pow(omega, q - 2, q), q, n)
+    return [ha[i] * n_inv % q * pow(psi_inv, i, q) % q for i in range(n)]
+
+
+def section2_ntt_benchmark():
+    """Empirically confirm the suite's NTT path: same result as schoolbook,
+    measurably faster at the production degree n=256.  TODO #94 item 2."""
+    print(SEP2)
+    print("§2.7  NTT-accelerated Σ-protocol multiply (vs O(n²) schoolbook)")
+    q = _Q
+    for n, reps in [(256, 200), (512, 100)]:
+        if (q - 1) % (2 * n) != 0:
+            continue
+        fs = [_rand_poly(n, q) for _ in range(reps)]
+        gs = [_rand_poly(n, q) for _ in range(reps)]
+        # correctness: NTT must equal schoolbook on the first sample
+        assert _poly_mul_ntt(fs[0], gs[0], q, n) == _poly_mul(fs[0], gs[0], q, n), \
+            "NTT multiply disagrees with schoolbook"
+        t0 = time.perf_counter()
+        for i in range(reps):
+            _poly_mul(fs[i], gs[i], q, n)
+        t_school = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        for i in range(reps):
+            _poly_mul_ntt(fs[i], gs[i], q, n)
+        t_ntt = time.perf_counter() - t0
+        speedup = t_school / t_ntt if t_ntt > 0 else float('inf')
+        print(f"  n={n:4d} ({reps} mults): schoolbook={t_school*1e3:8.1f} ms  "
+              f"NTT={t_ntt*1e3:8.1f} ms  speedup={speedup:5.1f}x  [results match]")
+    print("  The reference suite (rnl_poly_mul / _rnl_poly_mul / RnlPolyMul) uses")
+    print("  this negacyclic-NTT path for prover and verifier at the production")
+    print("  degree n=256; schoolbook is retained only for the n=32 didactic demo.")
+
+
 def section2():
     print()
     print(SEP)
@@ -468,6 +549,7 @@ def section2():
     section2_structured_cheats()
     section2_proofsize()
     section2_invertibility()
+    section2_ntt_benchmark()
 
 
 # =============================================================================

--- a/SecurityProofsCode/zkp_pqc_exploration.py
+++ b/SecurityProofsCode/zkp_pqc_exploration.py
@@ -32,6 +32,8 @@ This script covers the two NOT-yet-implemented pillars:
       §3.4  Completeness — 1 000 honest-prover trials
       §3.5  Soundness   — 200 cheating-prover trials
       §3.6  Proof-size analysis and scaling to n=256
+      §3.7  ZKB++ size breakdown vs basic ZKBoo (TODO #94 item 3c):
+            realistic ~2.0× (≈457 KB at n=256), not the generic 5×/180 KB
   §4  Parameter comparison vs NIST PQC standards
   §5  Summary and open construction paths
 
@@ -941,6 +943,59 @@ def section3_proofsize():
     print("  can reduce proof size 5-10× vs basic ZKBoo.")
 
 
+# ── §3.7  ZKB++ size breakdown (TODO #94 item 3c) ─────────────────────────────
+
+def section3_zkbpp_size():
+    """First-principles ZKB++ (Chase et al. 2017) vs ZKBoo size accounting.
+
+    ZKB++ applies four encodings to each round of ZKBoo:
+      (1) input shares of 2 parties are PRG-derived from 16-byte seeds, so only
+          seeds (not full n-bit shares) are sent for them;
+      (2) the third party's input "offset" share is sent once (ceil(n/8) B);
+      (3) only the single 'online' revealed party broadcasts its AND-gate output
+          bits — the other revealed party is recomputed offline from its seed,
+          so the dominant gate-bit term drops from 2x to 1x;
+      (4) only the hidden party's commitment is sent (32 B); the two opened
+          commitments are recomputed by the verifier.
+
+    The generic '5x' figure assumes the per-round overhead (commitments, tapes)
+    dominates.  For NL-FSCX the AND-gate broadcast dominates, so the realistic
+    reduction is governed by the 2x->1x gate term — quantified below."""
+    print(SEP2)
+    print("§3.7  NL-FSCX ZKB++ proof-size breakdown (vs basic ZKBoo)")
+    print()
+    SEED = 16                                   # 128-bit PRG seed
+    COM  = 32                                   # 256-bit commitment hash
+    prod_R = 219                                # 128-bit soundness
+    for n, label in [(_ZK_N, 'toy (n=8)'), (32, 'n=32'), (256, 'n=256, r=64')]:
+        r_steps   = max(1, n // 4)
+        and_total = r_steps * (n - 1)
+        share_b   = math.ceil(n / 8)
+        gate_b    = math.ceil(and_total / 8)
+
+        # ZKBoo per-round: 3 commitments + 2 full views (share+tape+gate each)
+        zkboo_pr  = 3 * COM + 2 * (share_b + COM + gate_b)
+        # ZKB++ per-round: 2 seeds + 1 input-offset share + 1x gate broadcast
+        #                  + 1 hidden-party commitment
+        zkbpp_pr  = 2 * SEED + share_b + gate_b + COM
+
+        zkboo_tot = prod_R * zkboo_pr
+        zkbpp_tot = prod_R * zkbpp_pr
+        factor    = zkboo_tot / zkbpp_tot
+
+        print(f"  {label}:  AND gates = {and_total}, gate-bits/round = {gate_b} B")
+        print(f"    ZKBoo (R={prod_R}) : {zkboo_tot:8,} B ({zkboo_tot/1024:7.1f} KB)")
+        print(f"    ZKB++ (R={prod_R}) : {zkbpp_tot:8,} B ({zkbpp_tot/1024:7.1f} KB)"
+              f"   reduction = {factor:.2f}x")
+    print()
+    print("  Finding: at n=256 the AND-gate broadcast (2040 B/round) dominates the")
+    print("  fixed overhead (~224 B/round), so ZKB++'s single-online-party encoding")
+    print("  yields only ~2.0x (≈457 KB), NOT the generic 5x (~180 KB) quoted for")
+    print("  overhead-dominated circuits.  Reaching ~180 KB requires reducing the")
+    print("  AND-gate count itself (e.g. a LowMC-like sparse circuit), which is a")
+    print("  circuit redesign separate from the ZKB++ transcript encoding.")
+
+
 def section3():
     print()
     print(SEP)
@@ -953,6 +1008,7 @@ def section3():
     section3_completeness()
     section3_soundness()
     section3_proofsize()
+    section3_zkbpp_size()
 
 
 # =============================================================================

--- a/TODO.md
+++ b/TODO.md
@@ -5856,7 +5856,19 @@ size breakdown; corrected the over-optimistic "5×/180 KB" claim to the realisti
 the 2×→1× online-party term helps; reaching ~180 KB needs a sparse LowMC-like circuit
 redesign).  SecurityProofs-3.md §11.10.4/§11.10.6 direction 3 updated.  A full ZKB++
 *implementation* (and the sparse-circuit redesign) remain open as future work.  Item
-3(d) hybrid Ring-LWR + Stern-F credential remains **OPEN**.
+3(d) hybrid Ring-LWR + Stern-F credential **DONE v1.9.67** (design sketch) —
+SecurityProofs-3.md §11.10.8 specifies the AND-composition of the Ring-LWR Σ-protocol
+and the Stern identification protocol, glued by a binding commitment to s with a single
+Fiat-Shamir challenge; completeness/soundness/ZK argued, proof size estimated ≈80 KB
+(Stern-F-dominated); the unresolved crux is the binding map φ relating the ternary ring
+secret to the fixed-weight binary Stern witness with a cheap gadget.
+
+**Overall #94 status: DONE v1.9.67** — items 1–2 (relaxed soundness + structured cheats,
+C/Go parity) and the §11.10.6 research directions 3(a)–(d) are all addressed at the
+analysis/proof/design level.  Two open-ended *implementation* follow-ups remain as future
+work and may be split into their own TODO entries: (i) a full ZKB++ transcript encoder
+plus a sparse LowMC-like NL-FSCX circuit to approach ~180 KB, and (ii) the
+hybrid-credential binding gadget φ and a working compound-proof implementation.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -5849,7 +5849,14 @@ SecurityProofs-3.md §11.10.7 gives a conditional reduction of relaxed Σ-protoc
 soundness to Ring-LWR via an intermediate approximate Ring-SIS step, with the rounding
 slack quantified as the SIS modulus 4t⌈q/(2p)⌉ = 36t (144 at n=32, 576 at n=256); the
 reduction remains conditional on aR-SIS hardness for the HKEX-RNL m, so it is not a fully
-tight standard-model reduction (recorded honestly).  Items 3(c), 3(d) remain **OPEN**.
+tight standard-model reduction (recorded honestly).  Item 3(c) ZKB++ size analysis
+**DONE v1.9.66** — `zkp_pqc_exploration.py` §3.7 gives a first-principles ZKB++-vs-ZKBoo
+size breakdown; corrected the over-optimistic "5×/180 KB" claim to the realistic
+**≈457 KB (2.0×)** at n=256 (the NL-FSCX circuit is AND-gate-broadcast-dominated, so only
+the 2×→1× online-party term helps; reaching ~180 KB needs a sparse LowMC-like circuit
+redesign).  SecurityProofs-3.md §11.10.4/§11.10.6 direction 3 updated.  A full ZKB++
+*implementation* (and the sparse-circuit redesign) remain open as future work.  Item
+3(d) hybrid Ring-LWR + Stern-F credential remains **OPEN**.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -5836,8 +5836,10 @@ non-invertible differences — strict special soundness is genuinely false at th
 parameters.  Structured cheats implemented in `zkp_pqc_exploration.py` §2.4b
 (wrong-key witness, tampered-w, perturbed-z, 64-attempt grinding; 0 cheat passes) and
 in the Python suite test [21] at n=32/256 (wrong-key / w-tamper / z-tamper rejection).
-C/Go test-[21] extension deferred as a cross-language parity follow-up.  Items
-3(a)–(d) remain **OPEN**; 3(b) NTT acceleration is the recommended next step.
+C/Go test-[21] structured-cheat parity **DONE v1.9.63** — `Herradura_tests.{c,go}`
+test [21] now runs wrong-key / w-tamper / z-tamper rejection at n=32/256 (5 checks,
+all PASS), matching the Python suite.  Items 3(a)–(d) remain **OPEN**; 3(b) NTT
+acceleration is the recommended next step.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -5844,7 +5844,12 @@ the prover/verifier polynomial products already use the negacyclic NTT
 three reference languages (schoolbook retained only for the n=32 didactic demo);
 `zkp_pqc_exploration.py` §2.7 cross-checks NTT==schoolbook and measures the speedup
 (~6.8× at n=256, ~12.7× at n=512 in pure Python); SecurityProofs-3.md §11.10.6
-direction 2 marked Resolved.  Items 3(a), 3(c), 3(d) remain **OPEN**.
+direction 2 marked Resolved.  Item 3(a) formal Ring-LWR reduction **DONE v1.9.65** —
+SecurityProofs-3.md §11.10.7 gives a conditional reduction of relaxed Σ-protocol
+soundness to Ring-LWR via an intermediate approximate Ring-SIS step, with the rounding
+slack quantified as the SIS modulus 4t⌈q/(2p)⌉ = 36t (144 at n=32, 576 at n=256); the
+reduction remains conditional on aR-SIS hardness for the HKEX-RNL m, so it is not a fully
+tight standard-model reduction (recorded honestly).  Items 3(c), 3(d) remain **OPEN**.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -5838,8 +5838,13 @@ parameters.  Structured cheats implemented in `zkp_pqc_exploration.py` §2.4b
 in the Python suite test [21] at n=32/256 (wrong-key / w-tamper / z-tamper rejection).
 C/Go test-[21] structured-cheat parity **DONE v1.9.63** — `Herradura_tests.{c,go}`
 test [21] now runs wrong-key / w-tamper / z-tamper rejection at n=32/256 (5 checks,
-all PASS), matching the Python suite.  Items 3(a)–(d) remain **OPEN**; 3(b) NTT
-acceleration is the recommended next step.
+all PASS), matching the Python suite.  Item 3(b) NTT acceleration **DONE v1.9.64** —
+the prover/verifier polynomial products already use the negacyclic NTT
+(`rnl_poly_mul` / `_rnl_poly_mul` / `RnlPolyMul`) at the production degree n=256 in all
+three reference languages (schoolbook retained only for the n=32 didactic demo);
+`zkp_pqc_exploration.py` §2.7 cross-checks NTT==schoolbook and measures the speedup
+(~6.8× at n=256, ~12.7× at n=512 in pure Python); SecurityProofs-3.md §11.10.6
+direction 2 marked Resolved.  Items 3(a), 3(c), 3(d) remain **OPEN**.
 
 ---
 


### PR DESCRIPTION
## Summary

Completes **TODO #94** (ZKP-RNL Σ-protocol soundness gaps and §11.10.6 follow-ups) across five batches:

- **v1.9.63 (item 2 — C/Go parity):** extended security test [21] in `Herradura_tests.{c,go}` with the three structured cheats already in the Python suite — wrong-key witness, tampered commitment `w`, perturbed response `z`. All five checks PASS at n=32/256.
- **v1.9.64 (item 3b — NTT):** confirmed the production Σ-protocol already uses negacyclic NTT (`rnl_poly_mul`/`_rnl_poly_mul`/`RnlPolyMul`) at n=256 in all three languages; added `zkp_pqc_exploration.py` §2.7, a self-checking NTT-vs-schoolbook benchmark (~6.8× at n=256, ~12.7× at n=512). §11.10.6 direction 2 → Resolved.
- **v1.9.65 (item 3a — formal reduction):** new SecurityProofs-3.md §11.10.7 — conditional reduction of relaxed soundness to Ring-LWR via an intermediate approximate Ring-SIS step; rounding slack quantified as the SIS modulus `4t⌈q/(2p)⌉ = 36t`.
- **v1.9.66 (item 3c — ZKB++ size):** new §3.7 first-principles size calculator; **corrected** the over-optimistic "5×/180 KB" estimate to the realistic **≈457 KB (2.0×)** — the NL-FSCX circuit is AND-gate-broadcast-dominated, so only the 2×→1× online-party term helps. Reaching ~180 KB needs a sparse circuit redesign, recorded separately.
- **v1.9.67 (item 3d — hybrid credential):** new §11.10.8 — design sketch for an AND-composed Ring-LWR + Stern-F compound credential (binding commitment to `s`, single Fiat-Shamir challenge, ≈80 KB). Identifies the open binding-map φ. **Closes #94.**

Two open-ended **implementation** follow-ups remain as future work (full ZKB++ encoder + sparse LowMC-like circuit; hybrid-credential gadget).

## Test plan

- [x] C: `gcc -O2 -o CryptosuiteTests/Herradura_tests_c CryptosuiteTests/Herradura_tests.c && ./CryptosuiteTests/Herradura_tests_c -r 8` — test [21] reports `wrongkey_reject`/`w_tamper`/`z_tamper` all PASS at n=32/256
- [x] Go: `cd CryptosuiteTests && go run Herradura_tests.go -r 8` — same
- [x] `python3 SecurityProofsCode/zkp_pqc_exploration.py` — §2.7 (NTT match + speedup) and §3.7 (ZKB++ 2.0×) print correctly
- [x] KaTeX: validator on `SecurityProofs-3.md` → 315 OK, 0 FAIL, 0 PIPE-FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)