### PR TITLE
CLI: HPKS-Stern-Ring anonymous ring signatures in sign/verify — v1.9.71 (TODO #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the Herradura Cryptographic Suite are documented here.
 
 ---
 
+## [1.9.71] - 2026-06-26
+
+### Feature — CLI: HPKS-Stern-Ring anonymous ring signatures in sign/verify (TODO #121)
+
+- **`HerraduraCli/herradura.py`, `herradura_cli.go`, `herradura_cli.c`:** added
+  `sign --algo hpks-ring --key SIGNER --ring P0,P1,...` and
+  `verify --algo hpks-ring --ring P0,P1,...`, exposing the code-based ring signature
+  (`hpks_stern_ring_sign`/`verify`, #78.I) on all three CLIs. One member of an ad-hoc
+  group signs anonymously; verification confirms a ring member signed without revealing
+  which one.
+- **Wire format:** new `HERRADURA HPKS-RING SIGNATURE` PEM — `SEQ(k, rounds, n, blob)`
+  with a member-major / round-major flat blob (`c0||c1||c2||b||resp_a||resp_b` per
+  (member, round)). Byte-for-byte interoperable across the three CLIs.
+- **Signer privacy:** the signer supplies an `hpks-stern` private key whose public key is
+  in `--ring`; its index is located by seed match and kept hidden in the output. Non-members
+  are refused at signing time.
+- **C suite port:** already present — `stern_ring_sign`/`verify` have shipped in `herradura.h`
+  since v1.9.16 (TODO #78.I) and pass security test [20]; only the CLI surface was missing.
+- **`CliTest/test_ring.sh` (new):** 9-way sign/verify interop matrix, anonymity (any member
+  signs), non-member sign refusal, tampered-message and wrong-ring rejection (21/21 pass).
+- **`HerraduraCli/primitives.py`:** re-export `hpks_stern_ring_sign`/`verify`.
+- **`docs/TUTORIAL.md`** and the three CLI usage headers document the anonymity property
+  and the demo-parameter caveat.
+
+---
+
 ## [1.9.70] - 2026-06-26
 
 ### Feature — CLI: HPKS-WOTS-F one-time signatures in genpkey/sign/verify (TODO #120)

--- a/CliTest/test_ring.sh
+++ b/CliTest/test_ring.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# CliTest/test_ring.sh — HPKS-Stern-Ring anonymous ring signatures, cross-language (TODO #121)
+# Covers: sign-by-member / verify-by-ring success, 9-way cross-CLI interop,
+# anonymity (any member can sign), non-member sign refusal, tamper rejection,
+# and wrong-ring rejection.
+set -euo pipefail
+
+DIR=$(dirname "$0")
+PY="python3 $DIR/../HerraduraCli/herradura.py"
+C="$DIR/../HerraduraCli/herradura_cli"
+GO="$DIR/../HerraduraCli/herradura_cli_go"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+for bin in "$C" "$GO"; do
+    if [ ! -x "$bin" ]; then
+        echo "SKIP: $bin not built (run build_c.sh / build_go.sh)"; exit 0
+    fi
+done
+
+# Three ring members (hpks-stern keypairs) + an outsider
+for m in 0 1 2; do
+    $PY genpkey --algo hpks-stern --out "$TMP/m$m.pem" 2>/dev/null
+    $PY pkey --in "$TMP/m$m.pem" --pubout --out "$TMP/m${m}_pub.pem" 2>/dev/null
+done
+$PY genpkey --algo hpks-stern --out "$TMP/outsider.pem" 2>/dev/null
+RING="$TMP/m0_pub.pem,$TMP/m1_pub.pem,$TMP/m2_pub.pem"
+printf 'anonymous ring signature test message' > "$TMP/msg.bin"
+
+declare -A CLI=( [py]="$PY" [c]="$C" [go]="$GO" )
+
+# 9-way interop: signer language signs as member 1, every verifier checks
+for s in py c go; do
+    ${CLI[$s]} sign --algo hpks-ring --key "$TMP/m1.pem" --ring "$RING" \
+        --in "$TMP/msg.bin" --out "$TMP/sig_$s.pem" 2>/dev/null
+    for v in py c go; do
+        if ${CLI[$v]} verify --algo hpks-ring --ring "$RING" \
+              --in "$TMP/msg.bin" --sig "$TMP/sig_$s.pem" >/dev/null 2>&1; then
+            echo "PASS ring $s-sign -> $v-verify"; PASS=$((PASS+1))
+        else
+            echo "FAIL ring $s-sign -> $v-verify"; FAIL=$((FAIL+1))
+        fi
+    done
+done
+
+# Anonymity: each of the three members can sign and the ring verifies (Python)
+for m in 0 1 2; do
+    ${CLI[py]} sign --algo hpks-ring --key "$TMP/m$m.pem" --ring "$RING" \
+        --in "$TMP/msg.bin" --out "$TMP/anon_$m.pem" 2>/dev/null
+    if ${CLI[py]} verify --algo hpks-ring --ring "$RING" \
+          --in "$TMP/msg.bin" --sig "$TMP/anon_$m.pem" >/dev/null 2>&1; then
+        echo "PASS ring member-$m signs anonymously"; PASS=$((PASS+1))
+    else
+        echo "FAIL ring member-$m signs anonymously"; FAIL=$((FAIL+1))
+    fi
+done
+
+# Non-member cannot sign (signer key not in ring)
+for s in py c go; do
+    if ${CLI[$s]} sign --algo hpks-ring --key "$TMP/outsider.pem" --ring "$RING" \
+          --in "$TMP/msg.bin" --out "$TMP/bad_$s.pem" 2>/dev/null; then
+        echo "FAIL ring $s non-member signed"; FAIL=$((FAIL+1))
+    else
+        echo "PASS ring $s non-member sign refused"; PASS=$((PASS+1))
+    fi
+done
+
+# Tampered message must fail verification (every language)
+printf 'tampered message' > "$TMP/tampered.bin"
+for v in py c go; do
+    if ${CLI[$v]} verify --algo hpks-ring --ring "$RING" \
+          --in "$TMP/tampered.bin" --sig "$TMP/sig_py.pem" >/dev/null 2>&1; then
+        echo "FAIL ring $v accepted tampered message"; FAIL=$((FAIL+1))
+    else
+        echo "PASS ring $v rejects tampered message"; PASS=$((PASS+1))
+    fi
+done
+
+# Wrong ring (member 0 swapped for outsider) must fail
+$PY pkey --in "$TMP/outsider.pem" --pubout --out "$TMP/outsider_pub.pem" 2>/dev/null
+WRONG_RING="$TMP/outsider_pub.pem,$TMP/m1_pub.pem,$TMP/m2_pub.pem"
+for v in py c go; do
+    if ${CLI[$v]} verify --algo hpks-ring --ring "$WRONG_RING" \
+          --in "$TMP/msg.bin" --sig "$TMP/sig_py.pem" >/dev/null 2>&1; then
+        echo "FAIL ring $v accepted wrong ring"; FAIL=$((FAIL+1))
+    else
+        echo "PASS ring $v rejects wrong ring"; PASS=$((PASS+1))
+    fi
+done
+
+echo
+echo "test_ring: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/HerraduraCli/herradura.py
+++ b/HerraduraCli/herradura.py
@@ -14,6 +14,8 @@
 #   python3 herradura.py sign    --algo hpks-nl   --key sig.pem --in large.bin --digest hfscx-256 --out s.pem
 #   python3 herradura.py genpkey --algo hpks-wots --out otk.pem            # ONE-TIME key
 #   python3 herradura.py sign    --algo hpks-wots --key otk.pem --in msg.bin --out s.pem  # signs once
+#   python3 herradura.py sign    --algo hpks-ring --key m1.pem --ring m0_pub.pem,m1_pub.pem,m2_pub.pem --in msg.bin --out s.pem
+#   python3 herradura.py verify  --algo hpks-ring --ring m0_pub.pem,m1_pub.pem,m2_pub.pem --in msg.bin --sig s.pem
 #   python3 herradura.py verify  --algo hpks      --pubkey sig.pem --in msg.bin --sig s.pem
 #   python3 herradura.py verify  --algo hpks-nl   --pubkey pub.pem --in large.bin --digest hfscx-256 --sig s.pem
 #   python3 herradura.py dgst                     --in file.bin               # hex to stdout
@@ -63,6 +65,7 @@ from primitives import (
     _rnl_keygen, _rnl_agree, _rnl_m_poly, _rnl_rand_poly, _rnl_poly_add,
     _rnl_lift, _rnl_poly_mul,
     stern_f_keygen, hpks_stern_f_sign, hpks_stern_f_verify,
+    hpks_stern_ring_sign, hpks_stern_ring_verify,
     hpke_stern_f_encap_with_e, hpke_stern_f_decap,
     rnl_sigma_sign, rnl_sigma_verify,
     zkp_nl_keygen, zkp_nl_prove, zkp_nl_verify,
@@ -116,6 +119,7 @@ _LABEL_OPRF_STATE  = 'HERRADURA OPRF CLIENT STATE'   # (r, alpha, nbits) — cli
 _LABEL_OPRF_EVAL   = 'HERRADURA OPRF EVALUATION'     # (beta, nbits) — server response
 _LABEL_PAKE_RECORD = 'HERRADURA PAKE RECORD'         # (salt, B, y) — server-side aPAKE record
 _LABEL_HDRBG_STATE = 'HERRADURA HDRBG STATE'         # (state[32], blocks) — DRBG checkpoint (TODO #119)
+_LABEL_RING_SIG    = 'HERRADURA HPKS-RING SIGNATURE'  # (k, rounds, n, blob) — ring signature (TODO #121)
 
 _ZKP_NL_ALGOS      = {'hpks-zkp-nl'}
 _ZKP_CLI_ROUNDS    = _ZKP_NL_PROD_ROUNDS   # CLI default: full 128-bit soundness
@@ -789,6 +793,88 @@ def _unpack_stern_sig(path):
 
 
 # ---------------------------------------------------------------------------
+# HPKS-Stern-Ring signature codec (TODO #121)
+#
+# Member-major, round-major flat blob; per (member, round) entry:
+#   c0 || c1 || c2 || b(1 byte) || resp_a || resp_b   (each n-bit value = n/8 B).
+# resp_a is a BitArray when b != 0 (pi_seed), else an integer (sr); resp_b is
+# always an integer.  PEM: SEQ(k, rounds, n, blob).
+# ---------------------------------------------------------------------------
+
+def _pack_ring_sig(sig, n):
+    all_commits, all_challenges, all_responses = sig
+    k      = len(all_challenges)
+    rounds = len(all_challenges[0])
+    nbytes = n // 8
+
+    def _vb(v):
+        iv = v.uint if isinstance(v, BitArray) else int(v)
+        return iv.to_bytes(nbytes, 'big')
+
+    blob = bytearray()
+    for i in range(k):
+        for r in range(rounds):
+            c0, c1, c2 = all_commits[i][r]
+            ra, rb     = all_responses[i][r]
+            blob += _vb(c0) + _vb(c1) + _vb(c2)
+            blob += bytes([all_challenges[i][r] & 0xFF])
+            blob += _vb(ra) + _vb(rb)
+
+    der = der_seq(der_int(k), der_int(rounds), der_int(n),
+                  der_int(int.from_bytes(blob, 'big'), len(blob)))
+    return pem_wrap(_LABEL_RING_SIG, der)
+
+
+def _unpack_ring_sig(path):
+    """Return (sig, k, rounds, n) — sig = (all_commits, all_challenges, all_responses)."""
+    label, ints = _read_pem_ints(path)
+    if label != _LABEL_RING_SIG:
+        raise ValueError(f"Expected HPKS-RING SIGNATURE PEM, got {label!r}")
+    k, rounds, n, blob_int = (int(ints[0]), int(ints[1]), int(ints[2]), ints[3])
+    nbytes = n // 8
+    entry  = 5 * nbytes + 1
+    blob   = blob_int.to_bytes(k * rounds * entry, 'big')
+
+    all_commits    = [[None] * rounds for _ in range(k)]
+    all_challenges = [[0]    * rounds for _ in range(k)]
+    all_responses  = [[None] * rounds for _ in range(k)]
+    off = 0
+    for i in range(k):
+        for r in range(rounds):
+            c0 = BitArray(n, int.from_bytes(blob[off:off+nbytes], 'big')); off += nbytes
+            c1 = BitArray(n, int.from_bytes(blob[off:off+nbytes], 'big')); off += nbytes
+            c2 = BitArray(n, int.from_bytes(blob[off:off+nbytes], 'big')); off += nbytes
+            b  = blob[off]; off += 1
+            ra = int.from_bytes(blob[off:off+nbytes], 'big'); off += nbytes
+            rb = int.from_bytes(blob[off:off+nbytes], 'big'); off += nbytes
+            all_commits[i][r]    = (c0, c1, c2)
+            all_challenges[i][r] = b
+            all_responses[i][r]  = ((ra if b == 0 else BitArray(n, ra)), rb)
+    return (all_commits, all_challenges, all_responses), k, rounds, n
+
+
+def _load_ring_pubkeys(ring_arg):
+    """Parse a comma-separated list of hpks-stern public-key PEM paths.
+
+    Returns (ring_keys, n) where ring_keys[i] = (seed BitArray, syndrome int)."""
+    paths = [p for p in ring_arg.split(',') if p]
+    if len(paths) < 2:
+        sys.exit("hpks-ring: --ring needs at least 2 member public keys")
+    ring_keys, ring_n = [], None
+    for p in paths:
+        algo_i, ints_i = _decode_pubkey(p)
+        if algo_i != 'hpks-stern':
+            sys.exit(f"hpks-ring: ring member {p!r} is {algo_i!r}, expected hpks-stern")
+        syn_i, seed_i, n_i = ints_i
+        if ring_n is None:
+            ring_n = n_i
+        elif n_i != ring_n:
+            sys.exit("hpks-ring: all ring members must share the same n")
+        ring_keys.append((BitArray(n_i, seed_i), syn_i))
+    return ring_keys, ring_n
+
+
+# ---------------------------------------------------------------------------
 # Key-loading helper for enc/dec (accepts both SESSION KEY and RNL RESPONSE)
 # ---------------------------------------------------------------------------
 
@@ -1252,6 +1338,28 @@ def cmd_sign(args):
         sig  = hpks_stern_f_sign(msg, e_int, seed, syn, n)
         _write_file(args.out, _pack_stern_sig(sig, n))
 
+    elif algo == 'hpks-ring':
+        print(_STERN_DEMO_WARNING, file=sys.stderr)
+        if our_algo != 'hpks-stern':
+            sys.exit(f"hpks-ring sign: signer key must be hpks-stern, got {our_algo!r}")
+        if not getattr(args, 'ring', None):
+            sys.exit("hpks-ring sign: --ring (comma-separated member public keys) required")
+        e_int, seed_int, n = our_ints
+        ring_keys, ring_n = _load_ring_pubkeys(args.ring)
+        if ring_n != n:
+            sys.exit(f"hpks-ring sign: signer n={n} != ring n={ring_n}")
+        # Locate the signer's own index in the ring (matched by seed).
+        j = next((idx for idx, (sd, _sy) in enumerate(ring_keys)
+                  if sd.uint == seed_int), None)
+        if j is None:
+            sys.exit("hpks-ring sign: signer's public key is not in --ring "
+                     "(run pkey --pubout on the signer key and include it)")
+        msg = BitArray(n, int.from_bytes(in_bytes[:n // 8].ljust(n // 8, b'\x00'), 'big'))
+        sig = hpks_stern_ring_sign(msg, e_int, j, ring_keys, n, SDFR)
+        _write_file(args.out, _pack_ring_sig(sig, n))
+        print(f"Ring signature created (k={len(ring_keys)}); signer index is hidden.",
+              file=sys.stderr)
+
     elif algo == 'rnl-sigma':
         # Sign using an HKEX-RNL private key: proves knowledge of s s.t. C = round_p(m·s)
         if our_algo != 'hkex-rnl':
@@ -1435,6 +1543,25 @@ def cmd_verify(args):
         R     = BitArray(nbits, R_val)
         s     = BitArray(nbits, s_val)
         ok    = hpkst_verify(C_agg, R, s, msg)
+        if ok:
+            print("Signature OK")
+            sys.exit(0)
+        else:
+            print("Verification FAILED")
+            sys.exit(1)
+
+    if algo == 'hpks-ring':
+        if not getattr(args, 'ring', None):
+            sys.exit("hpks-ring verify: --ring (comma-separated member public keys) required")
+        ring_keys, n = _load_ring_pubkeys(args.ring)
+        sig, k, rounds, sig_n = _unpack_ring_sig(sig_path)
+        if sig_n != n:
+            sys.exit(f"hpks-ring verify: signature n={sig_n} != ring n={n}")
+        if k != len(ring_keys):
+            sys.exit(f"hpks-ring verify: signature ring size {k} != "
+                     f"{len(ring_keys)} provided members")
+        msg = BitArray(n, int.from_bytes(in_bytes[:n // 8].ljust(n // 8, b'\x00'), 'big'))
+        ok  = hpks_stern_ring_verify(msg, sig, ring_keys, n)
         if ok:
             print("Signature OK")
             sys.exit(0)
@@ -1978,8 +2105,10 @@ def build_parser():
     sg = sub.add_parser('sign', help='Sign a message or generate a ZKP')
     sg.add_argument('--algo', required=True,
                     choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo',
-                             'hpks-xmss', 'hpks-wots'])
+                             'hpks-xmss', 'hpks-wots', 'hpks-ring'])
     sg.add_argument('--key',  required=True)
+    sg.add_argument('--ring', default=None,
+                    help='hpks-ring: comma-separated member public-key PEM paths')
     sg.add_argument('--in',  required=True, dest='in')
     sg.add_argument('--out', required=True)
     sg.add_argument('--digest', default='none', choices=['none', 'hfscx-256'],
@@ -1992,8 +2121,10 @@ def build_parser():
     vf = sub.add_parser('verify', help='Verify a signature or ZKP proof')
     vf.add_argument('--algo', required=True,
                     choices=['hpks', 'hpks-nl', 'hpks-stern', 'rnl-sigma', 'nl-zkboo',
-                             'hpks-xmss', 'hpks-wots', 'hpks-t'])
+                             'hpks-xmss', 'hpks-wots', 'hpks-ring', 'hpks-t'])
     vf.add_argument('--pubkey', default=None)
+    vf.add_argument('--ring', default=None,
+                    help='hpks-ring: comma-separated member public-key PEM paths')
     vf.add_argument('--in',  required=True, dest='in')
     vf.add_argument('--sig', required=True)
     vf.add_argument('--digest', default='none', choices=['none', 'hfscx-256'],

--- a/HerraduraCli/herradura_cli.c
+++ b/HerraduraCli/herradura_cli.c
@@ -1096,6 +1096,124 @@ static int stern_sig_load(const char *path, SternSig *sig)
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+ * HPKS-Stern-Ring signature CLI helpers (TODO #121)
+ *
+ * Wire format matches the Python/Go CLIs: SEQ(k, rounds, n, blob) where blob is
+ * member-major / round-major: c0||c1||c2||b(1 byte)||resp_a||resp_b per entry.
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+#define RING_MAX_K 64
+
+/* Parse comma-separated hpks-stern public-key PEM paths.  Fills seeds[k] and
+ * syndrs_flat[k*SDF_SYNBYTES].  Returns k (>=2). */
+static int ring_load_members(const char *ring_arg, BitArray *seeds,
+                             uint8_t *syndrs_flat)
+{
+    char buf[8192];
+    size_t al = strlen(ring_arg);
+    if (al >= sizeof buf) die("hpks-ring: --ring too long");
+    memcpy(buf, ring_arg, al + 1);
+    int k = 0;
+    char *save = NULL;
+    char *tok = strtok_r(buf, ",", &save);
+    while (tok) {
+        if (*tok) {
+            if (k >= RING_MAX_K) die("hpks-ring: too many ring members");
+            PemKey pub;
+            pem_key_load(&pub, tok);
+            if (strcmp(pub.label, PEM_HPKS_STERN_PUB) != 0) {
+                fprintf(stderr, "hpks-ring: ring member %s is %s, expected "
+                                "hpks-stern public key\n", tok, pub.label);
+                exit(1);
+            }
+            /* pubkey: vals[0]=syndrome(32B int), vals[1]=seed, vals[2]=n */
+            BitArray syn_ba;
+            ba_from_ra(&seeds[k], pub.vals[1], pub.vlens[1]);
+            ba_from_ra(&syn_ba,   pub.vals[0], pub.vlens[0]);
+            /* syndrome integer stores syndr[j] at byte KEYBYTES-1-j (see pkey). */
+            { int j; for (j = 0; j < SDF_SYNBYTES; j++)
+                syndrs_flat[k * SDF_SYNBYTES + j] = syn_ba.b[KEYBYTES - 1 - j]; }
+            pem_key_free(&pub);
+            k++;
+        }
+        tok = strtok_r(NULL, ",", &save);
+    }
+    if (k < 2) die("hpks-ring: --ring needs at least 2 member public keys");
+    return k;
+}
+
+static void ring_sig_pack_and_write(const SternRingSig *sig, const char *out_path)
+{
+    int k = sig->k, rounds = sig->rounds;
+    size_t entry = 5 * (size_t)KEYBYTES + 1;
+    size_t blen  = (size_t)k * rounds * entry;
+    uint8_t *blob = (uint8_t *)malloc(blen);
+    if (!blob) die("out of memory");
+    size_t off = 0;
+    int i, r;
+    for (i = 0; i < k; i++) {
+        for (r = 0; r < rounds; r++) {
+            int idx = i * rounds + r;
+            memcpy(blob + off, sig->c0[idx].b, KEYBYTES); off += KEYBYTES;
+            memcpy(blob + off, sig->c1[idx].b, KEYBYTES); off += KEYBYTES;
+            memcpy(blob + off, sig->c2[idx].b, KEYBYTES); off += KEYBYTES;
+            blob[off++] = (uint8_t)(sig->b[idx] & 0xFF);
+            memcpy(blob + off, sig->resp_a[idx].b, KEYBYTES); off += KEYBYTES;
+            memcpy(blob + off, sig->resp_b[idx].b, KEYBYTES); off += KEYBYTES;
+        }
+    }
+    uint8_t ik[DER_INT_LEN(8)], ir[DER_INT_LEN(8)], in[8];
+    size_t lk, lr, ln, lb;
+    uint8_t *ib = (uint8_t *)malloc(DER_INT_LEN(blen));
+    if (!ib) die("out of memory");
+    der_i_uint((uint64_t)k, ik, &lk);
+    der_i_uint((uint64_t)rounds, ir, &lr);
+    der_i_n256(in, &ln);
+    der_int_enc(blob, blen, ib, &lb);
+    const uint8_t *it[4] = {ik, ir, in, ib};
+    size_t il[4] = {lk, lr, ln, lb};
+    seq_and_write(it, il, 4, PEM_HPKS_RING_SIG, out_path);
+    free(blob); free(ib);
+}
+
+/* Load a ring signature into an allocated SternRingSig.  Caller frees via
+ * stern_ring_free.  Returns k. */
+static int ring_sig_load(const char *path, SternRingSig *sig)
+{
+    PemKey pk;
+    pem_key_load(&pk, path);
+    if (strcmp(pk.label, PEM_HPKS_RING_SIG) != 0 || pk.n_items < 4)
+        dief("verify: expected HPKS-RING SIGNATURE PEM, got: %s", pk.label);
+    int k      = (int)parse_be_uint(pk.vals[0], pk.vlens[0]);
+    int rounds = (int)parse_be_uint(pk.vals[1], pk.vlens[1]);
+    size_t entry = 5 * (size_t)KEYBYTES + 1;
+    size_t blen  = (size_t)k * rounds * entry;
+    uint8_t *blob = (uint8_t *)calloc(blen ? blen : 1, 1);
+    if (!blob) die("out of memory");
+    size_t vl = pk.vlens[3];
+    if (vl > blen) vl = blen;
+    memcpy(blob + (blen - vl), pk.vals[3], vl);   /* right-align */
+    pem_key_free(&pk);
+
+    stern_ring_alloc(sig, k, rounds);
+    size_t off = 0;
+    int i, r;
+    for (i = 0; i < k; i++) {
+        for (r = 0; r < rounds; r++) {
+            int idx = i * rounds + r;
+            memcpy(sig->c0[idx].b, blob + off, KEYBYTES); off += KEYBYTES;
+            memcpy(sig->c1[idx].b, blob + off, KEYBYTES); off += KEYBYTES;
+            memcpy(sig->c2[idx].b, blob + off, KEYBYTES); off += KEYBYTES;
+            sig->b[idx] = blob[off++];
+            memcpy(sig->resp_a[idx].b, blob + off, KEYBYTES); off += KEYBYTES;
+            memcpy(sig->resp_b[idx].b, blob + off, KEYBYTES); off += KEYBYTES;
+        }
+    }
+    free(blob);
+    return k;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
  * dgst
  * ───────────────────────────────────────────────────────────────────────────── */
 
@@ -2016,6 +2134,36 @@ static void cmd_sign(int argc, char **argv)
         hpks_stern_f_sign(&sig, &msg, &e_ba, &seed_ba, urnd);
         stern_sig_pack_and_write(&sig, out_path);
 
+    } else if (strcmp(algo, "hpks-ring") == 0) {
+        fprintf(stderr, "WARNING: Stern-F at N=256 provides only ~30-40 bits of security "
+                        "(demo parameters). 128-bit security requires N>=17000. "
+                        "Do not use for production.\n");
+        const char *ring_arg = get_arg(argc, argv, "--ring");
+        if (!ring_arg) die("hpks-ring sign: --ring (comma-separated member public keys) required");
+        if (priv_k.n_items < 2) die("sign: malformed Stern private key");
+        BitArray e_ba, signer_seed;
+        ba_from_ra(&e_ba,        priv_k.vals[0], priv_k.vlens[0]);
+        ba_from_ra(&signer_seed, priv_k.vals[1], priv_k.vlens[1]);
+        pem_key_free(&priv_k);
+
+        BitArray seeds[RING_MAX_K];
+        uint8_t  syndrs[RING_MAX_K * SDF_SYNBYTES];
+        int k = ring_load_members(ring_arg, seeds, syndrs);
+
+        int j = -1, i;
+        for (i = 0; i < k; i++)
+            if (ba_equal(&seeds[i], &signer_seed)) { j = i; break; }
+        if (j < 0)
+            die("hpks-ring sign: signer's public key is not in --ring "
+                "(run pkey --pubout on the signer key and include it)");
+
+        SternRingSig rsig;
+        stern_ring_alloc(&rsig, k, SDF_ROUNDS);
+        stern_ring_sign(&rsig, &msg, &e_ba, j, seeds, syndrs, urnd);
+        ring_sig_pack_and_write(&rsig, out_path);
+        stern_ring_free(&rsig);
+        fprintf(stderr, "Ring signature created (k=%d); signer index is hidden.\n", k);
+
     } else if (strcmp(algo, "rnl-sigma") == 0) {
         /* ZKP-RNL: uses hkex-rnl private key, n must equal RNL_N */
         if (priv_k.n_items < 3) die("sign: malformed hkex-rnl private key");
@@ -2078,7 +2226,7 @@ static void cmd_verify(int argc, char **argv)
     if (!algo)    die("verify: --algo required");
     if (!in_path) die("verify: --in required");
     if (!sig_path) die("verify: --sig required");
-    if (!pubkey_path && strcmp(algo, "hpks-t") != 0)
+    if (!pubkey_path && strcmp(algo, "hpks-t") != 0 && strcmp(algo, "hpks-ring") != 0)
         die("verify: --pubkey required");
 
     size_t in_len;
@@ -2130,6 +2278,27 @@ static void cmd_verify(int argc, char **argv)
     if (strcmp(algo, "hpks-t") == 0) {
         cmd_threshold_verify(argc, argv);
         return;  /* cmd_threshold_verify exits via exit() — this is a safeguard */
+    }
+
+    /* hpks-ring: anonymous verification against --ring members. */
+    if (strcmp(algo, "hpks-ring") == 0) {
+        const char *ring_arg = get_arg(argc, argv, "--ring");
+        if (!ring_arg) die("hpks-ring verify: --ring (comma-separated member public keys) required");
+        BitArray seeds[RING_MAX_K];
+        uint8_t  syndrs[RING_MAX_K * SDF_SYNBYTES];
+        int k = ring_load_members(ring_arg, seeds, syndrs);
+        SternRingSig rsig;
+        int sig_k = ring_sig_load(sig_path, &rsig);
+        if (sig_k != k) {
+            stern_ring_free(&rsig);
+            fprintf(stderr, "hpks-ring verify: signature ring size %d != %d "
+                            "provided members\n", sig_k, k);
+            exit(1);
+        }
+        int ok = stern_ring_verify(&rsig, &msg, seeds, syndrs);
+        stern_ring_free(&rsig);
+        if (ok) { puts("Signature OK");        exit(0); }
+        else    { puts("Verification FAILED"); exit(1); }
     }
 
     /* nl-zkboo uses raw binary PEM — handle before pem_key_load. */
@@ -2775,17 +2944,19 @@ static void usage(void)
 "  decfile --algo hske-nla1 --key SK --in FILE.hkx --out FILE\n"
 "    Verify-then-decrypt a .hkx file.  Exits non-zero on auth failure.\n"
 "\n"
-"  sign --algo ALGO --key PRIV --in FILE --out SIG [--digest hfscx-256]\n"
-"    Sign.  Algorithms: hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots\n"
+"  sign --algo ALGO --key PRIV --in FILE --out SIG [--digest hfscx-256] [--ring P0,P1,...]\n"
+"    Sign.  Algorithms: hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots hpks-ring\n"
 "    rnl-sigma: key = hkex-rnl private key (n=256); produces ZKP-RNL PROOF PEM.\n"
 "    nl-zkboo:  key = hpks-zkp-nl private key;      produces ZKP-NL PROOF PEM.\n"
 "    hpks-wots: ONE-TIME signature — a WOTS key may sign exactly once (reuse refused).\n"
+"    hpks-ring: anonymous ring signature; key = an hpks-stern key in --ring (member pubkeys).\n"
 "    --digest hfscx-256: pre-hash input before signing.\n"
 "\n"
-"  verify --algo ALGO [--pubkey PUB] --in FILE --sig SIG [--digest hfscx-256]\n"
+"  verify --algo ALGO [--pubkey PUB | --ring P0,P1,...] --in FILE --sig SIG [--digest hfscx-256]\n"
 "    Verify signature.  Exits 0 on OK, 1 on failure.\n"
 "    rnl-sigma: pubkey = hkex-rnl public key; sig = ZKP-RNL PROOF PEM.\n"
 "    nl-zkboo:  pubkey = hpks-zkp-nl public key; sig = ZKP-NL PROOF PEM.\n"
+"    hpks-ring: --ring = member public keys; verifies anonymously (no signer revealed).\n"
 "    hpks-t:    --pubkey not required; C_agg is embedded in the signature.\n"
 "\n"
 "  threshold-commit --key PRIV --commit-out COMMIT.pem --nonce-out NONCE.pem\n"

--- a/HerraduraCli/herradura_cli.go
+++ b/HerraduraCli/herradura_cli.go
@@ -58,6 +58,7 @@ const (
 	lblHpksWotsPriv = "HERRADURA HPKS-WOTS PRIVATE KEY"
 	lblHpksWotsPub  = "HERRADURA HPKS-WOTS PUBLIC KEY"
 	lblHpksWotsSig  = "HERRADURA HPKS-WOTS SIGNATURE"
+	lblRingSig      = "HERRADURA HPKS-RING SIGNATURE"
 
 	lblSession = "HERRADURA SESSION KEY"
 	lblRnlResp = "HERRADURA HKEX-RNL RESPONSE"
@@ -510,6 +511,114 @@ func encodeWotsBlobPEM(vals [WotsL]*BitArray, label string) string {
 	ed, _ := derIntSmall(WotsL)
 	seq, _ := DerSeqEnc(bd, ed)
 	return PemWrap(label, seq)
+}
+
+// ── HPKS-Stern-Ring signature helpers (TODO #121) ────────────────────────────
+//
+// Wire format matches the Python/C CLIs: SEQ(k, rounds, n, blob) where blob is a
+// member-major / round-major flat layout of c0||c1||c2||b(1 byte)||respA||respB
+// (each n-bit value = n/8 bytes) per (member, round).
+
+func loadRingPubkeys(ringArg string) ([]RingKeypair, int) {
+	paths := strings.Split(ringArg, ",")
+	var ring []RingKeypair
+	ringN := -1
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		label, ints, err := readPEMInts(p)
+		if err != nil {
+			die("hpks-ring", err)
+		}
+		if label != lblHpksSternPub {
+			fmt.Fprintf(os.Stderr, "hpks-ring: ring member %q is %q, expected hpks-stern public key\n", p, label)
+			os.Exit(1)
+		}
+		n := bytesToInt(ints[2])
+		if ringN < 0 {
+			ringN = n
+		} else if n != ringN {
+			fmt.Fprintln(os.Stderr, "hpks-ring: all ring members must share the same n")
+			os.Exit(1)
+		}
+		ring = append(ring, RingKeypair{
+			Seed:     NewBitArray(n, new(big.Int).SetBytes(ints[1])),
+			Syndrome: new(big.Int).SetBytes(ints[0]),
+		})
+	}
+	if len(ring) < 2 {
+		fmt.Fprintln(os.Stderr, "hpks-ring: --ring needs at least 2 member public keys")
+		os.Exit(1)
+	}
+	return ring, ringN
+}
+
+func encodeRingSig(sig *SternRingSig, n int) string {
+	nb := n / 8
+	blob := make([]byte, 0, sig.K*sig.Rounds*(5*nb+1))
+	put := func(ba *BitArray) {
+		b := make([]byte, nb)
+		ba.Val.FillBytes(b)
+		blob = append(blob, b...)
+	}
+	for i := 0; i < sig.K; i++ {
+		for r := 0; r < sig.Rounds; r++ {
+			rd := sig.Members[i].Rounds[r]
+			put(rd.C0)
+			put(rd.C1)
+			put(rd.C2)
+			blob = append(blob, byte(rd.B))
+			put(rd.RespA)
+			put(rd.RespB)
+		}
+	}
+	kd, _ := derIntSmall(sig.K)
+	rdd, _ := derIntSmall(sig.Rounds)
+	nd, _ := derIntSmall(n)
+	bd, _ := derIntBig(new(big.Int).SetBytes(blob), len(blob))
+	seq, _ := DerSeqEnc(kd, rdd, nd, bd)
+	return PemWrap(lblRingSig, seq)
+}
+
+func decodeRingSig(path string) (*SternRingSig, int) {
+	label, ints, err := readPEMInts(path)
+	if err != nil {
+		die("verify", err)
+	}
+	if label != lblRingSig {
+		fmt.Fprintf(os.Stderr, "verify: expected HPKS-RING SIGNATURE PEM, got %q\n", label)
+		os.Exit(1)
+	}
+	k := bytesToInt(ints[0])
+	rounds := bytesToInt(ints[1])
+	n := bytesToInt(ints[2])
+	nb := n / 8
+	entry := 5*nb + 1
+	blob := make([]byte, k*rounds*entry)
+	new(big.Int).SetBytes(ints[3]).FillBytes(blob)
+
+	sig := &SternRingSig{K: k, Rounds: rounds, Members: make([]SternSig, k)}
+	off := 0
+	take := func() *BitArray {
+		v := NewBitArray(n, new(big.Int).SetBytes(blob[off:off+nb]))
+		off += nb
+		return v
+	}
+	for i := 0; i < k; i++ {
+		sig.Members[i].Rounds = make([]SternRound, rounds)
+		for r := 0; r < rounds; r++ {
+			c0 := take()
+			c1 := take()
+			c2 := take()
+			b := int(blob[off])
+			off++
+			ra := take()
+			rb := take()
+			sig.Members[i].Rounds[r] = SternRound{C0: c0, C1: c1, C2: c2, B: b, RespA: ra, RespB: rb}
+		}
+	}
+	return sig, n
 }
 
 // ── genpkey ──────────────────────────────────────────────────────────────────
@@ -1913,6 +2022,7 @@ func cmdSign(args []string) {
 	in     := fs.String("in", "-", "Message input file")
 	digest := fs.String("digest", "", "Pre-hash algorithm (hfscx-256)")
 	out    := fs.String("out", "-", "Signature PEM output file")
+	ring   := fs.String("ring", "", "hpks-ring: comma-separated member public-key PEM paths")
 	fs.Parse(args)
 
 	if *algo == "" || *key == "" {
@@ -2021,6 +2131,40 @@ func cmdSign(args []string) {
 			die("sign", err)
 		}
 
+	case "hpks-ring":
+		fmt.Fprintln(os.Stderr, "WARNING: Stern-F at N=256 provides only ~30-40 bits of security (demo parameters). 128-bit security requires N>=17000. Do not use for production.")
+		if *ring == "" {
+			fmt.Fprintln(os.Stderr, "hpks-ring sign: --ring (comma-separated member public keys) required")
+			os.Exit(1)
+		}
+		n := bytesToInt(ourInts[2])
+		e := NewBitArray(n, new(big.Int).SetBytes(ourInts[0]))
+		signerSeed := new(big.Int).SetBytes(ourInts[1])
+		ringKeys, ringN := loadRingPubkeys(*ring)
+		if ringN != n {
+			fmt.Fprintf(os.Stderr, "hpks-ring sign: signer n=%d != ring n=%d\n", n, ringN)
+			os.Exit(1)
+		}
+		j := -1
+		for idx := range ringKeys {
+			if ringKeys[idx].Seed.Val.Cmp(signerSeed) == 0 {
+				j = idx
+				break
+			}
+		}
+		if j < 0 {
+			fmt.Fprintln(os.Stderr, "hpks-ring sign: signer's public key is not in --ring "+
+				"(run pkey --pubout on the signer key and include it)")
+			os.Exit(1)
+		}
+		msg := NewBitArray(n, new(big.Int).SetBytes(msgPad(inBytes, n/8)))
+		sig := HpksSternRingSign(msg, e, j, ringKeys, SdfRounds)
+		pem := encodeRingSig(sig, n)
+		if err := writeString(*out, pem); err != nil {
+			die("sign", err)
+		}
+		fmt.Fprintf(os.Stderr, "Ring signature created (k=%d); signer index is hidden.\n", len(ringKeys))
+
 	case "hpks-wots":
 		if wotsIsUsed(*key) {
 			fmt.Fprintln(os.Stderr, "sign: this HPKS-WOTS key was already used — WOTS keys "+
@@ -2056,13 +2200,14 @@ func cmdVerify(args []string) {
 	in     := fs.String("in", "-", "Message input file")
 	digest := fs.String("digest", "", "Pre-hash algorithm (hfscx-256)")
 	sig    := fs.String("sig", "", "Signature PEM file")
+	ring   := fs.String("ring", "", "hpks-ring: comma-separated member public-key PEM paths")
 	fs.Parse(args)
 
 	if *algo == "" || *sig == "" {
 		fmt.Fprintln(os.Stderr, "verify: --algo and --sig required")
 		os.Exit(1)
 	}
-	if *algo != "hpks-t" && *pubkey == "" {
+	if *algo != "hpks-t" && *algo != "hpks-ring" && *pubkey == "" {
 		fmt.Fprintln(os.Stderr, "verify: --pubkey required")
 		os.Exit(1)
 	}
@@ -2073,6 +2218,32 @@ func cmdVerify(args []string) {
 	}
 	if *digest == "hfscx-256" {
 		inBytes = Hfscx256(inBytes, nil)
+	}
+
+	// hpks-ring: anonymous ring verification against --ring members.
+	if *algo == "hpks-ring" {
+		if *ring == "" {
+			fmt.Fprintln(os.Stderr, "hpks-ring verify: --ring (comma-separated member public keys) required")
+			os.Exit(1)
+		}
+		ringKeys, n := loadRingPubkeys(*ring)
+		rsig, sigN := decodeRingSig(*sig)
+		if sigN != n {
+			fmt.Fprintf(os.Stderr, "hpks-ring verify: signature n=%d != ring n=%d\n", sigN, n)
+			os.Exit(1)
+		}
+		if rsig.K != len(ringKeys) {
+			fmt.Fprintf(os.Stderr, "hpks-ring verify: signature ring size %d != %d provided members\n",
+				rsig.K, len(ringKeys))
+			os.Exit(1)
+		}
+		msg := NewBitArray(n, new(big.Int).SetBytes(msgPad(inBytes, n/8)))
+		if HpksSternRingVerify(msg, rsig, ringKeys) {
+			fmt.Println("Signature OK")
+			os.Exit(0)
+		}
+		fmt.Println("Verification FAILED")
+		os.Exit(1)
 	}
 
 	// hpks-t: C_agg is embedded in sig — no pubkey file needed.
@@ -2778,7 +2949,8 @@ Algorithms (genpkey/pkey): hkex-gf hkex-rnl hpks hpks-nl hpke hpke-nl hpks-stern
 Algorithms (kex):           hkex-gf hkex-rnl
 Algorithms (enc/dec):       hske hske-nla1 hske-nla2 hske-duplex hpke hpke-nl hpke-stern
 Algorithms (encfile/decfile): hske-nla1
-Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots (one-time)
+Algorithms (sign/verify):   hpks hpks-nl hpks-stern rnl-sigma nl-zkboo hpks-wots (one-time) hpks-ring (anonymous)
+  sign/verify --algo hpks-ring --ring p0_pub.pem,p1_pub.pem,... : code-based ring signature
   fpe      --encrypt|--decrypt --key SK --context STR --in FILE [--out FILE]
   twk      --encrypt|--decrypt --key SK [--sector N] [--bidx N] --in FILE [--out FILE]
 `)

--- a/HerraduraCli/herradura_codec.h
+++ b/HerraduraCli/herradura_codec.h
@@ -63,6 +63,7 @@
 #define PEM_HPKS_WOTS_PRIV  "HERRADURA HPKS-WOTS PRIVATE KEY"
 #define PEM_HPKS_WOTS_PUB   "HERRADURA HPKS-WOTS PUBLIC KEY"
 #define PEM_HPKS_WOTS_SIG   "HERRADURA HPKS-WOTS SIGNATURE"
+#define PEM_HPKS_RING_SIG   "HERRADURA HPKS-RING SIGNATURE"
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * Buffer-size macros

--- a/HerraduraCli/primitives.py
+++ b/HerraduraCli/primitives.py
@@ -54,6 +54,8 @@ _rnl_poly_mul       = _s._rnl_poly_mul
 stern_f_keygen            = _s.stern_f_keygen
 hpks_stern_f_sign         = _s.hpks_stern_f_sign
 hpks_stern_f_verify       = _s.hpks_stern_f_verify
+hpks_stern_ring_sign      = _s.hpks_stern_ring_sign
+hpks_stern_ring_verify    = _s.hpks_stern_ring_verify
 hpke_stern_f_encap_with_e = _s.hpke_stern_f_encap_with_e
 hpke_stern_f_decap        = _s.hpke_stern_f_decap
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Herradura Cryptographic Suite (v1.9.70)
+# Herradura Cryptographic Suite (v1.9.71)
 
 The Herradura Cryptographic Suite implements cryptographic protocols built on the FSCX (Full Surroundings Cyclic XOR) primitive, Diffie-Hellman key exchange over GF(2^n)*, and a post-quantum Ring-LWR key exchange.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6555,4 +6555,14 @@ one member of an ad-hoc group sign anonymously on behalf of the group.
    tamper rejection, and Python↔Go interop.
 5. Document the anonymity property and ring-membership semantics in the CLI help and tutorial.
 
-Status: **OPEN**
+Status: **DONE v1.9.71** — `sign`/`verify --algo hpks-ring` added to the Python, Go, **and**
+C CLIs (all three, not just Python+Go).  Work item 1 (C suite port) was already satisfied:
+`stern_ring_sign`/`stern_ring_verify` have been in `herradura.h` since v1.9.16 (TODO #78.I)
+and pass security test [20] — the TODO's "not present in herradura.h" premise was outdated.
+New `HERRADURA HPKS-RING SIGNATURE` PEM: `SEQ(k, rounds, n, blob)` with a member-major /
+round-major flat blob (`c0||c1||c2||b||resp_a||resp_b` per entry), byte-for-byte interoperable
+across the three CLIs.  `--ring <p0,p1,...>` supplies the ordered member public keys; the signer
+(an `hpks-stern` key) is located by seed match and kept hidden.  `CliTest/test_ring.sh` covers
+the 9-way sign/verify interop matrix, anonymity (any member signs), non-member sign refusal,
+tampered-message rejection, and wrong-ring rejection (21/21 pass).  Documented in the three CLI
+usage headers and `docs/TUTORIAL.md` (anonymity + demo-parameter caveat).

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -157,6 +157,38 @@ $CLI sign   --algo hpks-wots --key otk.pem --in msg.bin --out sig2.pem
 > byte-for-byte interoperable across the Python, C, and Go CLIs
 > (`CliTest/test_wots.sh`).
 
+#### Anonymous ring signatures (HPKS-Stern-Ring)
+
+`hpks-ring` is a code-based **ring signature** (#78.I): one member of an ad-hoc
+group signs on behalf of the whole group, and a verifier confirms *some* member
+signed without learning **which** one.  Each ring member is an ordinary
+`hpks-stern` keypair; the ring is the ordered list of their public keys.
+
+```bash
+# Three members each generate an hpks-stern keypair and publish their public key
+for m in 0 1 2; do
+  $CLI genpkey --algo hpks-stern --out m$m.pem
+  $CLI pkey    --in m$m.pem --pubout --out m${m}_pub.pem
+done
+RING=m0_pub.pem,m1_pub.pem,m2_pub.pem
+
+# Member 1 signs anonymously on behalf of the ring (its index is hidden)
+$CLI sign   --algo hpks-ring --key m1.pem --ring "$RING" --in msg.bin --out sig.pem
+
+# Anyone verifies against the ring; the signer's identity is not revealed
+$CLI verify --algo hpks-ring --ring "$RING" --in msg.bin --sig sig.pem
+# Prints: Signature OK
+```
+
+The signer must be a member of `--ring` (its public key present), else signing is
+refused.  Verification is anonymous: it succeeds for a signature from *any* ring
+member and fails for non-members, a tampered message, or a different ring.
+Signatures are byte-for-byte interoperable across the Python, C, and Go CLIs
+(`CliTest/test_ring.sh`).
+
+> **Demo parameters.** Like `hpks-stern`, the ring signature uses N=256 / 32
+> Fiat-Shamir rounds, a low-soundness demo configuration — not for production use.
+
 ### El Gamal encryption (HPKE)
 
 ```bash


### PR DESCRIPTION
## Summary

Implements **TODO #121** (the last item from the CLI capability review): exposes the code-based ring signature (`hpks_stern_ring_sign`/`verify`, #78.I) on the Python, C, **and** Go CLIs as `sign`/`verify --algo hpks-ring`.

One member of an ad-hoc group signs anonymously on behalf of the whole group; verification confirms *some* ring member signed without revealing which one.

- **Wire format:** new `HERRADURA HPKS-RING SIGNATURE` PEM — `SEQ(k, rounds, n, blob)` with a member-major / round-major flat blob (`c0||c1||c2||b||resp_a||resp_b` per (member, round)). Byte-for-byte interoperable across all three CLIs.
- **`--ring P0,P1,...`** supplies the ordered member public keys; the signer (an `hpks-stern` key) is located by seed match and kept hidden. Non-members are refused at signing time.
- **C suite port (work item 1) was already satisfied:** `stern_ring_sign`/`verify` have shipped in `herradura.h` since v1.9.16 (TODO #78.I) and pass security test [20] — the TODO's "not present in herradura.h" premise was outdated. Only the CLI surface was missing.
- `HerraduraCli/primitives.py` re-exports the ring functions.

Done in 5 reviewable batches (Python+wire format → Go → C → test → docs), each a separate commit.

## Test plan

- [x] `CliTest/test_ring.sh` (new): 9-way sign/verify interop matrix, anonymity (any member signs), non-member sign refusal, tampered-message rejection, wrong-ring rejection → **21/21 pass**
- [x] No regression: `test_wots.sh` (18/18), `test_duplex.sh` (23/23), `test_rand.sh` (20/20)
- [x] C ring security test [20] still passes (`3/3 ring-verified [PASS]`)
- [x] C and Go CLIs build clean

To reproduce: `bash CliTest/test_ring.sh` (requires C + Go CLIs built via `build_c.sh` / `build_go.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)