### PR TITLE
CLI: rand command for HDRBG deterministic byte generation — v1.9.69 (TODO #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.69] - 2026-06-24
+
+### Feature — CLI: `rand` command for HDRBG deterministic byte generation (TODO #119)
+
+- **`HerraduraCli/herradura.py`, `herradura_cli.c`, `herradura_cli.go`:** added a `rand`
+  subcommand exposing the forward-secure HDRBG —
+  `rand (--seed FILE | --state FILE) [--personalization STR] [--reseed FILE] [--bytes N]
+  [--hex] [--out FILE]`. Deterministic DRBG (not an OS entropy source); identical
+  seed/personalization/byte-count is byte-identical across the three CLIs.
+- **State checkpoint/resume:** new `HERRADURA HDRBG STATE` PEM (`SEQ(state[32], blocks)`)
+  lets a stream be produced across invocations via `--state`; `--reseed` folds fresh
+  entropy into a saved state.
+- **`herradura/herradura.go`:** exported `DrbgState()` and `DrbgFromState()` accessors so
+  the Go CLI can checkpoint/restore the (previously unexported) DRBG state.
+- **`HerraduraCli/primitives.py`:** re-export `HDrbg` / `drbg_seed` / `drbg_generate` /
+  `drbg_reseed`.
+- **`CliTest/test_rand.sh` (new):** determinism, 3-language KAT, personalization separation,
+  reseed-changes-stream, and the full 9-way cross-language state checkpoint/resume matrix
+  (20/20 pass).
+- **`docs/TUTORIAL.md`** and the three CLI usage headers document the command.
+
+---
+
 ## [1.9.68] - 2026-06-24
 
 ### Feature — CLI: HSKE-NL-V2-Duplex single-pass AEAD in `enc`/`dec` (TODO #118)

--- a/CliTest/test_rand.sh
+++ b/CliTest/test_rand.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# CliTest/test_rand.sh — HDRBG `rand` deterministic generation, cross-language KAT (TODO #119)
+# Covers: determinism, Python/C/Go byte-identical KAT, personalization separation,
+# reseed-changes-stream, and state checkpoint/resume continuity (incl. cross-language).
+set -euo pipefail
+
+DIR=$(dirname "$0")
+PY="python3 $DIR/../HerraduraCli/herradura.py"
+C="$DIR/../HerraduraCli/herradura_cli"
+GO="$DIR/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+for bin in "$C" "$GO"; do
+    if [ ! -x "$bin" ]; then
+        echo "SKIP: $bin not built (run build_c.sh / build_go.sh)"; exit 0
+    fi
+done
+
+check() { # check LABEL FILE_A FILE_B  (pass if identical)
+    if cmp -s "$2" "$3"; then echo "PASS $1"; PASS=$((PASS+1));
+    else echo "FAIL $1"; FAIL=$((FAIL+1)); fi
+}
+check_differ() { # pass if files DIFFER
+    if cmp -s "$2" "$3"; then echo "FAIL $1 (identical, expected differ)"; FAIL=$((FAIL+1));
+    else echo "PASS $1"; PASS=$((PASS+1)); fi
+}
+
+printf 'this-is-a-fixed-32-byte-seed-12345' > "$TMP/seed.bin"
+declare -A CLI=( [py]="$PY" [c]="$C" [go]="$GO" )
+
+# Determinism + 3-language KAT (same seed → byte-identical 96-byte hex)
+for impl in py c go; do
+    ${CLI[$impl]} rand --seed "$TMP/seed.bin" --bytes 96 --hex --out "$TMP/k_$impl.hex"
+done
+check "rand KAT py==c" "$TMP/k_py.hex" "$TMP/k_c.hex"
+check "rand KAT py==go" "$TMP/k_py.hex" "$TMP/k_go.hex"
+
+# Personalization separation (per language) + cross-language KAT for one pers
+for impl in py c go; do
+    ${CLI[$impl]} rand --seed "$TMP/seed.bin" --personalization "ctx-A" --bytes 48 --hex --out "$TMP/pa_$impl.hex"
+done
+check        "rand pers KAT py==c"  "$TMP/pa_py.hex" "$TMP/pa_c.hex"
+check        "rand pers KAT py==go" "$TMP/pa_py.hex" "$TMP/pa_go.hex"
+check_differ "rand pers vs no-pers" "$TMP/pa_py.hex" "$TMP/k_py.hex"
+
+# State checkpoint/resume continuity, per language: gen 32 + resume 32 == one-shot 64
+for impl in py c go; do
+    ${CLI[$impl]} rand --seed "$TMP/seed.bin" --state "$TMP/st_$impl.pem" --bytes 32 --out "$TMP/s1_$impl.bin"
+    ${CLI[$impl]} rand --state "$TMP/st_$impl.pem" --bytes 32 --out "$TMP/s2_$impl.bin"
+    cat "$TMP/s1_$impl.bin" "$TMP/s2_$impl.bin" > "$TMP/s12_$impl.bin"
+    ${CLI[$impl]} rand --seed "$TMP/seed.bin" --bytes 64 --out "$TMP/s64_$impl.bin"
+    check "rand resume continuity ($impl)" "$TMP/s12_$impl.bin" "$TMP/s64_$impl.bin"
+done
+
+# Cross-language state: each producer writes a checkpoint, every consumer resumes it
+for prod in py c go; do
+    ${CLI[$prod]} rand --seed "$TMP/seed.bin" --state "$TMP/xs_$prod.pem" --bytes 32 --out "$TMP/xs1_$prod.bin"
+    for cons in py c go; do
+        cp "$TMP/xs_$prod.pem" "$TMP/xs_${prod}_${cons}.pem"
+        ${CLI[$cons]} rand --state "$TMP/xs_${prod}_${cons}.pem" --bytes 32 --out "$TMP/xs2_${prod}_${cons}.bin"
+        cat "$TMP/xs1_$prod.bin" "$TMP/xs2_${prod}_${cons}.bin" > "$TMP/xs12_${prod}_${cons}.bin"
+        check "rand cross-state $prod->$cons" "$TMP/xs12_${prod}_${cons}.bin" "$TMP/s64_py.bin"
+    done
+done
+
+# Reseed changes the stream
+for impl in py c go; do
+    ${CLI[$impl]} rand --seed "$TMP/seed.bin" --state "$TMP/rs_$impl.pem" --bytes 0 --out /dev/null 2>/dev/null \
+        || ${CLI[$impl]} rand --seed "$TMP/seed.bin" --state "$TMP/rs_$impl.pem" --bytes 1 --out /dev/null
+    cp "$TMP/rs_$impl.pem" "$TMP/rs2_$impl.pem"
+    printf 'extra-entropy' > "$TMP/re.bin"
+    ${CLI[$impl]} rand --state "$TMP/rs2_$impl.pem" --reseed "$TMP/re.bin" --bytes 32 --out "$TMP/after_$impl.bin"
+    ${CLI[$impl]} rand --state "$TMP/rs_$impl.pem" --bytes 32 --out "$TMP/noreseed_$impl.bin"
+    check_differ "rand reseed-changes-stream ($impl)" "$TMP/after_$impl.bin" "$TMP/noreseed_$impl.bin"
+done
+
+echo
+echo "test_rand: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -16,6 +16,8 @@
 #   python3 herradura.py verify  --algo hpks-nl   --pubkey pub.pem --in large.bin --digest hfscx-256 --sig s.pem
 #   python3 herradura.py dgst                     --in file.bin               # hex to stdout
 #   python3 herradura.py dgst    --algo hfscx-256 --in file.bin --out d.pem   # PEM digest file
+#   python3 herradura.py rand    --seed seed.bin  --bytes 64 --hex            # deterministic bytes
+#   python3 herradura.py rand    --state st.pem   --bytes 64 --out r.bin      # resume DRBG stream
 #   python3 herradura.py encfile --algo hske-nla1 --key sk.pem --in large.bin --out cipher.hkx
 #   python3 herradura.py decfile --algo hske-nla1 --key sk.pem --in cipher.hkx --out plain.bin
 #
@@ -55,6 +57,7 @@ from primitives import (
     hfscx_256, hfscx_256_ds, hmac_hfscx_256, _HFSCX256_IV_BYTES, _RNL_KDF_DC_256,
     hske_nl_aead_encrypt, hske_nl_aead_decrypt,
     hske_nl_v2_duplex_encrypt, hske_nl_v2_duplex_decrypt,
+    HDrbg, drbg_seed, drbg_generate, drbg_reseed,
     _rnl_keygen, _rnl_agree, _rnl_m_poly, _rnl_rand_poly, _rnl_poly_add,
     _rnl_lift, _rnl_poly_mul,
     stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
@@ -109,6 +112,7 @@ _LABEL_ZKP_NL      = 'HERRADURA ZKP-NL PROOF'
 _LABEL_OPRF_STATE  = 'HERRADURA OPRF CLIENT STATE'   # (r, alpha, nbits) — client keeps this
 _LABEL_OPRF_EVAL   = 'HERRADURA OPRF EVALUATION'     # (beta, nbits) — server response
 _LABEL_PAKE_RECORD = 'HERRADURA PAKE RECORD'         # (salt, B, y) — server-side aPAKE record
+_LABEL_HDRBG_STATE = 'HERRADURA HDRBG STATE'         # (state[32], blocks) — DRBG checkpoint (TODO #119)
 
 _ZKP_NL_ALGOS      = {'hpks-zkp-nl'}
 _ZKP_CLI_ROUNDS    = _ZKP_NL_PROD_ROUNDS   # CLI default: full 128-bit soundness
@@ -1561,6 +1565,65 @@ def cmd_dgst(args):
 
 
 # ---------------------------------------------------------------------------
+# Sub-command: rand — HDRBG deterministic byte generation (TODO #119)
+#
+# Deterministic DRBG (NOT an OS entropy source): identical seed +
+# personalization + byte count yield byte-identical output across the
+# Python, C, and Go CLIs.  A DRBG state can be checkpointed to a
+# 'HERRADURA HDRBG STATE' PEM (state[32], blocks) and resumed later.
+# ---------------------------------------------------------------------------
+
+def _encode_hdrbg_state(drbg):
+    der = der_seq(der_int(drbg.state.uint, KEYBITS // 8),
+                  der_int(drbg.blocks))
+    return pem_wrap(_LABEL_HDRBG_STATE, der)
+
+
+def _decode_hdrbg_state(path):
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_HDRBG_STATE:
+        raise ValueError(f"Expected HDRBG STATE PEM, got {label!r}")
+    state_int, blocks = ints
+    return HDrbg(BitArray(KEYBITS, state_int), blocks)
+
+
+def cmd_rand(args):
+    # Obtain the DRBG: fresh from --seed, or resumed from --state.
+    if args.seed:
+        pers = (args.personalization or '').encode()
+        drbg = drbg_seed(_read_file(args.seed), pers)
+    elif args.state:
+        drbg = _decode_hdrbg_state(args.state)
+    else:
+        sys.exit("rand: one of --seed or --state is required")
+
+    if getattr(args, 'reseed', None):
+        drbg_reseed(drbg, _read_file(args.reseed))
+
+    if args.bytes is not None:
+        if args.bytes < 0:
+            sys.exit("rand: --bytes must be non-negative")
+        try:
+            out = drbg_generate(drbg, args.bytes)
+        except RuntimeError as e:
+            sys.exit(f"rand: {e}")
+        if args.hex:
+            data = (out.hex() + '\n').encode()
+        else:
+            data = out
+        if args.out == '-':
+            sys.stdout.buffer.write(data)
+        else:
+            _write_file(args.out, data)
+    elif not getattr(args, 'reseed', None):
+        sys.exit("rand: nothing to do (specify --bytes and/or --reseed)")
+
+    # Persist the (advanced/reseeded) state if a state file was given.
+    if args.state:
+        _write_file(args.state, _encode_hdrbg_state(drbg))
+
+
+# ---------------------------------------------------------------------------
 # Sub-command: fpe (78.A)
 # ---------------------------------------------------------------------------
 
@@ -1880,6 +1943,24 @@ def build_parser():
     dg.add_argument('--out', default='-',
                     help='Output: - prints hex to stdout (default); file path writes PEM digest')
 
+    # rand (HDRBG — deterministic byte generation, TODO #119)
+    rd = sub.add_parser('rand',
+                        help='Generate deterministic bytes from an HDRBG seed/state')
+    rd.add_argument('--seed', default=None,
+                    help='Seed/entropy file to instantiate the DRBG')
+    rd.add_argument('--state', default=None,
+                    help='HDRBG STATE PEM to resume from and/or update (checkpoint)')
+    rd.add_argument('--personalization', default=None,
+                    help='Personalization string (with --seed only)')
+    rd.add_argument('--reseed', default=None,
+                    help='Entropy file to fold into the state before generating')
+    rd.add_argument('--bytes', type=int, default=None,
+                    help='Number of output bytes to generate')
+    rd.add_argument('--hex', action='store_true',
+                    help='Hex-encode the output instead of raw bytes')
+    rd.add_argument('--out', default='-',
+                    help='Output file (default: - = stdout)')
+
     # fpe (78.A)
     fp = sub.add_parser('fpe',
                         help='Format-preserving encrypt/decrypt a 256-bit block (78.A)')
@@ -1976,6 +2057,7 @@ _DISPATCH = {
     'encfile': cmd_encfile,
     'decfile': cmd_decfile,
     'dgst':    cmd_dgst,
+    'rand':         cmd_rand,
     'fpe':          cmd_fpe,
     'twk':          cmd_twk,
     'oprf-blind':     cmd_oprf_blind,

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -1040,6 +1040,95 @@ static void cmd_dgst(int argc, char **argv)
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+ * rand — HDRBG deterministic byte generation (TODO #119)
+ *
+ * Deterministic DRBG (NOT an OS entropy source): identical seed +
+ * personalization + byte count yield byte-identical output across the
+ * Python, C, and Go CLIs.  State can be checkpointed to a
+ * 'HERRADURA HDRBG STATE' PEM (state[32], blocks) and resumed.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+static void write_hdrbg_state(const HDrbg *d, const char *path)
+{
+    uint8_t is[DER_INT_LEN(KEYBYTES)], ib[DER_INT_LEN(8)];
+    size_t ls, lb;
+    der_int_enc(d->state.b, KEYBYTES, is, &ls);
+    der_i_uint(d->blocks, ib, &lb);
+    const uint8_t *it[2] = {is, ib}; size_t il[2] = {ls, lb};
+    seq_and_write(it, il, 2, PEM_HDRBG_STATE, path);
+}
+
+static void load_hdrbg_state(HDrbg *d, const char *path)
+{
+    PemKey k;
+    pem_key_load(&k, path);
+    if (strcmp(k.label, PEM_HDRBG_STATE) != 0)
+        dief("rand: expected HDRBG STATE PEM, got: %s", k.label);
+    if (k.n_items < 2) die("rand: malformed HDRBG state");
+    BitArray st;
+    ba_from_ra(&st, k.vals[0], k.vlens[0]);
+    d->state = st;
+    d->blocks = parse_be_uint(k.vals[1], k.vlens[1]);
+    pem_key_free(&k);
+}
+
+static void cmd_rand(int argc, char **argv)
+{
+    const char *seed_path   = get_arg(argc, argv, "--seed");
+    const char *state_path  = get_arg(argc, argv, "--state");
+    const char *pers        = get_arg(argc, argv, "--personalization");
+    const char *reseed_path = get_arg(argc, argv, "--reseed");
+    const char *bytes_arg   = get_arg(argc, argv, "--bytes");
+    const char *out_path    = get_arg(argc, argv, "--out");
+    int hex = has_flag(argc, argv, "--hex");
+
+    HDrbg d;
+    if (seed_path) {
+        size_t slen, plen = pers ? strlen(pers) : 0;
+        uint8_t *sbuf = read_binary_file(seed_path, &slen);
+        drbg_seed(&d, sbuf, slen, (const uint8_t *)(pers ? pers : ""), plen);
+        free(sbuf);
+    } else if (state_path) {
+        load_hdrbg_state(&d, state_path);
+    } else {
+        die("rand: one of --seed or --state is required");
+    }
+
+    if (reseed_path) {
+        size_t rlen;
+        uint8_t *rbuf = read_binary_file(reseed_path, &rlen);
+        drbg_reseed(&d, rbuf, rlen);
+        free(rbuf);
+    }
+
+    if (bytes_arg) {
+        long n = strtol(bytes_arg, NULL, 10);
+        if (n < 0) die("rand: --bytes must be non-negative");
+        uint8_t *out = (uint8_t *)malloc((size_t)n ? (size_t)n : 1);
+        if (!out) die("rand: out of memory");
+        if (!drbg_generate(&d, out, (size_t)n))
+            die("rand: output limit reached — reseed required");
+        if (!out_path || strcmp(out_path, "-") == 0) {
+            if (hex) { long i; for (i = 0; i < n; i++) printf("%02x", out[i]); putchar('\n'); }
+            else fwrite(out, 1, (size_t)n, stdout);
+        } else if (hex) {
+            char *hbuf = (char *)malloc((size_t)n * 2 + 2);
+            long i; for (i = 0; i < n; i++) sprintf(hbuf + i * 2, "%02x", out[i]);
+            hbuf[n * 2] = '\n';
+            write_binary_file(out_path, (uint8_t *)hbuf, (size_t)n * 2 + 1);
+            free(hbuf);
+        } else {
+            write_binary_file(out_path, out, (size_t)n);
+        }
+        free(out);
+    } else if (!reseed_path) {
+        die("rand: nothing to do (specify --bytes and/or --reseed)");
+    }
+
+    if (state_path) write_hdrbg_state(&d, state_path);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
  * enc
  * ───────────────────────────────────────────────────────────────────────────── */
 
@@ -2551,6 +2640,12 @@ static void usage(void)
 "    Compute HFSCX-256 digest.  Without --out: hex to stdout.\n"
 "    With --out FILE: HERRADURA DIGEST PEM.\n"
 "\n"
+"  rand (--seed FILE | --state FILE) [--personalization STR] [--reseed FILE]\n"
+"       [--bytes N] [--hex] [--out FILE]\n"
+"    HDRBG deterministic byte generation (NOT an OS entropy source).\n"
+"    --seed instantiates; --state resumes/checkpoints a HERRADURA HDRBG STATE PEM.\n"
+"    Same seed+personalization+N is byte-identical across the Python/C/Go CLIs.\n"
+"\n"
 "  fpe (--encrypt|--decrypt) --key SK --context CTX --in FILE [--out FILE]\n"
 "    Format-preserving encrypt/decrypt a 32-byte block (78.A).\n"
 "    Key: HERRADURA SESSION KEY PEM.  CTX: arbitrary context string.\n"
@@ -2594,6 +2689,7 @@ int main(int argc, char **argv)
     if (strcmp(cmd, "sign")    == 0) { cmd_sign(argc, argv);    return 0; }
     if (strcmp(cmd, "verify")  == 0) { cmd_verify(argc, argv);  return 0; }
     if (strcmp(cmd, "dgst")    == 0) { cmd_dgst(argc, argv);    return 0; }
+    if (strcmp(cmd, "rand")    == 0) { cmd_rand(argc, argv);    return 0; }
     if (strcmp(cmd, "encfile") == 0) { cmd_encfile(argc, argv); return 0; }
     if (strcmp(cmd, "decfile") == 0) { cmd_decfile(argc, argv); return 0; }
     if (strcmp(cmd, "fpe")          == 0) { cmd_fpe(argc, argv);          return 0; }

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -13,6 +13,7 @@
 //   herradura_cli_go verify   --algo hpks      --pubkey pub.pem --in msg.bin --sig sig.pem
 //   herradura_cli_go dgst     --in file.bin                       # hex to stdout
 //   herradura_cli_go dgst     --algo hfscx-256 --in file.bin --out d.pem
+//   herradura_cli_go rand     --seed seed.bin --bytes 64 --hex     # deterministic bytes
 //
 // HKEX-RNL (2-round):
 //   herradura_cli_go kex --algo hkex-rnl --our bob.pem --their alice_pub.pem --out resp.pem
@@ -59,6 +60,7 @@ const (
 	lblCT      = "HERRADURA CIPHERTEXT"
 	lblSig     = "HERRADURA SIGNATURE"
 	lblDigest  = "HERRADURA DIGEST"
+	lblHdrbg   = "HERRADURA HDRBG STATE"
 
 	lblZkpRnlProof = "HERRADURA ZKP-RNL PROOF"
 	lblZkpNlPriv   = "HERRADURA ZKP-NL PRIVATE KEY"
@@ -890,6 +892,101 @@ func cmdDgst(args []string) {
 	pem := PemWrap(lblDigest, seq)
 	if err := writeString(*out, pem); err != nil {
 		die("dgst", err)
+	}
+}
+
+// ── rand — HDRBG deterministic byte generation (TODO #119) ───────────────────
+//
+// Deterministic DRBG (NOT an OS entropy source): identical seed +
+// personalization + byte count yield byte-identical output across the
+// Python, C, and Go CLIs.  State can be checkpointed to a
+// 'HERRADURA HDRBG STATE' PEM (state[32], blocks) and resumed.
+
+func encodeHdrbgState(d *HDrbg) string {
+	sd, _ := derIntBig(new(big.Int).SetBytes(d.DrbgState()), 32)
+	bd, _ := derIntSmall(int(d.Blocks))
+	seq, _ := DerSeqEnc(sd, bd)
+	return PemWrap(lblHdrbg, seq)
+}
+
+func loadHdrbgState(path string) *HDrbg {
+	label, ints, err := readPEMInts(path)
+	if err != nil {
+		die("rand", err)
+	}
+	if label != lblHdrbg {
+		fmt.Fprintf(os.Stderr, "rand: expected HDRBG STATE PEM, got %q\n", label)
+		os.Exit(1)
+	}
+	if len(ints) < 2 {
+		fmt.Fprintln(os.Stderr, "rand: malformed HDRBG state")
+		os.Exit(1)
+	}
+	state := make([]byte, 32)
+	new(big.Int).SetBytes(ints[0]).FillBytes(state)
+	return DrbgFromState(state, uint64(bytesToInt(ints[1])))
+}
+
+func cmdRand(args []string) {
+	fs := flag.NewFlagSet("rand", flag.ExitOnError)
+	seed   := fs.String("seed", "", "Seed/entropy file to instantiate the DRBG")
+	state  := fs.String("state", "", "HDRBG STATE PEM to resume from and/or update")
+	pers   := fs.String("personalization", "", "Personalization string (with --seed only)")
+	reseed := fs.String("reseed", "", "Entropy file to fold into the state before generating")
+	nbytes := fs.Int("bytes", -1, "Number of output bytes to generate")
+	asHex  := fs.Bool("hex", false, "Hex-encode the output instead of raw bytes")
+	out    := fs.String("out", "-", "Output file (default: - = stdout)")
+	fs.Parse(args)
+
+	var d *HDrbg
+	switch {
+	case *seed != "":
+		sbuf, err := readFile(*seed)
+		if err != nil {
+			die("rand", err)
+		}
+		d = DrbgSeed(sbuf, []byte(*pers))
+	case *state != "":
+		d = loadHdrbgState(*state)
+	default:
+		fmt.Fprintln(os.Stderr, "rand: one of --seed or --state is required")
+		os.Exit(1)
+	}
+
+	if *reseed != "" {
+		rbuf, err := readFile(*reseed)
+		if err != nil {
+			die("rand", err)
+		}
+		d.DrbgReseed(rbuf)
+	}
+
+	if *nbytes >= 0 {
+		outBytes, ok := d.DrbgGenerate(*nbytes)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "rand: output limit reached — reseed required")
+			os.Exit(1)
+		}
+		var data []byte
+		if *asHex {
+			data = []byte(hex.EncodeToString(outBytes) + "\n")
+		} else {
+			data = outBytes
+		}
+		if *out == "-" {
+			os.Stdout.Write(data)
+		} else if err := writeBytes(*out, data); err != nil {
+			die("rand", err)
+		}
+	} else if *reseed == "" {
+		fmt.Fprintln(os.Stderr, "rand: nothing to do (specify --bytes and/or --reseed)")
+		os.Exit(1)
+	}
+
+	if *state != "" {
+		if err := writeString(*state, encodeHdrbgState(d)); err != nil {
+			die("rand", err)
+		}
 	}
 }
 
@@ -2554,6 +2651,7 @@ Commands:
   encfile  --key FILE --in FILE --out FILE
   decfile  --key FILE --in FILE --out FILE
   dgst     [--algo hfscx-256] --in FILE [--out FILE]
+  rand     (--seed FILE | --state FILE) [--personalization STR] [--reseed FILE] [--bytes N] [--hex] [--out FILE]
 
 Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern hpke-stern hpks-zkp-nl
 Algorithms (kex):           hkex-gf hkex-rnl
@@ -2947,6 +3045,8 @@ func main() {
 		cmdDecfile(rest)
 	case "dgst":
 		cmdDgst(rest)
+	case "rand":
+		cmdRand(rest)
 	case "fpe":
 		cmdFpe(rest)
 	case "twk":

--- a/HerraduraCli/herradura_codec.h
+++ b/HerraduraCli/herradura_codec.h
@@ -59,6 +59,7 @@
 #define PEM_HPKST_AGGREGATE "HERRADURA HPKST AGGREGATE"
 #define PEM_HPKST_PARTIAL   "HERRADURA HPKST PARTIAL"
 #define PEM_HPKST_SIG       "HERRADURA HPKST SIGNATURE"
+#define PEM_HDRBG_STATE     "HERRADURA HDRBG STATE"
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * Buffer-size macros

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -32,6 +32,10 @@ hske_nl_aead_encrypt   = _s.hske_nl_aead_encrypt
 hske_nl_aead_decrypt   = _s.hske_nl_aead_decrypt
 hske_nl_v2_duplex_encrypt = _s.hske_nl_v2_duplex_encrypt
 hske_nl_v2_duplex_decrypt = _s.hske_nl_v2_duplex_decrypt
+HDrbg                  = _s.HDrbg
+drbg_seed              = _s.drbg_seed
+drbg_generate          = _s.drbg_generate
+drbg_reseed            = _s.drbg_reseed
 _HFSCX256_IV_BYTES     = _s._HFSCX256_IV_BYTES
 _RNL_KDF_DC_256        = _s._RNL_KDF_DC_256
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.68)
+# Herradura Cryptographic Suite (v1.9.69)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6481,7 +6481,18 @@ number of deterministic bytes, with optional reseed.
    distinct-personalization-separation checks.
 5. Document the subcommand and note it is a deterministic DRBG (not an OS entropy source).
 
-Status: **OPEN**
+Status: **DONE v1.9.69** — `rand` subcommand added to the Python (`herradura.py`), C
+(`herradura_cli.c`), and Go (`herradura_cli_go`) CLIs:
+`rand (--seed FILE | --state FILE) [--personalization STR] [--reseed FILE] [--bytes N]
+[--hex] [--out FILE]`.  Output defaults to raw bytes on stdout; `--hex` hex-encodes.
+A `HERRADURA HDRBG STATE` PEM (`SEQ(state[32], blocks)`) checkpoints/resumes the DRBG
+across invocations, and `--reseed` folds fresh entropy into a saved state.  The Go package
+gained exported `DrbgState()` / `DrbgFromState()` accessors (the `state` field was
+unexported) for state persistence.  `CliTest/test_rand.sh` verifies determinism, 3-language
+byte-identical KAT, personalization separation, reseed-changes-stream, and the full 9-way
+cross-language state checkpoint/resume matrix (20/20 pass).  Documented in the three CLI
+usage headers and `docs/TUTORIAL.md` (with the "deterministic DRBG, not an OS entropy
+source" caveat).
 
 ---
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -162,6 +162,31 @@ $CLI kex --algo hkex-rnl --our alice_rnl.pem --their bob_resp.pem \
 # Both bob_resp.pem and alice_sk_rnl.pem hold the same session key.
 ```
 
+### Deterministic random bytes (HDRBG)
+
+The `rand` command exposes the forward-secure HDRBG.  It is a **deterministic**
+DRBG, *not* an OS entropy source: identical seed + personalization + byte count
+produce byte-identical output across the Python, C, and Go CLIs.
+
+```bash
+# Generate 64 deterministic bytes from a seed (hex to stdout)
+$CLI rand --seed seed.bin --bytes 64 --hex
+
+# Domain-separate two streams from the same seed with --personalization
+$CLI rand --seed seed.bin --personalization "stream-A" --bytes 32 --out a.bin
+
+# Checkpoint/resume: --state writes (and later resumes) a DRBG STATE PEM, so a
+# long stream can be produced across several invocations without repetition.
+$CLI rand --seed seed.bin --state drbg.pem --bytes 32 --out part1.bin
+$CLI rand --state drbg.pem               --bytes 32 --out part2.bin   # continues
+
+# Fold fresh entropy into a saved state with --reseed (forward-secure advance)
+$CLI rand --state drbg.pem --reseed more_entropy.bin --bytes 32 --out part3.bin
+```
+
+`--out` defaults to stdout; `--hex` hex-encodes the output.  See
+`CliTest/test_rand.sh` for the cross-language KAT and state-resume matrix.
+
 See `CliTest/` for full integration test scripts covering all algorithms
 and cross-language interoperability.
 

--- a/herradura/herradura.go
+++ b/herradura/herradura.go
@@ -802,6 +802,16 @@ func (d *HDrbg) DrbgReseed(entropy []byte) {
 	d.Blocks = 0
 }
 
+// DrbgState returns the raw 32-byte internal state, for checkpointing the
+// DRBG between invocations (see the CLI `rand --state` flow, TODO #119).
+func (d *HDrbg) DrbgState() []byte { return d.state.Bytes() }
+
+// DrbgFromState reconstructs a DRBG from a checkpointed 32-byte state and the
+// output-block counter.  Inverse of DrbgState + .Blocks.
+func DrbgFromState(state []byte, blocks uint64) *HDrbg {
+	return &HDrbg{state: NewBitArray(256, new(big.Int).SetBytes(state)), Blocks: blocks}
+}
+
 // ---------------------------------------------------------------------------
 // HKEX-RNL ring-arithmetic helpers (negacyclic Z_q[x]/(x^n+1))
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **TODO #119**: adds a `rand` subcommand to the Python, C, and Go CLIs exposing the forward-secure HDRBG (`drbg_seed`/`drbg_generate`/`drbg_reseed`, added in v1.9.34).

```
rand (--seed FILE | --state FILE) [--personalization STR] [--reseed FILE] [--bytes N] [--hex] [--out FILE]
```

- **Deterministic DRBG** (clearly documented as *not* an OS entropy source): identical seed + personalization + byte count is **byte-identical across all three CLIs**.
- **State checkpoint/resume:** new `HERRADURA HDRBG STATE` PEM (`SEQ(state[32], blocks)`) lets a stream span multiple invocations via `--state`; `--reseed` folds fresh entropy into a saved state.
- **Go library change:** `HDrbg.state` was unexported, so exported `DrbgState()` / `DrbgFromState()` accessors were added to `herradura/herradura.go` to enable state persistence.
- `HerraduraCli/primitives.py` re-exports the DRBG functions; output defaults to raw bytes on stdout, `--hex` hex-encodes.

## Test plan

- [x] `CliTest/test_rand.sh` (new): determinism, 3-language byte-identical KAT, personalization separation, reseed-changes-stream, and the full 9-way cross-language state checkpoint/resume matrix → **20/20 pass**
- [x] No regression: `CliTest/test_duplex.sh` (23/23), `test_aead.sh` (19/19), `test_c_keygen.sh` (16/16)
- [x] C CLI builds clean; Go CLI builds clean (`go build -o herradura_cli_go herradura_cli.go`)

To reproduce: `bash CliTest/test_rand.sh` (requires C + Go CLIs built via `build_c.sh` / `build_go.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)