### PR TITLE
CLI: HSKE-NL-V2-Duplex single-pass AEAD in enc/dec — v1.9.68 (TODO #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.68] - 2026-06-24
+
+### Feature — CLI: HSKE-NL-V2-Duplex single-pass AEAD in `enc`/`dec` (TODO #118)
+
+- **`HerraduraCli/herradura.py`, `herradura_cli.c`, `herradura_cli.go`:** added
+  `enc --algo hske-duplex` / `dec --algo hske-duplex`, exposing the MonkeyDuplex sponge
+  AEAD (`hske_nl_v2_duplex_encrypt`/`decrypt`, v1.9.62) on the CLI. Supports `--ad`
+  associated data and requires a 256-bit key.
+- **Wire format:** new CIPHERTEXT PEM format tag 3 — `SEQ(3, nonce, ct_len, ct, tag, nbits)` —
+  storing the ciphertext length-prefixed so **arbitrary-length** plaintext is supported
+  (unlike the single-block `hske-nla1 --aead`). Byte-for-byte interoperable across the three
+  CLIs.
+- **`HerraduraCli/primitives.py`:** re-export `hske_nl_v2_duplex_encrypt`/`decrypt`.
+- **`CliTest/test_duplex.sh` (new):** 9-way producer/consumer interop matrix, wrong-AD /
+  wrong-key / mutated-ciphertext rejection, and empty-plaintext round-trip (23/23 pass).
+- **`docs/TUTORIAL.md`** and the three CLI usage headers document the new algorithm.
+
+---
+
 ## [1.9.67] - 2026-06-24
 
 ### Docs/Design — Hybrid Ring-LWR + Stern-F credential design sketch (TODO #94 item 3d; closes #94)

--- a/CliTest/test_duplex.sh
+++ b/CliTest/test_duplex.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# CliTest/test_duplex.sh — HSKE-NL-V2-Duplex AEAD enc/dec cross-language interop (TODO #118)
+# Covers all 9 producer/consumer pairs across the Python, C, and Go CLIs, plus
+# tamper rejection (wrong --ad, wrong key, mutated ciphertext), a multi-block
+# arbitrary-length message, and an empty-plaintext round-trip.
+set -euo pipefail
+
+DIR=$(dirname "$0")
+PY="python3 $DIR/../HerraduraCli/herradura.py"
+C="$DIR/../HerraduraCli/herradura_cli"
+GO="$DIR/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+for bin in "$DIR/../HerraduraCli/herradura_cli" "$DIR/../HerraduraCli/herradura_cli_go"; do
+    if [ ! -x "$bin" ]; then
+        echo "SKIP: $bin not built (run build_c.sh / build_go.sh)"; exit 0
+    fi
+done
+
+# Shared 256-bit symmetric key via HKEX-GF
+$PY genpkey --algo hkex-gf --out "$TMP/alice.pem"
+$PY pkey    --in "$TMP/alice.pem" --pubout --out "$TMP/alice_pub.pem"
+$PY genpkey --algo hkex-gf --out "$TMP/bob.pem"
+$PY pkey    --in "$TMP/bob.pem"   --pubout --out "$TMP/bob_pub.pem"
+$PY kex     --algo hkex-gf --our "$TMP/alice.pem" --their "$TMP/bob_pub.pem" \
+            --out "$TMP/sk.pem"
+
+# Arbitrary-length, multi-block plaintext (the duplex AEAD's whole point)
+printf 'HSKE-NL-V2-Duplex single-pass AEAD: arbitrary-length message spanning multiple 16-byte rate blocks (well over 32 bytes).' > "$TMP/msg.bin"
+AD="duplex-test-context"
+
+declare -A CLI=( [py]="$PY" [c]="$C" [go]="$GO" )
+
+for enc in py c go; do
+    ${CLI[$enc]} enc --algo hske-duplex --ad "$AD" \
+        --key "$TMP/sk.pem" --in "$TMP/msg.bin" --out "$TMP/ct_$enc.pem"
+    for dec in py c go; do
+        if ${CLI[$dec]} dec --algo hske-duplex --ad "$AD" \
+              --key "$TMP/sk.pem" --in "$TMP/ct_$enc.pem" --out "$TMP/pt_${enc}_${dec}.bin" \
+           && cmp -s "$TMP/msg.bin" "$TMP/pt_${enc}_${dec}.bin"; then
+            echo "PASS duplex $enc-enc -> $dec-dec"; PASS=$((PASS+1))
+        else
+            echo "FAIL duplex $enc-enc -> $dec-dec"; FAIL=$((FAIL+1))
+        fi
+        # wrong AD must be rejected
+        if ${CLI[$dec]} dec --algo hske-duplex --ad "wrong-ad" \
+              --key "$TMP/sk.pem" --in "$TMP/ct_$enc.pem" --out "$TMP/bad.bin" 2>/dev/null; then
+            echo "FAIL duplex $enc-enc -> $dec-dec accepted wrong --ad"; FAIL=$((FAIL+1))
+        else
+            echo "PASS duplex $enc-enc -> $dec-dec rejects wrong --ad"; PASS=$((PASS+1))
+        fi
+    done
+done
+
+# Empty-plaintext round-trip (each producer -> Python consumer)
+: > "$TMP/empty.bin"
+for enc in py c go; do
+    ${CLI[$enc]} enc --algo hske-duplex --ad "$AD" \
+        --key "$TMP/sk.pem" --in "$TMP/empty.bin" --out "$TMP/ect_$enc.pem"
+    if $PY dec --algo hske-duplex --ad "$AD" \
+          --key "$TMP/sk.pem" --in "$TMP/ect_$enc.pem" --out "$TMP/ept_$enc.bin" \
+       && cmp -s "$TMP/empty.bin" "$TMP/ept_$enc.bin"; then
+        echo "PASS duplex empty-pt $enc-enc -> py-dec"; PASS=$((PASS+1))
+    else
+        echo "FAIL duplex empty-pt $enc-enc -> py-dec"; FAIL=$((FAIL+1))
+    fi
+done
+
+# Mutated ciphertext must be rejected: flip a base64 char in the PEM body
+$PY enc --algo hske-duplex --ad "$AD" --key "$TMP/sk.pem" --in "$TMP/msg.bin" --out "$TMP/ct_mut.pem"
+awk 'NR==2{ c=substr($0,1,1); n=(c=="A"?"B":"A"); print n substr($0,2); next } {print}' \
+    "$TMP/ct_mut.pem" > "$TMP/ct_mut2.pem"
+if $PY dec --algo hske-duplex --ad "$AD" \
+      --key "$TMP/sk.pem" --in "$TMP/ct_mut2.pem" --out "$TMP/bad_mut.bin" 2>/dev/null; then
+    echo "FAIL duplex mutated ciphertext accepted"; FAIL=$((FAIL+1))
+else
+    echo "PASS duplex mutated ciphertext rejected"; PASS=$((PASS+1))
+fi
+
+# Wrong key must be rejected
+$PY genpkey --algo hkex-gf --out "$TMP/eve.pem"
+$PY pkey    --in "$TMP/eve.pem" --pubout --out "$TMP/eve_pub.pem"
+$PY kex     --algo hkex-gf --our "$TMP/eve.pem" --their "$TMP/bob_pub.pem" \
+            --out "$TMP/sk_eve.pem"
+if $PY dec --algo hske-duplex --ad "$AD" \
+      --key "$TMP/sk_eve.pem" --in "$TMP/ct_py.pem" --out "$TMP/bad2.bin" 2>/dev/null; then
+    echo "FAIL duplex wrong key accepted"; FAIL=$((FAIL+1))
+else
+    echo "PASS duplex wrong key rejected"; PASS=$((PASS+1))
+fi
+
+echo
+echo "test_duplex: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -8,6 +8,8 @@
 #   python3 herradura.py kex     --algo hkex-gf  --our alice.pem --their bob_pub.pem --kdf hfscx-256 --out sk.pem
 #   python3 herradura.py enc     --algo hske      --key sk.pem --in msg.bin --out cipher.pem
 #   python3 herradura.py dec     --algo hske      --key sk.pem --in cipher.pem --out plain.bin
+#   python3 herradura.py enc     --algo hske-duplex --key sk.pem --in msg.bin --ad hdr --out cipher.pem
+#   python3 herradura.py dec     --algo hske-duplex --key sk.pem --in cipher.pem --ad hdr --out plain.bin
 #   python3 herradura.py sign    --algo hpks      --key sig.pem --in msg.bin --out s.pem
 #   python3 herradura.py sign    --algo hpks-nl   --key sig.pem --in large.bin --digest hfscx-256 --out s.pem
 #   python3 herradura.py verify  --algo hpks      --pubkey sig.pem --in msg.bin --sig s.pem
@@ -52,6 +54,7 @@ from primitives import (
     nl_fscx_revolve_v2_inv, gf_mul, gf_pow,
     hfscx_256, hfscx_256_ds, hmac_hfscx_256, _HFSCX256_IV_BYTES, _RNL_KDF_DC_256,
     hske_nl_aead_encrypt, hske_nl_aead_decrypt,
+    hske_nl_v2_duplex_encrypt, hske_nl_v2_duplex_decrypt,
     _rnl_keygen, _rnl_agree, _rnl_m_poly, _rnl_rand_poly, _rnl_poly_add,
     _rnl_lift, _rnl_poly_mul,
     stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
@@ -525,6 +528,38 @@ def _decode_sym_ct(path):
 
 
 # ---------------------------------------------------------------------------
+# Ciphertext serialization (HSKE-NL-V2-Duplex AEAD — TODO #118)
+#
+# Unlike the single-block sym formats above, the duplex AEAD handles
+# arbitrary-length plaintext, so the ciphertext is stored length-prefixed:
+#   format tag 3, nonce (KEYBYTES), ct_len, ct (ct_len bytes), tag (32), nbits.
+# ---------------------------------------------------------------------------
+
+def _encode_duplex_ct(nonce_int, ct_bytes, tag_int, nbits):
+    nbytes = nbits // 8
+    ct_len = len(ct_bytes)
+    der = der_seq(der_int(3),                       # format tag 3: V2-Duplex AEAD
+                  der_int(nonce_int, nbytes),
+                  der_int(ct_len),
+                  der_int(int.from_bytes(ct_bytes, 'big'), max(1, ct_len)),
+                  der_int(tag_int, 32),
+                  der_int(nbits))
+    return pem_wrap(_LABEL_CT, der)
+
+
+def _decode_duplex_ct(path):
+    """Return (nonce_int, ct_bytes, tag_int, nbits)."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_CT:
+        raise ValueError(f"Expected CIPHERTEXT PEM, got {label!r}")
+    if ints[0] != 3:
+        raise ValueError(f"Expected V2-Duplex ciphertext (format 3), got {ints[0]}")
+    _, nonce_int, ct_len, ct_int, tag_int, nbits = ints
+    ct_bytes = ct_int.to_bytes(ct_len, 'big') if ct_len else b''
+    return nonce_int, ct_bytes, tag_int, nbits
+
+
+# ---------------------------------------------------------------------------
 # Ciphertext serialization (asymmetric HPKE / HPKE-NL)
 # ---------------------------------------------------------------------------
 
@@ -873,6 +908,21 @@ def cmd_enc(args):
     in_bytes = _read_file(getattr(args, 'in'))
     out_path = args.out
 
+    # ── HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) ──────────────
+    if algo == 'hske-duplex':
+        key_path = args.key
+        if not key_path:
+            sys.exit(f"--key required for {algo}")
+        key_int, nbits = _load_key(key_path)
+        if nbits != 256:
+            sys.exit("enc: hske-duplex requires a 256-bit key")
+        K = BitArray(nbits, key_int)
+        ad = (args.ad or '').encode()
+        nonce, ct, tag = hske_nl_v2_duplex_encrypt(K, in_bytes, ad)
+        _write_file(out_path, _encode_duplex_ct(
+            nonce.uint, ct, int.from_bytes(tag, 'big'), nbits))
+        return
+
     # ── Symmetric algos ─────────────────────────────────────────────────────
     if algo in ('hske', 'hske-nla1', 'hske-nla2'):
         key_path = args.key
@@ -962,6 +1012,25 @@ def cmd_enc(args):
 def cmd_dec(args):
     algo     = args.algo
     out_path = args.out
+
+    # ── HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) ──────────────
+    if algo == 'hske-duplex':
+        key_path = args.key
+        if not key_path:
+            sys.exit(f"--key required for {algo}")
+        key_int, nbits = _load_key(key_path)
+        if nbits != 256:
+            sys.exit("dec: hske-duplex requires a 256-bit key")
+        K = BitArray(nbits, key_int)
+        nonce_int, ct_bytes, tag_int, _nb = _decode_duplex_ct(getattr(args, 'in'))
+        ad = (getattr(args, 'ad', None) or '').encode()
+        pt = hske_nl_v2_duplex_decrypt(K, BitArray(nbits, nonce_int), ct_bytes,
+                                       tag_int.to_bytes(32, 'big'), ad)
+        if pt is None:
+            sys.exit("dec: authentication tag mismatch — "
+                     "ciphertext corrupt, wrong key, or wrong --ad")
+        _write_file(out_path, pt)
+        return
 
     # ── Symmetric algos ─────────────────────────────────────────────────────
     if algo in ('hske', 'hske-nla1', 'hske-nla2'):
@@ -1695,7 +1764,8 @@ def build_parser():
     # enc
     en = sub.add_parser('enc', help='Encrypt')
     en.add_argument('--algo', required=True,
-                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hpke', 'hpke-nl', 'hpke-stern'])
+                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hske-duplex',
+                             'hpke', 'hpke-nl', 'hpke-stern'])
     en.add_argument('--key',    default=None)
     en.add_argument('--pubkey', default=None)
     en.add_argument('--in',  required=True, dest='in')
@@ -1708,7 +1778,8 @@ def build_parser():
     # dec
     de = sub.add_parser('dec', help='Decrypt')
     de.add_argument('--algo', required=True,
-                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hpke', 'hpke-nl', 'hpke-stern'])
+                    choices=['hske', 'hske-nla1', 'hske-nla2', 'hske-duplex',
+                             'hpke', 'hpke-nl', 'hpke-stern'])
     de.add_argument('--key',    default=None)
     de.add_argument('--in',  required=True, dest='in')
     de.add_argument('--out', required=True)

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -134,6 +134,28 @@ static int der_i32(const uint8_t bytes[KEYBYTES], uint8_t *out, size_t *olen)
 static int der_i_n256(uint8_t *out, size_t *olen)
 { static const uint8_t n[2] = {0x01, 0x00}; return der_int_enc(n, 2, out, olen); }
 
+/* DER INTEGER for an unsigned value, minimal big-endian width (matches Python der_int).
+ * Used for the variable ciphertext length in the HSKE-NL-V2-Duplex format. */
+static int der_i_uint(uint64_t v, uint8_t *out, size_t *olen)
+{
+    uint8_t tmp[8]; int n = 0;
+    if (v == 0) { tmp[0] = 0; n = 1; }
+    else {
+        uint8_t b[8]; int i = 0, j;
+        while (v) { b[i++] = (uint8_t)(v & 0xFF); v >>= 8; }
+        for (j = i - 1; j >= 0; j--) tmp[n++] = b[j];
+    }
+    return der_int_enc(tmp, (size_t)n, out, olen);
+}
+
+/* Parse a big-endian unsigned integer from DER value bytes (small lengths only). */
+static uint64_t parse_be_uint(const uint8_t *p, size_t l)
+{
+    uint64_t v = 0; size_t i;
+    for (i = 0; i < l; i++) v = (v << 8) | p[i];
+    return v;
+}
+
 /* Wrap items into SEQUENCE DER, then PEM-wrap and write. */
 static void seq_and_write(const uint8_t **it, const size_t *il, int ni,
                           const char *label, const char *out_path)
@@ -1034,6 +1056,45 @@ static void cmd_enc(int argc, char **argv)
     size_t in_len;
     uint8_t *in_buf = read_binary_file(in_path, &in_len);
 
+    /* ── HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) — TODO #118 ── */
+    if (strcmp(algo, "hske-duplex") == 0) {
+        if (!key_path) die("enc: --key required for hske-duplex");
+        BitArray K, N_nonce;
+        load_sym_key(&K, key_path);
+        const char *ad = get_arg(argc, argv, "--ad");
+        FILE *urnd = fopen("/dev/urandom", "rb");
+        if (!urnd) die("cannot open /dev/urandom");
+        ba_rand(&N_nonce, urnd);
+        fclose(urnd);
+
+        uint8_t *ct_buf = malloc(in_len ? in_len : 1);
+        if (!ct_buf) die("enc: out of memory");
+        uint8_t tag[32];
+        hske_nl_v2_duplex_encrypt(&K, &N_nonce,
+                                  (const uint8_t *)(ad ? ad : ""),
+                                  ad ? strlen(ad) : 0,
+                                  in_buf, in_len, ct_buf, tag);
+
+        /* format tag 3: SEQ(3, nonce, ct_len, ct, tag, nbits) */
+        uint8_t it0[8], itn[DER_INT_LEN(KEYBYTES)], itl[DER_INT_LEN(8)];
+        uint8_t itt[DER_INT_LEN(KEYBYTES)], itnb[8];
+        uint8_t *itE = malloc(DER_INT_LEN(in_len ? in_len : 1));
+        if (!itE) die("enc: out of memory");
+        size_t l0, ln, ll, lE, lt, lnb;
+        der_i_byte(3, it0, &l0);
+        der_i32(N_nonce.b, itn, &ln);
+        der_i_uint((uint64_t)in_len, itl, &ll);
+        if (in_len) der_int_enc(ct_buf, in_len, itE, &lE);
+        else { static const uint8_t z = 0; der_int_enc(&z, 1, itE, &lE); }
+        der_i32(tag, itt, &lt);
+        der_i_n256(itnb, &lnb);
+        const uint8_t *it[6] = {it0, itn, itl, itE, itt, itnb};
+        size_t il[6] = {l0, ln, ll, lE, lt, lnb};
+        seq_and_write(it, il, 6, PEM_CIPHERTEXT, out_path);
+        free(itE); free(ct_buf); free(in_buf);
+        return;
+    }
+
     /* Plaintext BitArray: input left-aligned into big-endian block, zero-padded. */
     BitArray P;
     make_msg_ba(&P, in_buf, in_len);
@@ -1195,6 +1256,43 @@ static void cmd_dec(int argc, char **argv)
     pem_key_load(&ct, in_path);
     if (strcmp(ct.label, PEM_CIPHERTEXT) != 0)
         dief("dec: expected CIPHERTEXT PEM, got: %s", ct.label);
+
+    /* ── HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) — TODO #118 ── */
+    if (strcmp(algo, "hske-duplex") == 0) {
+        if (!key_path) die("dec: --key required for hske-duplex");
+        BitArray K, N_nonce;
+        load_sym_key(&K, key_path);
+        if (ct.n_items < 6 || ct.vlens[0] < 1 || ct.vals[0][0] != 3)
+            die("dec: not a V2-Duplex (format 3) ciphertext");
+        const char *ad = get_arg(argc, argv, "--ad");
+        ba_from_ra(&N_nonce, ct.vals[1], ct.vlens[1]);
+        size_t ct_len = (size_t)parse_be_uint(ct.vals[2], ct.vlens[2]);
+        /* Right-align the parsed ct value into a zero-padded ct_len buffer
+         * (integer encoding may have dropped leading zero bytes). */
+        uint8_t *ct_buf = calloc(ct_len ? ct_len : 1, 1);
+        uint8_t *pt_buf = malloc(ct_len ? ct_len : 1);
+        if (!ct_buf || !pt_buf) die("dec: out of memory");
+        size_t vl = ct.vlens[3];
+        if (vl > ct_len) vl = ct_len;   /* defensive */
+        memcpy(ct_buf + (ct_len - vl), ct.vals[3], vl);
+        uint8_t tag_buf[32];
+        BitArray tag_ba;
+        ba_from_ra(&tag_ba, ct.vals[4], ct.vlens[4]);
+        memcpy(tag_buf, tag_ba.b, 32);
+        int ok = hske_nl_v2_duplex_decrypt(&K, &N_nonce,
+                                           (const uint8_t *)(ad ? ad : ""),
+                                           ad ? strlen(ad) : 0,
+                                           ct_buf, ct_len, tag_buf, pt_buf);
+        pem_key_free(&ct);
+        if (!ok) {
+            free(ct_buf); free(pt_buf);
+            die("dec: authentication tag mismatch — "
+                "ciphertext corrupt, wrong key, or wrong --ad");
+        }
+        write_binary_file(out_path, pt_buf, ct_len);
+        free(ct_buf); free(pt_buf);
+        return;
+    }
 
     /* ── Symmetric algos ── */
     if (strcmp(algo, "hske") == 0 || strcmp(algo, "hske-nla1") == 0 ||
@@ -2407,10 +2505,11 @@ static void usage(void)
 "    Both sides must use the same --kdf flag to derive the same final key.\n"
 "\n"
 "  enc --algo ALGO (--key SK | --pubkey PUB) --in FILE [--out FILE] [--aead [--ad STR]]\n"
-"    Encrypt.  Symmetric (--key): hske hske-nla1 hske-nla2\n"
+"    Encrypt.  Symmetric (--key): hske hske-nla1 hske-nla2 hske-duplex\n"
 "    Asymmetric (--pubkey): hpke hpke-nl hpke-stern\n"
 "    --aead (hske-nla1 only): HSKE-NL-AEAD authenticated encryption; --ad binds\n"
 "    optional associated data into the tag (must match at dec).\n"
+"    hske-duplex: arbitrary-length single-pass AEAD (256-bit key; --ad supported).\n"
 "\n"
 "  dec --algo ALGO --key KEY --in CT_FILE [--out FILE] [--ad STR]\n"
 "    Decrypt.  Symmetric: key=SESSION KEY PEM.  Asymmetric: key=PRIVATE KEY PEM.\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -7,6 +7,8 @@
 //   herradura_cli_go kex      --algo hkex-gf   --our alice.pem --their bob_pub.pem --out sk.pem
 //   herradura_cli_go enc      --algo hske      --key sk.pem --in msg.bin --out ct.pem
 //   herradura_cli_go dec      --algo hske      --key sk.pem --in ct.pem  --out plain.bin
+//   herradura_cli_go enc      --algo hske-duplex --key sk.pem --in msg.bin --ad hdr --out ct.pem
+//   herradura_cli_go dec      --algo hske-duplex --key sk.pem --in ct.pem  --ad hdr --out plain.bin
 //   herradura_cli_go sign     --algo hpks      --key priv.pem --in msg.bin --out sig.pem
 //   herradura_cli_go verify   --algo hpks      --pubkey pub.pem --in msg.bin --sig sig.pem
 //   herradura_cli_go dgst     --in file.bin                       # hex to stdout
@@ -976,6 +978,28 @@ func encodeSymCTTag(algo string, E *big.Int, n int, nonce, authTag *big.Int) (st
 	return PemWrap(lblCT, seq), nil
 }
 
+// encodeDuplexCT: HSKE-NL-V2-Duplex AEAD, format tag 3 (TODO #118):
+// SEQ(3, nonce, ct_len, ct, tag, nbits) with variable-length ciphertext.
+func encodeDuplexCT(nonce *big.Int, ct []byte, tag *big.Int, n int) (string, error) {
+	nb := n / 8
+	ctLen := len(ct)
+	ctWidth := ctLen
+	if ctWidth == 0 {
+		ctWidth = 1
+	}
+	t3, _ := derIntSmall(3)
+	nd, _ := derIntBig(nonce, nb)
+	ld, _ := derIntSmall(ctLen)
+	ed, _ := derIntBig(new(big.Int).SetBytes(ct), ctWidth)
+	td, _ := derIntBig(tag, 32)
+	nn, _ := derIntSmall(n)
+	seq, err := DerSeqEnc(t3, nd, ld, ed, td, nn)
+	if err != nil {
+		return "", err
+	}
+	return PemWrap(lblCT, seq), nil
+}
+
 func encodeAsymCT(R, E *big.Int, n int) (string, error) {
 	nb := n / 8
 	rd, err := derIntBig(R, nb)
@@ -1362,6 +1386,31 @@ func cmdEnc(args []string) {
 	gen := new(big.Int).SetInt64(GfGen)
 
 	switch *algo {
+	case "hske-duplex":
+		// HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) — TODO #118
+		if *key == "" {
+			fmt.Fprintln(os.Stderr, "enc: --key required for hske-duplex")
+			os.Exit(1)
+		}
+		keyInt, n, err := loadKey(*key)
+		if err != nil {
+			die("enc", err)
+		}
+		if n != 256 {
+			fmt.Fprintln(os.Stderr, "enc: hske-duplex requires a 256-bit key")
+			os.Exit(1)
+		}
+		K := NewBitArray(n, keyInt)
+		nonce := NewRandBitArray(n)
+		ct, authTag := HskeNlV2DuplexEncrypt(K, nonce, []byte(*ad), inBytes)
+		pem, err := encodeDuplexCT(&nonce.Val, ct, new(big.Int).SetBytes(authTag), n)
+		if err != nil {
+			die("enc", err)
+		}
+		if err := writeString(*out, pem); err != nil {
+			die("enc", err)
+		}
+
 	case "hske", "hske-nla1", "hske-nla2":
 		if *key == "" {
 			fmt.Fprintf(os.Stderr, "enc: --key required for %s\n", *algo)
@@ -1496,6 +1545,45 @@ func cmdDec(args []string) {
 	}
 
 	switch *algo {
+	case "hske-duplex":
+		// HSKE-NL-V2-Duplex AEAD (arbitrary-length, single-pass) — TODO #118
+		if *key == "" {
+			fmt.Fprintln(os.Stderr, "dec: --key required for hske-duplex")
+			os.Exit(1)
+		}
+		keyInt, _, err := loadKey(*key)
+		if err != nil {
+			die("dec", err)
+		}
+		_, ctInts, err := readPEMInts(*in)
+		if err != nil {
+			die("dec", err)
+		}
+		if len(ctInts) < 6 || bytesToInt(ctInts[0]) != 3 {
+			fmt.Fprintln(os.Stderr, "dec: not a V2-Duplex (format 3) ciphertext")
+			os.Exit(1)
+		}
+		n := bytesToInt(ctInts[5])
+		K := NewBitArray(n, keyInt)
+		nonce := NewBitArray(n, new(big.Int).SetBytes(ctInts[1]))
+		ctLen := bytesToInt(ctInts[2])
+		ct := make([]byte, ctLen)
+		if ctLen > 0 {
+			new(big.Int).SetBytes(ctInts[3]).FillBytes(ct)
+		}
+		authTag := make([]byte, 32)
+		new(big.Int).SetBytes(ctInts[4]).FillBytes(authTag)
+		pt, ok := HskeNlV2DuplexDecrypt(K, nonce, []byte(*ad), ct, authTag)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "dec: authentication tag mismatch — "+
+				"ciphertext corrupt, wrong key, or wrong --ad")
+			os.Exit(1)
+		}
+		if err := writeBytes(*out, pt); err != nil {
+			die("dec", err)
+		}
+		return
+
 	case "hske", "hske-nla1", "hske-nla2":
 		if *key == "" {
 			fmt.Fprintf(os.Stderr, "dec: --key required for %s\n", *algo)
@@ -2469,7 +2557,7 @@ Commands:
 
 Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern hpke-stern hpks-zkp-nl
 Algorithms (kex):           hkex-gf hkex-rnl
-Algorithms (enc/dec):       hske hske-nla1 hske-nla2 hpke hpke-nl hpke-stern
+Algorithms (enc/dec):       hske hske-nla1 hske-nla2 hske-duplex hpke hpke-nl hpke-stern
 Algorithms (encfile/decfile): hske-nla1
 Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo
   fpe      --encrypt|--decrypt --key SK --context STR --in FILE [--out FILE]

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -30,6 +30,8 @@ hfscx_256_ds           = _s.hfscx_256_ds
 hmac_hfscx_256         = _s.hmac_hfscx_256
 hske_nl_aead_encrypt   = _s.hske_nl_aead_encrypt
 hske_nl_aead_decrypt   = _s.hske_nl_aead_decrypt
+hske_nl_v2_duplex_encrypt = _s.hske_nl_v2_duplex_encrypt
+hske_nl_v2_duplex_decrypt = _s.hske_nl_v2_duplex_decrypt
 _HFSCX256_IV_BYTES     = _s._HFSCX256_IV_BYTES
 _RNL_KDF_DC_256        = _s._RNL_KDF_DC_256
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.67)
+# Herradura Cryptographic Suite (v1.9.68)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6407,3 +6407,132 @@ Status: **DONE v1.9.56**
 2. Add a security note explaining the QC-MDPC decoder requirement and that the demo should not be used in production.
 
 Status: **DONE v1.9.58**
+
+---
+
+## CLI Capability Review — Suite Features Not Yet Exposed in the CLI — Identified 2026-06-24
+
+A review of suite functionality added since the last CLI extension (TODO #106) against the
+`HerraduraCli/` subcommand surface (Python `herradura.py`, C `herradura_cli.c`, Go
+`herradura_cli_go`) found four primitives that are fully implemented in the library across
+all three CLI languages but have no CLI entry point.  Each item below records the suite API,
+the natural CLI surface, and the PEM/wire-format work needed for byte-for-byte cross-language
+compatibility (the standing CLI invariant).
+
+---
+
+### 118. CLI: expose HSKE-NL-V2-Duplex single-pass AEAD in `enc`/`dec` (CLI Extension, Medium)
+
+**Discovered:** CLI capability review, 2026-06-24.
+
+**Current state:** the MonkeyDuplex-style single-pass AEAD `hske_nl_v2_duplex_encrypt` /
+`hske_nl_v2_duplex_decrypt` (TODO #95 Option 2, v1.9.62) is implemented and byte-for-byte
+interoperable in `herradura.h` (C), `Herradura cryptographic suite.py` (Python), and
+`herradura/herradura.go` (Go), with demo blocks and round-trip/tamper tests.  The CLI `enc`/`dec`
+subcommands support `hske`, `hske-nla1` (with `--aead`), `hske-nla2`, `hpke`, `hpke-nl`, and
+`hpke-stern`, but not the V2-Duplex AEAD.
+
+**Goal:** add `enc --algo hske-duplex` and `dec --algo hske-duplex` (with `--ad` associated-data
+support), producing a PEM ciphertext object carrying nonce, ciphertext, and 32-byte tag.
+
+**Work items:**
+1. Define a PEM/DER ciphertext object (e.g. label `HERRADURA HSKE-DUPLEX CIPHERTEXT`) encoding
+   `{nonce (KEYBYTES), ciphertext (variable), tag (32)}`; reuse the existing AEAD codec pattern
+   from `hske-nla1 --aead`.
+2. Wire `hske-duplex` into the `enc`/`dec` `--algo` choices and dispatch in the Python CLI
+   (`cmd_enc`/`cmd_dec`), C CLI, and Go CLI.
+3. Require a 256-bit key (as with `hske-nla1 --aead`); error clearly otherwise.
+4. Add `CliTest/test_duplex.sh` — round-trip, tamper rejection (ciphertext/tag/AD), and a
+   9-way cross-CLI interop matrix (Python/C/Go encrypt × decrypt), mirroring `test_aead.sh`.
+5. Document the subcommand in the CLI usage header and `docs/TUTORIAL.md`.
+
+Status: **DONE v1.9.68** — `enc`/`dec --algo hske-duplex` implemented in the Python
+(`herradura.py`), C (`herradura_cli.c`), and Go (`herradura_cli_go`) CLIs with `--ad`
+support and a 256-bit-key requirement.  New PEM ciphertext format tag 3
+(`SEQ(3, nonce, ct_len, ct, tag, nbits)`) stores the variable-length ciphertext
+length-prefixed so arbitrary-length plaintext (not just one 32-byte block) is supported.
+`CliTest/test_duplex.sh` exercises the 9-way producer/consumer interop matrix, wrong-AD /
+wrong-key / mutated-ciphertext rejection, and empty-plaintext round-trip (23/23 pass).
+Documented in the three CLI usage headers and `docs/TUTORIAL.md`.
+
+---
+
+### 119. CLI: `rand` command for HDRBG forward-secure deterministic byte generation (CLI Extension, Medium)
+
+**Discovered:** CLI capability review, 2026-06-24.
+
+**Current state:** the forward-secure DRBG (`drbg_seed` / `drbg_generate` / `drbg_reseed`,
+TODO #96, v1.9.34) is implemented in all three CLI languages (`drbg_generate` in C and Go,
+`drbg_seed`/`generate`/`reseed` in Python) but has no CLI entry point.  There is no way to
+generate deterministic random bytes from a seed via the CLI.
+
+**Goal:** add a `rand` subcommand that seeds an HDRBG from a file/PEM seed and emits a requested
+number of deterministic bytes, with optional reseed.
+
+**Work items:**
+1. Add `rand --seed <file> --bytes N [--personalization STR] [--out FILE]` to the Python, C, and
+   Go CLIs; default output is raw bytes to stdout (or `--out` file), with a `--hex` option.
+2. Define an optional persistent DRBG-state PEM object (e.g. `HERRADURA HDRBG STATE`) so a
+   caller can checkpoint and resume a stream across invocations; include a `--reseed <file>`
+   flag that folds new entropy into a saved state.
+3. Ensure identical seed + personalization + byte count produces byte-identical output across
+   the three CLIs (cross-language KAT).
+4. Add `CliTest/test_rand.sh` — determinism, cross-CLI KAT, reseed-changes-stream, and
+   distinct-personalization-separation checks.
+5. Document the subcommand and note it is a deterministic DRBG (not an OS entropy source).
+
+Status: **OPEN**
+
+---
+
+### 120. CLI: HPKS-WOTS-F one-time signatures in `genpkey`/`sign`/`verify` (CLI Extension, Medium)
+
+**Discovered:** CLI capability review, 2026-06-24.
+
+**Current state:** the many-time XMSS wrapper is already exposed as `sign/verify --algo hpks-xmss`,
+but the underlying HPKS-WOTS-F one-time signature primitive (`hpks_wots_keygen` / `hpks_wots_sign`
+/ `hpks_wots_verify` / `hpks_wots_recover_pk`, present in C, Go, and Python) has no standalone CLI
+surface.  A one-time signature is useful on its own (e.g. constrained-device single-use tokens).
+
+**Goal:** add `genpkey --algo hpks-wots`, `sign --algo hpks-wots`, and `verify --algo hpks-wots`.
+
+**Work items:**
+1. Define WOTS-F private/public key PEM objects (master seed + leaf index for the private key;
+   the WOTS public-key chain endpoints for the public key).
+2. Wire `hpks-wots` into `genpkey`, `sign`, and `verify` `--algo` dispatch in the Python, C, and
+   Go CLIs, packing/unpacking the signature (the WOTS chain values) in a shared PEM format.
+3. Enforce one-time semantics: refuse to sign twice with the same key (track/burn the leaf index,
+   as the XMSS CLI does with its index file), with a clear error on reuse.
+4. Add `CliTest/test_wots.sh` — keygen, sign/verify round-trip, reuse-refusal, tamper rejection,
+   and cross-CLI interop (Python sign → C/Go verify and vice versa).
+5. Document the one-time constraint prominently in the CLI help and `docs/TUTORIAL.md`.
+
+Status: **OPEN**
+
+---
+
+### 121. CLI: HPKS-Stern-Ring ring signatures in `sign`/`verify` (CLI Extension, Medium)
+
+**Discovered:** CLI capability review, 2026-06-24.
+
+**Current state:** the code-based ring signature `hpks_stern_ring_sign` / `hpks_stern_ring_verify`
+(#78.I) is implemented in the Python and Go suites and exercised by security test [20], but is
+**not** present in `herradura.h` (C) and has no CLI surface in any language.  A ring signature lets
+one member of an ad-hoc group sign anonymously on behalf of the group.
+
+**Goal:** add `sign --algo hpks-ring` (signer key + a list of ring public-key PEMs) and
+`verify --algo hpks-ring` (same ring) to the Python and Go CLIs.
+
+**Work items:**
+1. **Dependency:** port `hpks_stern_ring_sign`/`hpks_stern_ring_verify` to `herradura.h` so the C
+   CLI can participate; until then, scope the CLI to Python + Go and note the C gap (or split the
+   C suite port into its own sub-item).
+2. Define a ring-signature PEM object encoding the ring size, the per-member challenge/response
+   data, and the key-image/linking tag if applicable.
+3. Add a `--ring <pem1,pem2,...>` argument (ordered list of member public keys) to `sign`/`verify`
+   and wire `hpks-ring` into the `--algo` dispatch.
+4. Add `CliTest/test_ring.sh` — sign-by-member / verify-by-ring success, non-member rejection,
+   tamper rejection, and Python↔Go interop.
+5. Document the anonymity property and ring-membership semantics in the CLI help and tutorial.
+
+Status: **OPEN**

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -104,6 +104,24 @@ $CLI dec --algo hske-nla1 --ad "header-v1" \
 The C and Go CLIs accept the same `--aead` and `--ad` flags.  AEAD PEMs are
 cross-language compatible — see `CliTest/test_aead.sh` for a 9-way interop test.
 
+`hske-nla1 --aead` operates on a single 32-byte block.  For **arbitrary-length**
+single-pass authenticated encryption, use the `hske-duplex` algorithm (a
+MonkeyDuplex sponge AEAD over `nl_fscx_revolve_v2`):
+
+```bash
+# Encrypt arbitrary-length input; nonce, ciphertext, and 32-byte tag in ct.pem
+$CLI enc --algo hske-duplex --ad "header-v1" \
+         --key alice_sk.pem --in large_msg.bin --out ct_duplex.pem
+
+# Decrypt (--ad must match; fails on any ciphertext / tag / AD tampering)
+$CLI dec --algo hske-duplex --ad "header-v1" \
+         --key alice_sk.pem --in ct_duplex.pem --out recovered.bin
+```
+
+`hske-duplex` requires a 256-bit key and is supported identically by the
+Python, C, and Go CLIs — see `CliTest/test_duplex.sh` for the 9-way interop
+matrix (plus empty-plaintext and tamper-rejection cases).
+
 ### Signing and verification (HPKS)
 
 ```bash


### PR DESCRIPTION
## Summary

Implements **TODO #118**: exposes the MonkeyDuplex sponge AEAD (`hske_nl_v2_duplex_encrypt`/`decrypt`, added in v1.9.62) on the CLI as `enc`/`dec --algo hske-duplex`, across the Python, C, and Go CLIs.

- **`--ad` support** and a **256-bit-key requirement** (matching `hske-nla1 --aead`).
- **New CIPHERTEXT PEM format tag 3** — `SEQ(3, nonce, ct_len, ct, tag, nbits)` — stores the ciphertext length-prefixed, so **arbitrary-length** plaintext is supported (unlike the single-block `hske-nla1 --aead`). Careful DER leading-zero handling keeps the format byte-for-byte interoperable across all three CLIs.
- `HerraduraCli/primitives.py` re-exports the duplex functions for the Python CLI.
- `docs/TUTORIAL.md` and the three CLI usage headers document the new algorithm.

This PR also includes the **CLI Capability Review** TODO entries #118–#121 (suite features not yet exposed in the CLI); #118 is implemented here, #119–#121 remain open.

## Test plan

- [x] `CliTest/test_duplex.sh` (new): 9-way producer/consumer interop matrix + wrong-AD / wrong-key / mutated-ciphertext rejection + empty-plaintext round-trip → **23/23 pass**
- [x] No regression: `CliTest/test_aead.sh` (19/19), `CliTest/test_vectors.sh` (3/3)
- [x] C CLI builds clean (`gcc -O2 -o HerraduraCli/herradura_cli HerraduraCli/herradura_cli.c`)
- [x] Go CLI builds clean (`cd HerraduraCli && go build -o herradura_cli_go herradura_cli.go`)

To reproduce: `bash CliTest/test_duplex.sh` (requires C + Go CLIs built via `build_c.sh` / `build_go.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)