### PR TITLE
CLI: HPKS-WOTS-F one-time signatures in genpkey/sign/verify — v1.9.70 (TODO #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.70] - 2026-06-26
+
+### Feature — CLI: HPKS-WOTS-F one-time signatures in genpkey/sign/verify (TODO #120)
+
+- **`HerraduraCli/herradura.py`, `herradura_cli.c`, `herradura_cli.go`:** added
+  `genpkey --algo hpks-wots`, `sign --algo hpks-wots`, and `verify --algo hpks-wots`,
+  exposing the standalone Winternitz one-time signature (the primitive underlying the
+  existing `hpks-xmss` wrapper).
+- **Wire format:** new PEM objects `HERRADURA HPKS-WOTS PRIVATE KEY`
+  (`SEQ(seed[32], leaf_idx)`), `… PUBLIC KEY` and `… SIGNATURE`
+  (`SEQ(blob[ℓ·32], ℓ)` with ℓ=67 chain values). Byte-for-byte interoperable across the
+  three CLIs.
+- **One-time enforcement:** signing burns the key via a `<key>.idx` state file
+  (0 = unused, 1 = burned); a second `sign` is refused with a clear error. WOTS signs the
+  full message (hashed internally), bypassing the single-block truncation other sign algos use.
+- **`CliTest/test_wots.sh` (new):** 9-way sign/verify interop matrix, per-language reuse
+  refusal, tampered-message rejection, and wrong-public-key rejection (18/18 pass).
+- **`docs/TUTORIAL.md`** and the three CLI usage headers document the algorithm with a
+  prominent one-time-reuse warning.
+
+---
+
 ## [1.9.69] - 2026-06-24
 
 ### Feature — CLI: `rand` command for HDRBG deterministic byte generation (TODO #119)

--- a/CliTest/test_wots.sh
+++ b/CliTest/test_wots.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# CliTest/test_wots.sh — HPKS-WOTS-F one-time signature CLI, cross-language interop (TODO #120)
+# Covers: keygen/pubout/sign/verify round-trip, 9-way cross-CLI interop,
+# one-time reuse refusal, and tamper rejection.
+set -euo pipefail
+
+DIR=$(dirname "$0")
+PY="python3 $DIR/../HerraduraCli/herradura.py"
+C="$DIR/../HerraduraCli/herradura_cli"
+GO="$DIR/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+for bin in "$C" "$GO"; do
+    if [ ! -x "$bin" ]; then
+        echo "SKIP: $bin not built (run build_c.sh / build_go.sh)"; exit 0
+    fi
+done
+
+printf 'HPKS-WOTS-F one-time signature message — arbitrary length is fine.' > "$TMP/msg.bin"
+declare -A CLI=( [py]="$PY" [c]="$C" [go]="$GO" )
+
+# 9-way interop: each signer generates a fresh one-time key, every verifier checks
+for s in py c go; do
+    ${CLI[$s]} genpkey --algo hpks-wots --out "$TMP/k_$s.pem" 2>/dev/null
+    ${CLI[$s]} pkey --in "$TMP/k_$s.pem" --pubout --out "$TMP/k_${s}_pub.pem"
+    ${CLI[$s]} sign --algo hpks-wots --key "$TMP/k_$s.pem" --in "$TMP/msg.bin" \
+        --out "$TMP/sig_$s.pem" 2>/dev/null
+    for v in py c go; do
+        if ${CLI[$v]} verify --algo hpks-wots --pubkey "$TMP/k_${s}_pub.pem" \
+              --in "$TMP/msg.bin" --sig "$TMP/sig_$s.pem" >/dev/null 2>&1; then
+            echo "PASS wots $s-sign -> $v-verify"; PASS=$((PASS+1))
+        else
+            echo "FAIL wots $s-sign -> $v-verify"; FAIL=$((FAIL+1))
+        fi
+    done
+done
+
+# One-time reuse must be refused in every language
+for s in py c go; do
+    if ${CLI[$s]} sign --algo hpks-wots --key "$TMP/k_$s.pem" --in "$TMP/msg.bin" \
+          --out "$TMP/reuse_$s.pem" 2>/dev/null; then
+        echo "FAIL wots $s reuse allowed"; FAIL=$((FAIL+1))
+    else
+        echo "PASS wots $s one-time reuse refused"; PASS=$((PASS+1))
+    fi
+done
+
+# Tampered message must fail verification (cross-language)
+printf 'tampered message' > "$TMP/bad.bin"
+for v in py c go; do
+    if ${CLI[$v]} verify --algo hpks-wots --pubkey "$TMP/k_py_pub.pem" \
+          --in "$TMP/bad.bin" --sig "$TMP/sig_py.pem" >/dev/null 2>&1; then
+        echo "FAIL wots $v accepted tampered message"; FAIL=$((FAIL+1))
+    else
+        echo "PASS wots $v rejects tampered message"; PASS=$((PASS+1))
+    fi
+done
+
+# Wrong public key must fail (sig_py verified against k_c_pub)
+for v in py c go; do
+    if ${CLI[$v]} verify --algo hpks-wots --pubkey "$TMP/k_c_pub.pem" \
+          --in "$TMP/msg.bin" --sig "$TMP/sig_py.pem" >/dev/null 2>&1; then
+        echo "FAIL wots $v accepted wrong public key"; FAIL=$((FAIL+1))
+    else
+        echo "PASS wots $v rejects wrong public key"; PASS=$((PASS+1))
+    fi
+done
+
+echo
+echo "test_wots: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -12,6 +12,8 @@
 #   python3 herradura.py dec     --algo hske-duplex --key sk.pem --in cipher.pem --ad hdr --out plain.bin
 #   python3 herradura.py sign    --algo hpks      --key sig.pem --in msg.bin --out s.pem
 #   python3 herradura.py sign    --algo hpks-nl   --key sig.pem --in large.bin --digest hfscx-256 --out s.pem
+#   python3 herradura.py genpkey --algo hpks-wots --out otk.pem            # ONE-TIME key
+#   python3 herradura.py sign    --algo hpks-wots --key otk.pem --in msg.bin --out s.pem  # signs once
 #   python3 herradura.py verify  --algo hpks      --pubkey sig.pem --in msg.bin --sig s.pem
 #   python3 herradura.py verify  --algo hpks-nl   --pubkey pub.pem --in large.bin --digest hfscx-256 --sig s.pem
 #   python3 herradura.py dgst                     --in file.bin               # hex to stdout
@@ -95,6 +97,7 @@ _PRIV_ALGOS = {
     'hpks-zkp-nl': 'HERRADURA ZKP-NL PRIVATE KEY',
     'oprf':        'HERRADURA OPRF PRIVATE KEY',
     'hpks-xmss':   'HERRADURA HPKS-XMSS PRIVATE KEY',
+    'hpks-wots':   'HERRADURA HPKS-WOTS PRIVATE KEY',
 }
 
 _PUB_ALGOS = {k: v.replace('PRIVATE', 'PUBLIC') for k, v in _PRIV_ALGOS.items()}
@@ -378,6 +381,90 @@ def _xmss_read_idx(key_path: str, h: int) -> int:
 
 def _xmss_write_idx(key_path: str, next_idx: int):
     open(_xmss_state_path(key_path), 'w').write(str(next_idx) + '\n')
+
+
+# ---------------------------------------------------------------------------
+# HPKS-WOTS-F one-time signature codec (TODO #120)
+#
+# A WOTS-F key signs EXACTLY ONCE.  The private key is (master_seed, leaf_idx);
+# the public key is the list of ℓ=67 chain endpoints.  One-time use is enforced
+# via a `.idx` state file alongside the private key (0 = unused, 1 = burned).
+# ---------------------------------------------------------------------------
+
+_LABEL_WOTS_SIG = 'HERRADURA HPKS-WOTS SIGNATURE'
+
+
+def _encode_wots_privkey(master_seed: bytes, leaf_idx: int) -> str:
+    der = der_seq(der_int(int.from_bytes(master_seed, 'big'), 32),
+                  der_int(leaf_idx))
+    return pem_wrap(_PRIV_ALGOS['hpks-wots'], der)
+
+
+def _decode_wots_privkey(path):
+    """Returns (master_seed, leaf_idx)."""
+    label, der = _read_pem(path)
+    if label != _PRIV_ALGOS['hpks-wots']:
+        raise ValueError(f"Expected HPKS-WOTS private key, got {label!r}")
+    seed_int, leaf_idx = der_parse_seq(der)
+    return seed_int.to_bytes(32, 'big'), int(leaf_idx)
+
+
+def _encode_wots_pubkey(pk: list) -> str:
+    """Public key PEM: the ℓ chain endpoints (ℓ × 32 bytes) + ℓ."""
+    nbytes = KEYBITS // 8
+    blob = b''.join(v.uint.to_bytes(nbytes, 'big') for v in pk)
+    der = der_seq(der_int(int.from_bytes(blob, 'big'), len(blob)),
+                  der_int(len(pk)))
+    return pem_wrap(_PUB_ALGOS['hpks-wots'], der)
+
+
+def _decode_wots_pubkey(path):
+    """Returns pk as a list of ℓ BitArrays."""
+    label, der = _read_pem(path)
+    if label != _PUB_ALGOS['hpks-wots']:
+        raise ValueError(f"Expected HPKS-WOTS public key, got {label!r}")
+    blob_int, ell = der_parse_seq(der)
+    ell = int(ell)
+    nbytes = KEYBITS // 8
+    blob = blob_int.to_bytes(ell * nbytes, 'big')
+    return [BitArray(KEYBITS, int.from_bytes(blob[i*nbytes:(i+1)*nbytes], 'big'))
+            for i in range(ell)]
+
+
+def _pack_wots_sig(sig: list) -> str:
+    """Signature PEM: the ℓ chain values (ℓ × 32 bytes) + ℓ."""
+    nbytes = KEYBITS // 8
+    blob = b''.join(v.uint.to_bytes(nbytes, 'big') for v in sig)
+    der = der_seq(der_int(int.from_bytes(blob, 'big'), len(blob)),
+                  der_int(len(sig)))
+    return pem_wrap(_LABEL_WOTS_SIG, der)
+
+
+def _unpack_wots_sig(path: str):
+    """Returns the signature as a list of ℓ BitArrays."""
+    label, der = _read_pem(path)
+    if label != _LABEL_WOTS_SIG:
+        raise ValueError(f"Expected HPKS-WOTS signature, got {label!r}")
+    blob_int, ell = der_parse_seq(der)
+    ell = int(ell)
+    nbytes = KEYBITS // 8
+    blob = blob_int.to_bytes(ell * nbytes, 'big')
+    return [BitArray(KEYBITS, int.from_bytes(blob[i*nbytes:(i+1)*nbytes], 'big'))
+            for i in range(ell)]
+
+
+def _wots_is_used(key_path: str) -> bool:
+    sp = _xmss_state_path(key_path)   # reuse <key>.idx convention
+    if os.path.exists(sp):
+        try:
+            return int(open(sp).read().strip()) != 0
+        except Exception:
+            pass
+    return False
+
+
+def _wots_mark_used(key_path: str):
+    open(_xmss_state_path(key_path), 'w').write('1\n')
 
 
 def _load_zkp_nl_privkey(path):
@@ -767,6 +854,16 @@ def cmd_genpkey(args):
         if out_path and out_path != '-':
             _xmss_write_idx(out_path, 0)
 
+    elif algo == 'hpks-wots':
+        import secrets as _sec
+        master_seed = _sec.token_bytes(32)
+        pem_out = _encode_wots_privkey(master_seed, 0)
+        out_path = args.out
+        if out_path and out_path != '-':
+            _xmss_write_idx(out_path, 0)   # 0 = unused (one-time key)
+        print("HPKS-WOTS: ONE-TIME key — it may sign exactly one message.",
+              file=sys.stderr)
+
     else:
         sys.exit(f"Unknown algorithm: {algo!r}")
 
@@ -800,6 +897,10 @@ def cmd_pkey(args):
         elif algo == 'hpks-xmss':
             master_seed, h, _, leaf_hashes, root = _decode_xmss_privkey(in_path)
             pem_out = _encode_xmss_pubkey(root, h)
+        elif algo == 'hpks-wots':
+            master_seed, leaf_idx = _decode_wots_privkey(in_path)
+            _sk, pk = hpks_wots_keygen(master_seed, leaf_idx)
+            pem_out = _encode_wots_pubkey(pk)
         else:
             sys.exit(f"Unknown algorithm: {algo!r}")
         _write_file(args.out or '-', pem_out)
@@ -1184,6 +1285,19 @@ def cmd_sign(args):
         print(f"XMSS leaf {leaf_idx} used; {num_leaves - leaf_idx - 1} leaves remaining.",
               file=sys.stderr)
 
+    elif algo == 'hpks-wots':
+        if our_algo != 'hpks-wots':
+            sys.exit(f"hpks-wots sign: expected hpks-wots key, got {our_algo!r}")
+        if _wots_is_used(key_path):
+            sys.exit("sign: this HPKS-WOTS key was already used — WOTS keys are "
+                     "ONE-TIME. Generate a fresh key (genpkey --algo hpks-wots).")
+        master_seed, leaf_idx = _decode_wots_privkey(key_path)
+        sig, _pk = hpks_wots_sign(in_bytes, master_seed, leaf_idx)
+        _write_file(args.out, _pack_wots_sig(sig))
+        _wots_mark_used(key_path)
+        print("HPKS-WOTS key burned (one-time use); do not sign again with it.",
+              file=sys.stderr)
+
     else:
         sys.exit(f"sign: unsupported algorithm {algo!r}")
 
@@ -1400,6 +1514,17 @@ def cmd_verify(args):
         root, h = _decode_xmss_pubkey(pubkey_path)
         sig = _unpack_xmss_sig(sig_path)
         ok  = hpks_xmss_verify(in_bytes, sig, root)
+        if ok:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    elif algo == 'hpks-wots':
+        pk  = _decode_wots_pubkey(pubkey_path)
+        sig = _unpack_wots_sig(sig_path)
+        ok  = hpks_wots_verify(in_bytes, sig, pk)
         if ok:
             print("Signature OK")
             sys.exit(0)
@@ -1852,7 +1977,8 @@ def build_parser():
     # sign
     sg = sub.add_parser('sign', help='Sign a message or generate a ZKP')
     sg.add_argument('--algo', required=True,
-                    choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo', 'hpks-xmss'])
+                    choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo',
+                             'hpks-xmss', 'hpks-wots'])
     sg.add_argument('--key',  required=True)
     sg.add_argument('--in',  required=True, dest='in')
     sg.add_argument('--out', required=True)
@@ -1866,7 +1992,7 @@ def build_parser():
     vf = sub.add_parser('verify', help='Verify a signature or ZKP proof')
     vf.add_argument('--algo', required=True,
                     choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo',
-                             'hpks-xmss', 'hpks-t'])
+                             'hpks-xmss', 'hpks-wots', 'hpks-t'])
     vf.add_argument('--pubkey', default=None)
     vf.add_argument('--in',  required=True, dest='in')
     vf.add_argument('--sig', required=True)

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -310,6 +310,56 @@ static int pem_key_get_n(const PemKey *k, int idx)
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+ * HPKS-WOTS-F one-time signature helpers (TODO #120)
+ *
+ * One-time use is enforced via a `<key>.idx` state file (0 = unused, 1 = burned),
+ * mirroring the Python CLI.  A WOTS public key / signature is ℓ=WOTS_L chain
+ * values, serialised as a single (WOTS_L * KEYBYTES)-byte DER INTEGER blob.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+static void wots_idx_path(const char *key_path, char *buf, size_t buflen)
+{
+    snprintf(buf, buflen, "%s.idx", key_path);
+}
+
+static int wots_is_used(const char *key_path)
+{
+    char p[4096]; wots_idx_path(key_path, p, sizeof p);
+    FILE *f = fopen(p, "r");
+    if (!f) return 0;
+    int v = 0;
+    if (fscanf(f, "%d", &v) != 1) v = 0;
+    fclose(f);
+    return v != 0;
+}
+
+static void wots_write_idx(const char *key_path, int val)
+{
+    char p[4096]; wots_idx_path(key_path, p, sizeof p);
+    FILE *f = fopen(p, "w");
+    if (f) { fprintf(f, "%d\n", val); fclose(f); }
+}
+
+/* Serialise ℓ WOTS chain values into a flat (WOTS_L * KEYBYTES)-byte blob. */
+static void wots_blob_pack(uint8_t *blob, const BitArray vals[WOTS_L])
+{
+    for (int i = 0; i < WOTS_L; i++)
+        memcpy(blob + (size_t)i * KEYBYTES, vals[i].b, KEYBYTES);
+}
+
+/* Recover ℓ BitArrays from a parsed DER value (right-aligned into the blob,
+ * since integer encoding may have dropped leading zero bytes). */
+static void wots_blob_unpack(BitArray vals[WOTS_L], const uint8_t *v, size_t vl)
+{
+    uint8_t blob[WOTS_L * KEYBYTES];
+    memset(blob, 0, sizeof blob);
+    if (vl > sizeof blob) vl = sizeof blob;
+    memcpy(blob + (sizeof blob - vl), v, vl);
+    for (int i = 0; i < WOTS_L; i++)
+        ba_from_ra(&vals[i], blob + (size_t)i * KEYBYTES, KEYBYTES);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
  * genpkey
  * ───────────────────────────────────────────────────────────────────────────── */
 
@@ -426,6 +476,22 @@ static void cmd_genpkey(int argc, char **argv)
         fclose(urnd); return;
     }
 
+    /* HPKS-WOTS-F one-time key: SEQUENCE(INTEGER(seed,32), INTEGER(leaf_idx=0)) */
+    if (strcmp(algo, "hpks-wots") == 0) {
+        uint8_t seed[KEYBYTES];
+        if (fread(seed, 1, KEYBYTES, urnd) != KEYBYTES) die("urandom read failed");
+        uint8_t is[DER_INT_LEN(KEYBYTES)], il0[DER_INT_LEN(8)];
+        size_t ls, ll;
+        der_i32(seed, is, &ls);
+        der_i_uint(0, il0, &ll);
+        const uint8_t *it[2] = {is, il0}; size_t ill[2] = {ls, ll};
+        seq_and_write(it, ill, 2, PEM_HPKS_WOTS_PRIV, out);
+        if (out && strcmp(out, "-") != 0) wots_write_idx(out, 0);
+        fprintf(stderr, "HPKS-WOTS: ONE-TIME key — it may sign exactly one message.\n");
+        explicit_bzero(seed, KEYBYTES);
+        fclose(urnd); return;
+    }
+
     fclose(urnd);
     dief("genpkey: unsupported algorithm: %s", algo);
 }
@@ -502,6 +568,7 @@ static void cmd_pkey(int argc, char **argv)
         { PEM_HKEX_RNL_PRIV,   PEM_HKEX_RNL_PUB,   "hkex-rnl",   0 },
         { PEM_HPKS_STERN_PRIV, PEM_HPKS_STERN_PUB, "hpks-stern", 2 },
         { PEM_HPKE_STERN_PRIV, PEM_HPKE_STERN_PUB, "hpke-stern", 2 },
+        { PEM_HPKS_WOTS_PRIV,  PEM_HPKS_WOTS_PUB,  "hpks-wots",  3 },
         { NULL, NULL, NULL, 0 }
     };
 
@@ -580,6 +647,33 @@ static void cmd_pkey(int argc, char **argv)
             seq_and_write(it, il, 4, PEM_HKEX_RNL_PUB, out_path);
             explicit_bzero(n_A, KEYBYTES);
             free(ic_der); free(im_der); free(ina_der);
+        }
+    }
+
+    /* ── HPKS-WOTS-F one-time ─── */
+    else if (kind == 3) {
+        if (k.n_items < 1) die("pkey: malformed WOTS private key");
+        BitArray seed_ba;
+        ba_from_ra(&seed_ba, k.vals[0], k.vlens[0]);
+        uint32_t leaf_idx = (k.n_items >= 2)
+            ? (uint32_t)parse_be_uint(k.vals[1], k.vlens[1]) : 0;
+        BitArray sk[WOTS_L], pk[WOTS_L];
+        hpks_wots_keygen(sk, pk, seed_ba.b, leaf_idx);
+        if (text) {
+            printf("%-10s: %s\n", "algorithm", algo);
+            printf("%-10s: one-time\n", "type");
+        } else {
+            uint8_t blob[WOTS_L * KEYBYTES];
+            wots_blob_pack(blob, pk);
+            uint8_t *ib = (uint8_t *)malloc(DER_INT_LEN(sizeof blob));
+            uint8_t iell[DER_INT_LEN(8)];
+            size_t lb, lell;
+            if (!ib) die("out of memory");
+            der_int_enc(blob, sizeof blob, ib, &lb);
+            der_i_uint(WOTS_L, iell, &lell);
+            const uint8_t *it[2] = {ib, iell}; size_t il[2] = {lb, lell};
+            seq_and_write(it, il, 2, PEM_HPKS_WOTS_PUB, out_path);
+            free(ib);
         }
     }
 
@@ -1793,6 +1887,48 @@ static void cmd_sign(int argc, char **argv)
     uint8_t *in_buf = read_binary_file(in_path, &in_len);
     uint8_t msg_bytes[KEYBYTES];
 
+    /* HPKS-WOTS-F signs the full message (hashed internally), not a truncated
+     * 256-bit block — handle it before the block-truncation logic below. */
+    if (strcmp(algo, "hpks-wots") == 0) {
+        PemKey wk;
+        pem_key_load(&wk, key_path);
+        if (strcmp(wk.label, PEM_HPKS_WOTS_PRIV) != 0)
+            dief("sign: expected HPKS-WOTS private key, got: %s", wk.label);
+        if (wots_is_used(key_path))
+            die("sign: this HPKS-WOTS key was already used — WOTS keys are ONE-TIME. "
+                "Generate a fresh key (genpkey --algo hpks-wots).");
+        BitArray seed_ba;
+        ba_from_ra(&seed_ba, wk.vals[0], wk.vlens[0]);
+        uint32_t leaf_idx = (wk.n_items >= 2)
+            ? (uint32_t)parse_be_uint(wk.vals[1], wk.vlens[1]) : 0;
+        pem_key_free(&wk);
+
+        const uint8_t *wmsg; size_t wmlen; uint8_t wdig[KEYBYTES];
+        if (digest && strcmp(digest, "hfscx-256") == 0) {
+            hfscx_256(in_buf, in_len, NULL, wdig);
+            wmsg = wdig; wmlen = KEYBYTES;
+        } else {
+            wmsg = in_buf; wmlen = in_len;
+        }
+        BitArray sig[WOTS_L];
+        hpks_wots_sign(sig, wmsg, wmlen, seed_ba.b, leaf_idx);
+        free(in_buf);
+
+        uint8_t blob[WOTS_L * KEYBYTES];
+        wots_blob_pack(blob, sig);
+        uint8_t *ib = (uint8_t *)malloc(DER_INT_LEN(sizeof blob));
+        uint8_t iell[DER_INT_LEN(8)]; size_t lb, lell;
+        if (!ib) die("out of memory");
+        der_int_enc(blob, sizeof blob, ib, &lb);
+        der_i_uint(WOTS_L, iell, &lell);
+        const uint8_t *it[2] = {ib, iell}; size_t il[2] = {lb, lell};
+        seq_and_write(it, il, 2, PEM_HPKS_WOTS_SIG, out_path);
+        free(ib);
+        wots_write_idx(key_path, 1);
+        fprintf(stderr, "HPKS-WOTS key burned (one-time use); do not sign again with it.\n");
+        return;
+    }
+
     if (digest && strcmp(digest, "hfscx-256") == 0) {
         /* Pre-hash: sign the 32-byte digest. */
         hfscx_256(in_buf, in_len, NULL, msg_bytes);
@@ -1948,6 +2084,35 @@ static void cmd_verify(int argc, char **argv)
     size_t in_len;
     uint8_t *in_buf = read_binary_file(in_path, &in_len);
     uint8_t msg_bytes[KEYBYTES];
+
+    /* HPKS-WOTS-F verifies against the full message (hashed internally). */
+    if (strcmp(algo, "hpks-wots") == 0) {
+        const uint8_t *wmsg; size_t wmlen; uint8_t wdig[KEYBYTES];
+        if (digest && strcmp(digest, "hfscx-256") == 0) {
+            hfscx_256(in_buf, in_len, NULL, wdig);
+            wmsg = wdig; wmlen = KEYBYTES;
+        } else {
+            wmsg = in_buf; wmlen = in_len;
+        }
+        PemKey pubk; pem_key_load(&pubk, pubkey_path);
+        if (strcmp(pubk.label, PEM_HPKS_WOTS_PUB) != 0)
+            dief("verify: expected HPKS-WOTS public key, got: %s", pubk.label);
+        BitArray pk[WOTS_L];
+        wots_blob_unpack(pk, pubk.vals[0], pubk.vlens[0]);
+        pem_key_free(&pubk);
+
+        PemKey sigk; pem_key_load(&sigk, sig_path);
+        if (strcmp(sigk.label, PEM_HPKS_WOTS_SIG) != 0)
+            dief("verify: expected HPKS-WOTS signature, got: %s", sigk.label);
+        BitArray sig[WOTS_L];
+        wots_blob_unpack(sig, sigk.vals[0], sigk.vlens[0]);
+        pem_key_free(&sigk);
+
+        int ok = hpks_wots_verify(wmsg, wmlen, sig, pk);
+        free(in_buf);
+        if (ok) { puts("Signature OK");        exit(0); }
+        else    { puts("Verification FAILED"); exit(1); }
+    }
 
     if (digest && strcmp(digest, "hfscx-256") == 0) {
         hfscx_256(in_buf, in_len, NULL, msg_bytes);
@@ -2611,9 +2776,10 @@ static void usage(void)
 "    Verify-then-decrypt a .hkx file.  Exits non-zero on auth failure.\n"
 "\n"
 "  sign --algo ALGO --key PRIV --in FILE --out SIG [--digest hfscx-256]\n"
-"    Sign.  Algorithms: hpks hpks-nl hpks-stern rnl-sigma nl-zkboo\n"
+"    Sign.  Algorithms: hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots\n"
 "    rnl-sigma: key = hkex-rnl private key (n=256); produces ZKP-RNL PROOF PEM.\n"
 "    nl-zkboo:  key = hpks-zkp-nl private key;      produces ZKP-NL PROOF PEM.\n"
+"    hpks-wots: ONE-TIME signature — a WOTS key may sign exactly once (reuse refused).\n"
 "    --digest hfscx-256: pre-hash input before signing.\n"
 "\n"
 "  verify --algo ALGO [--pubkey PUB] --in FILE --sig SIG [--digest hfscx-256]\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -55,6 +55,10 @@ const (
 	lblHpksSternPub = "HERRADURA HPKS-STERN PUBLIC KEY"
 	lblHpkeSternPub = "HERRADURA HPKE-STERN PUBLIC KEY"
 
+	lblHpksWotsPriv = "HERRADURA HPKS-WOTS PRIVATE KEY"
+	lblHpksWotsPub  = "HERRADURA HPKS-WOTS PUBLIC KEY"
+	lblHpksWotsSig  = "HERRADURA HPKS-WOTS SIGNATURE"
+
 	lblSession = "HERRADURA SESSION KEY"
 	lblRnlResp = "HERRADURA HKEX-RNL RESPONSE"
 	lblCT      = "HERRADURA CIPHERTEXT"
@@ -88,6 +92,7 @@ var privToAlgo = map[string]string{
 	lblHpkeNLPriv:    "hpke-nl",
 	lblHpksSternPriv: "hpks-stern",
 	lblHpkeSternPriv: "hpke-stern",
+	lblHpksWotsPriv:  "hpks-wots",
 }
 
 var algoToPrivLbl = map[string]string{
@@ -99,6 +104,7 @@ var algoToPrivLbl = map[string]string{
 	"hpke-nl":    lblHpkeNLPriv,
 	"hpks-stern": lblHpksSternPriv,
 	"hpke-stern": lblHpkeSternPriv,
+	"hpks-wots":  lblHpksWotsPriv,
 }
 
 var algoToPubLbl = map[string]string{
@@ -110,6 +116,7 @@ var algoToPubLbl = map[string]string{
 	"hpke-nl":    lblHpkeNLPub,
 	"hpks-stern": lblHpksSternPub,
 	"hpke-stern": lblHpkeSternPub,
+	"hpks-wots":  lblHpksWotsPub,
 }
 
 var classicalAlgos = map[string]bool{
@@ -455,6 +462,56 @@ func rnlContributoryKDF(kRaw *BitArray, n int, nA, nB []byte) *BitArray {
 	return NewBitArray(n, new(big.Int).SetBytes(digest))
 }
 
+// ── HPKS-WOTS-F one-time signature helpers (TODO #120) ───────────────────────
+//
+// One-time use is enforced via a `<key>.idx` state file (0 = unused, 1 = burned).
+// A WOTS public key / signature is WotsL chain values, serialised as a single
+// (WotsL * 32)-byte DER INTEGER blob.
+
+func wotsIdxPath(keyPath string) string { return keyPath + ".idx" }
+
+func wotsIsUsed(keyPath string) bool {
+	b, err := os.ReadFile(wotsIdxPath(keyPath))
+	if err != nil {
+		return false
+	}
+	v := strings.TrimSpace(string(b))
+	return v != "" && v != "0"
+}
+
+func wotsWriteIdx(keyPath string, val int) {
+	_ = os.WriteFile(wotsIdxPath(keyPath), []byte(fmt.Sprintf("%d\n", val)), 0644)
+}
+
+func wotsBlobPack(vals [WotsL]*BitArray) []byte {
+	blob := make([]byte, WotsL*32)
+	for i := 0; i < WotsL; i++ {
+		vals[i].Val.FillBytes(blob[i*32 : (i+1)*32])
+	}
+	return blob
+}
+
+func wotsBlobUnpack(v []byte) [WotsL]*BitArray {
+	blob := make([]byte, WotsL*32)
+	if len(v) > len(blob) {
+		v = v[len(v)-len(blob):]
+	}
+	copy(blob[len(blob)-len(v):], v)
+	var out [WotsL]*BitArray
+	for i := 0; i < WotsL; i++ {
+		out[i] = NewBitArray(256, new(big.Int).SetBytes(blob[i*32:(i+1)*32]))
+	}
+	return out
+}
+
+func encodeWotsBlobPEM(vals [WotsL]*BitArray, label string) string {
+	blob := wotsBlobPack(vals)
+	bd, _ := derIntBig(new(big.Int).SetBytes(blob), len(blob))
+	ed, _ := derIntSmall(WotsL)
+	seq, _ := DerSeqEnc(bd, ed)
+	return PemWrap(label, seq)
+}
+
 // ── genpkey ──────────────────────────────────────────────────────────────────
 
 func cmdGenpkey(args []string) {
@@ -525,6 +582,25 @@ func cmdGenpkey(args []string) {
 			os.Exit(1)
 		}
 		pem = PemWrap(lblOprfPriv, seq)
+
+	case *algo == "hpks-wots":
+		seed := NewRandBitArray(256).Bytes() // 32-byte master seed
+		sd, e1 := derIntBig(new(big.Int).SetBytes(seed), 32)
+		ld, e2 := derIntSmall(0) // leaf_idx = 0
+		if e1 != nil || e2 != nil {
+			fmt.Fprintln(os.Stderr, "genpkey: DER encode error")
+			os.Exit(1)
+		}
+		seq, e3 := DerSeqEnc(sd, ld)
+		if e3 != nil {
+			fmt.Fprintln(os.Stderr, "genpkey: DER seq error")
+			os.Exit(1)
+		}
+		pem = PemWrap(lblHpksWotsPriv, seq)
+		if *out != "-" {
+			wotsWriteIdx(*out, 0)
+		}
+		fmt.Fprintln(os.Stderr, "HPKS-WOTS: ONE-TIME key — it may sign exactly one message.")
 
 	default:
 		fmt.Fprintf(os.Stderr, "genpkey: unknown algorithm %q\n", *algo)
@@ -627,6 +703,16 @@ func cmdPkey(args []string) {
 			seed := NewBitArray(n, new(big.Int).SetBytes(ints[1]))
 			syn  := SternSyndrome(seed, e)
 			pem, err = encodeSternPub(syn, seed, n, algo)
+
+		case algo == "hpks-wots":
+			seed := make([]byte, 32)
+			new(big.Int).SetBytes(ints[0]).FillBytes(seed)
+			var leafIdx uint32
+			if len(ints) >= 2 {
+				leafIdx = uint32(bytesToInt(ints[1]))
+			}
+			_, pk := HpksWotsKeygen(seed, leafIdx)
+			pem = encodeWotsBlobPEM(pk, lblHpksWotsPub)
 		}
 
 		if err != nil {
@@ -1935,6 +2021,26 @@ func cmdSign(args []string) {
 			die("sign", err)
 		}
 
+	case "hpks-wots":
+		if wotsIsUsed(*key) {
+			fmt.Fprintln(os.Stderr, "sign: this HPKS-WOTS key was already used — WOTS keys "+
+				"are ONE-TIME. Generate a fresh key (genpkey --algo hpks-wots).")
+			os.Exit(1)
+		}
+		seed := make([]byte, 32)
+		new(big.Int).SetBytes(ourInts[0]).FillBytes(seed)
+		var leafIdx uint32
+		if len(ourInts) >= 2 {
+			leafIdx = uint32(bytesToInt(ourInts[1]))
+		}
+		sig := HpksWotsSign(inBytes, seed, leafIdx)
+		pem := encodeWotsBlobPEM(sig, lblHpksWotsSig)
+		if err := writeString(*out, pem); err != nil {
+			die("sign", err)
+		}
+		wotsWriteIdx(*key, 1)
+		fmt.Fprintln(os.Stderr, "HPKS-WOTS key burned (one-time use); do not sign again with it.")
+
 	default:
 		fmt.Fprintf(os.Stderr, "sign: unsupported algorithm %q\n", *algo)
 		os.Exit(1)
@@ -2092,6 +2198,21 @@ func cmdVerify(args []string) {
 			die("verify", err)
 		}
 		if HpksSternFVerify(msg, sternSig, seed, synInt) {
+			fmt.Println("Signature OK")
+			os.Exit(0)
+		} else {
+			fmt.Println("Verification FAILED")
+			os.Exit(1)
+		}
+
+	case "hpks-wots":
+		pk := wotsBlobUnpack(theirInts[0])
+		_, sigInts, serr := readPEMInts(*sig)
+		if serr != nil {
+			die("verify", serr)
+		}
+		sigArr := wotsBlobUnpack(sigInts[0])
+		if HpksWotsVerify(inBytes, sigArr, pk) {
 			fmt.Println("Signature OK")
 			os.Exit(0)
 		} else {
@@ -2657,7 +2778,7 @@ Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern
 Algorithms (kex):           hkex-gf hkex-rnl
 Algorithms (enc/dec):       hske hske-nla1 hske-nla2 hske-duplex hpke hpke-nl hpke-stern
 Algorithms (encfile/decfile): hske-nla1
-Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo
+Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots (one-time)
   fpe      --encrypt|--decrypt --key SK --context STR --in FILE [--out FILE]
   twk      --encrypt|--decrypt --key SK [--sector N] [--bidx N] --in FILE [--out FILE]
 `)

--- a/HerraduraCli/herradura_codec.h
+++ b/HerraduraCli/herradura_codec.h
@@ -60,6 +60,9 @@
 #define PEM_HPKST_PARTIAL   "HERRADURA HPKST PARTIAL"
 #define PEM_HPKST_SIG       "HERRADURA HPKST SIGNATURE"
 #define PEM_HDRBG_STATE     "HERRADURA HDRBG STATE"
+#define PEM_HPKS_WOTS_PRIV  "HERRADURA HPKS-WOTS PRIVATE KEY"
+#define PEM_HPKS_WOTS_PUB   "HERRADURA HPKS-WOTS PUBLIC KEY"
+#define PEM_HPKS_WOTS_SIG   "HERRADURA HPKS-WOTS SIGNATURE"
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * Buffer-size macros

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.69)
+# Herradura Cryptographic Suite (v1.9.70)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6518,7 +6518,16 @@ surface.  A one-time signature is useful on its own (e.g. constrained-device sin
    and cross-CLI interop (Python sign → C/Go verify and vice versa).
 5. Document the one-time constraint prominently in the CLI help and `docs/TUTORIAL.md`.
 
-Status: **OPEN**
+Status: **DONE v1.9.70** — `genpkey`/`sign`/`verify --algo hpks-wots` added to the Python
+(`herradura.py`), C (`herradura_cli.c`), and Go (`herradura_cli_go`) CLIs.  New PEM objects
+`HERRADURA HPKS-WOTS PRIVATE KEY` (`SEQ(seed[32], leaf_idx)`),
+`… PUBLIC KEY` and `… SIGNATURE` (`SEQ(blob[ℓ·32], ℓ)`), byte-for-byte interoperable.
+One-time use is enforced via a `<key>.idx` burn file (0=unused, 1=burned); a second sign
+is refused with a clear error.  WOTS signs the full message (hashed internally), bypassing
+the single-block truncation used by the other sign algos.  `CliTest/test_wots.sh` covers the
+9-way sign/verify interop matrix, per-language reuse refusal, tampered-message rejection, and
+wrong-public-key rejection (18/18 pass).  Documented in the three CLI usage headers and
+`docs/TUTORIAL.md` (with a prominent one-time-reuse warning).
 
 ---
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -133,6 +133,30 @@ $CLI verify --algo hpks --pubkey sign_pub.pem --in msg.bin --sig sig.pem
 # Prints: Signature OK
 ```
 
+#### One-time signatures (HPKS-WOTS-F)
+
+`hpks-wots` is a hash-based **one-time** signature (Winternitz OTS over HFSCX-256).
+A WOTS key may sign **exactly one** message; the CLI burns the key after signing
+(tracked in a `<key>.idx` file next to the private key) and refuses any reuse.
+
+```bash
+$CLI genpkey --algo hpks-wots --out otk.pem          # ONE-TIME key
+$CLI pkey    --in otk.pem --pubout --out otk_pub.pem
+
+$CLI sign   --algo hpks-wots --key otk.pem --in msg.bin --out sig.pem   # burns otk.pem
+$CLI verify --algo hpks-wots --pubkey otk_pub.pem --in msg.bin --sig sig.pem
+# Prints: Signature OK
+
+$CLI sign   --algo hpks-wots --key otk.pem --in msg.bin --out sig2.pem
+# Error: this HPKS-WOTS key was already used — WOTS keys are ONE-TIME.
+```
+
+> **Reusing a WOTS key to sign a second message catastrophically breaks its
+> security.** Generate a fresh key per message, or use the many-time `hpks-xmss`
+> wrapper (library API) which manages a tree of WOTS leaves.  Signatures are
+> byte-for-byte interoperable across the Python, C, and Go CLIs
+> (`CliTest/test_wots.sh`).
+
 ### El Gamal encryption (HPKE)
 
 ```bash


### PR DESCRIPTION
## Summary

Implements **TODO #120**: exposes the standalone Winternitz one-time signature (HPKS-WOTS-F — the primitive underlying the existing `hpks-xmss` wrapper) on the Python, C, and Go CLIs as `genpkey`/`sign`/`verify --algo hpks-wots`.

- **New PEM objects** (byte-for-byte interoperable across all three CLIs):
  - `HERRADURA HPKS-WOTS PRIVATE KEY` — `SEQ(seed[32], leaf_idx)`
  - `HERRADURA HPKS-WOTS PUBLIC KEY` / `SIGNATURE` — `SEQ(blob[67·32], 67)`
- **One-time enforcement:** signing burns the key via a `<key>.idx` state file (0 = unused, 1 = burned); a second `sign` is refused with a clear error in every language.
- **Full-message signing:** WOTS hashes the full message internally, so the C and Go CLIs bypass the single-block truncation the other sign algos apply (the main cross-language correctness subtlety).

## Test plan

- [x] `CliTest/test_wots.sh` (new): 9-way sign/verify interop matrix, per-language one-time reuse refusal, tampered-message rejection, wrong-public-key rejection → **18/18 pass**
- [x] No regression: `test_rand.sh` (20/20), `test_duplex.sh` (23/23), `test_c_keygen.sh` / `test_go_keygen.sh` (16/16 each)
- [x] C CLI builds clean; Go CLI builds clean

To reproduce: `bash CliTest/test_wots.sh` (requires C + Go CLIs built via `build_c.sh` / `build_go.sh`).

## Notes

This leaves **#121 (HPKS-Stern-Ring)** as the last item from the CLI capability review; it will additionally need a C suite port (`hpks_stern_ring_*` is currently Go/Python only in the library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)